### PR TITLE
Improve logging config and Azure Monitor exporter logic

### DIFF
--- a/Cloud/Api/host.json
+++ b/Cloud/Api/host.json
@@ -4,6 +4,7 @@
   "logging": {
     "logLevel": {
       "default": "None",
+      "Host.Startup": "Information",
       "Host.Results": "Warning",
       "Function": "Warning",
       "RedditPodcastPoster": "Information",

--- a/Cloud/Azure/HostFactory.cs
+++ b/Cloud/Azure/HostFactory.cs
@@ -13,12 +13,15 @@ public static class HostFactory
     {
         var builder = FunctionsApplication.CreateBuilder(args);
         var isDevelopment = builder.Configuration.IsDevelopment();
+        var appInsightsConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
+        var enableAzureMonitorExporter = !isDevelopment && !string.IsNullOrWhiteSpace(appInsightsConnectionString);
+
         builder.Services.AddLogging();
         builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
 
         builder.Logging.ConsoleWriteConfig();
 
-        if (!isDevelopment)
+        if (enableAzureMonitorExporter)
         {
             builder.Services.AddOpenTelemetry()
                 .UseFunctionsWorkerDefaults()

--- a/Cloud/Discovery/host.json
+++ b/Cloud/Discovery/host.json
@@ -17,6 +17,7 @@
   "logging": {
     "logLevel": {
       "default": "None",
+      "Host.Startup": "Information",
       "Host.Results": "Warning",
       "Function": "Warning",
       "RedditPodcastPoster": "Information",

--- a/Cloud/Indexer/host.json
+++ b/Cloud/Indexer/host.json
@@ -17,6 +17,7 @@
   "logging": {
     "logLevel": {
       "default": "None",
+      "Host.Startup": "Information",
       "Host.Results": "Warning",
       "Function": "Warning",
       "RedditPodcastPoster": "Information",


### PR DESCRIPTION
Updated host.json to add log levels for Host.Startup, Discovery, and Indexer. Refined HostFactory to enable Azure Monitor Exporter only when not in development and Application Insights connection string is set.