### PR TITLE
Improve spotify-timestamp

### DIFF
--- a/ApplePodcastEpisodeEnricher/MissingFilesProcessor.cs
+++ b/ApplePodcastEpisodeEnricher/MissingFilesProcessor.cs
@@ -60,7 +60,6 @@ public class MissingFilesProcessor
                             return isMatch;
                         }
 
-
                         if (appleEpisodeMatch.Groups["title"].Success && episodeMatch.Groups["title"].Success)
                         {
                             var appleEpisodeTitle = appleEpisodeMatch.Groups["title"].Value;

--- a/RedditPodcastPoster.Common/Episodes/EpisodeProvider.cs
+++ b/RedditPodcastPoster.Common/Episodes/EpisodeProvider.cs
@@ -28,13 +28,13 @@ public class EpisodeProvider : IEpisodeProvider
         bool skipYouTube)
     {
         IList<Episode> episodes;
-        if (!string.IsNullOrWhiteSpace(podcast.SpotifyId))
+        if (podcast.ReleaseAuthority is null or Service.Spotify && !string.IsNullOrWhiteSpace(podcast.SpotifyId))
         {
             episodes = await _spotifyEpisodeProvider.GetEpisodes(
                 new SpotifyGetEpisodesRequest(podcast.SpotifyId, processRequestReleasedSince));
             _logger.LogInformation($"{nameof(GetEpisodes)} (Spotify) - Found '{episodes.Count}' episodes released since {processRequestReleasedSince:R}");
         }
-        else if (!string.IsNullOrWhiteSpace(podcast.YouTubeChannelId))
+        else if (podcast.ReleaseAuthority is Service.YouTube || !string.IsNullOrWhiteSpace(podcast.YouTubeChannelId))
         {
             if (skipYouTube)
             {

--- a/RedditPodcastPoster.Common/PodcastServices/PodcastServicesEpisodeEnricher.cs
+++ b/RedditPodcastPoster.Common/PodcastServices/PodcastServicesEpisodeEnricher.cs
@@ -92,6 +92,10 @@ public class PodcastServicesEpisodeEnricher : IPodcastServicesEpisodeEnricher
                 _logger.LogInformation($"{nameof(EnrichFromApple)} Found matching Apple episode: '{appleItem.Id}' with title '{appleItem.Title}' and release-date '{appleItem.Release:R}'.");
                 episode.Urls.Apple = appleItem.Url.CleanAppleUrl();
                 episode.AppleId = appleItem.Id;
+                if (episode.Release.TimeOfDay == TimeSpan.MinValue)
+                {
+                    episode.Release = appleItem.Release;
+                }
             }
         }
     }

--- a/RedditPodcastPoster.Models/Episode.cs
+++ b/RedditPodcastPoster.Models/Episode.cs
@@ -35,7 +35,7 @@ public class Episode
 
     [JsonPropertyName("release")]
     [JsonPropertyOrder(7)]
-    public DateTime Release { get; init; }
+    public DateTime Release { get; set; }
 
     [JsonPropertyName("duration")]
     [JsonPropertyOrder(8)]

--- a/RedditPodcastPoster.Models/Podcast.cs
+++ b/RedditPodcastPoster.Models/Podcast.cs
@@ -30,8 +30,13 @@ public class Podcast : CosmosSelector
     [JsonPropertyOrder(6)]
     public bool IndexAllEpisodes { get; set; } = false;
 
-    [JsonPropertyName("primaryPostService")]
+    [JsonPropertyName("useYouTubeAsReleaseAuthority")]
     [JsonPropertyOrder(7)]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public Service? ReleaseAuthority { get; set; }
+
+    [JsonPropertyName("primaryPostService")]
+    [JsonPropertyOrder(8)]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Service? PrimaryPostService { get; set; }
 


### PR DESCRIPTION
Allow to use YouTube as authority on releases when podcast has Spotify-id