### PR TITLE
Enhance episode merging logic in PodcastUpdater

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
@@ -80,7 +80,10 @@ public class PodcastUpdater(
             
             mergeResult = episodeMerger.MergeEpisodes(podcast, episodes, newEpisodes);
 
+            // Merge does not mutate `episodes`; new adds live only on mergeResult until saved. Include them
+            // before enrichment and elimination filtering so new episodes are not evaluated only on a later index pass.
             episodes = episodes
+                .Concat(mergeResult.AddedEpisodes)
                 .Where(x => ReduceToSinceIncorporatingPublishDelay(x, youTubePublishingDelay, releasedSince))
                 .ToList();
         }


### PR DESCRIPTION
Updated the episode merging process to ensure that newly added episodes are included before enrichment and filtering. This change prevents new episodes from being evaluated only on a later index pass, improving the overall efficiency of the episode processing workflow.