### PR TITLE
Add YouTube channel search handling and related features

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Models/Podcast.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Podcast.cs
@@ -104,6 +104,10 @@ public class Podcast
     [JsonPropertyOrder(160)]
     public bool? YouTubePlaylistQueryIsExpensive { get; set; }
 
+    [JsonPropertyName("youTubeChannelSearchForbidden")]
+    [JsonPropertyOrder(161)]
+    public bool? YouTubeChannelSearchForbidden { get; set; }
+
     [JsonPropertyName("skipEnrichingFromYouTube")]
     [JsonPropertyOrder(170)]
     public bool? SkipEnrichingFromYouTube { get; set; }
@@ -174,6 +178,11 @@ public class Podcast
     public bool HasExpensiveYouTubePlaylistQuery()
     {
         return YouTubePlaylistQueryIsExpensive.HasValue && YouTubePlaylistQueryIsExpensive.Value;
+    }
+
+    public bool HasYouTubeChannelSearchForbidden()
+    {
+        return YouTubeChannelSearchForbidden.HasValue && YouTubeChannelSearchForbidden.Value;
     }
 
     public bool HasExpensiveSpotifyEpisodesQuery()

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Extensions/PlaylistItemExtensionsTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Extensions/PlaylistItemExtensionsTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Google.Apis.YouTube.v3.Data;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Extensions;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Extensions;
+
+public class PlaylistItemExtensionsTests
+{
+    [Fact]
+    public void ForEpisodeMatching_WithoutReleasedSince_CapsToFiveItems()
+    {
+        var items = Enumerable.Range(1, 10)
+            .Select(i => CreatePlaylistItem($"video-{i}"))
+            .ToList();
+
+        var result = items.ForEpisodeMatching(new IndexingContext());
+
+        result.Should().HaveCount(5);
+        result.Select(x => x.GetVideoId()).Should().Equal("video-1", "video-2", "video-3", "video-4", "video-5");
+    }
+
+    [Fact]
+    public void ForEpisodeMatching_WithReleasedSince_FiltersByPublishDate()
+    {
+        var releasedSince = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var items = new List<PlaylistItem>
+        {
+            CreatePlaylistItem("old", releasedSince.AddDays(-1)),
+            CreatePlaylistItem("new", releasedSince.AddDays(1))
+        };
+
+        var result = items.ForEpisodeMatching(new IndexingContext(releasedSince));
+
+        result.Should().ContainSingle().Which.GetVideoId().Should().Be("new");
+    }
+
+    [Fact]
+    public void GetVideoId_PrefersContentDetailsVideoId()
+    {
+        var item = new PlaylistItem
+        {
+            ContentDetails = new PlaylistItemContentDetails { VideoId = "content-details-id" },
+            Snippet = new PlaylistItemSnippet
+            {
+                ResourceId = new ResourceId { VideoId = "resource-id" }
+            }
+        };
+
+        item.GetVideoId().Should().Be("content-details-id");
+    }
+
+    private static PlaylistItem CreatePlaylistItem(string videoId, DateTimeOffset? publishedAt = null) =>
+        new()
+        {
+            Snippet = new PlaylistItemSnippet
+            {
+                ResourceId = new ResourceId { VideoId = videoId },
+                PublishedAtDateTimeOffset = publishedAt ?? DateTimeOffset.UtcNow
+            }
+        };
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Extensions/VideoExtensionsTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Extensions/VideoExtensionsTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using Google.Apis.YouTube.v3.Data;
+using RedditPodcastPoster.PodcastServices.YouTube.Extensions;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Extensions;
+
+public class VideoExtensionsTests
+{
+    [Theory]
+    [InlineData("none", true)]
+    [InlineData("completed", true)]
+    [InlineData("live", false)]
+    [InlineData("upcoming", false)]
+    public void IsCompletedPublicVideo_FiltersLiveAndUpcoming(string liveBroadcastContent, bool expected)
+    {
+        var video = new Google.Apis.YouTube.v3.Data.Video
+        {
+            Snippet = new VideoSnippet { LiveBroadcastContent = liveBroadcastContent }
+        };
+
+        video.IsCompletedPublicVideo().Should().Be(expected);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Services/SearchResultFinderTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Services/SearchResultFinderTests.cs
@@ -1,19 +1,44 @@
 using AutoFixture;
 using FluentAssertions;
 using Google.Apis.YouTube.v3.Data;
+using Moq;
 using Moq.AutoMock;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Services;
+using RedditPodcastPoster.PodcastServices.YouTube.Video;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Services;
 
 public class SearchResultFinderTests
 {
+    private static readonly TimeSpan DefaultEpisodeLength = TimeSpan.FromHours(1);
     private readonly Fixture _fixture = new();
     private readonly AutoMocker _mocker = new();
 
     private ISearchResultFinder Sut => _mocker.CreateInstance<SearchResultFinder>();
+
+    public SearchResultFinderTests()
+    {
+        _mocker.GetMock<IYouTubeVideoService>()
+            .Setup(x => x.GetVideoContentDetails(
+                It.IsAny<IYouTubeServiceWrapper>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync((IYouTubeServiceWrapper _, IEnumerable<string> videoIds, IndexingContext _, bool _, bool _) =>
+                videoIds.Select(CreateVideoWithMatchingDuration).ToList());
+    }
+
+    private static Google.Apis.YouTube.v3.Data.Video CreateVideoWithMatchingDuration(string videoId) =>
+        new()
+        {
+            Id = videoId,
+            ContentDetails = new VideoContentDetails { Duration = "PT1H0M0S" },
+            Snippet = new VideoSnippet { LiveBroadcastContent = "none" }
+        };
 
     [Theory]
     [InlineData(0)]
@@ -29,6 +54,7 @@ public class SearchResultFinderTests
             .Build<RedditPodcastPoster.Models.Episode>()
             .With(x => x.Title, expectedTitle)
             .With(x => x.Release, today)
+            .With(x => x.Length, DefaultEpisodeLength)
             .With(x => x.AppleId, (long?) null)
             .With(x => x.Urls, _fixture.Build<ServiceUrls>().With(x => x.Apple, (Uri?) null).Create())
             .Create();
@@ -73,6 +99,7 @@ public class SearchResultFinderTests
             .With(x => x.Title, "Episode-title")
             .With(x => x.Title, expectedTitle)
             .With(x => x.Release, release)
+            .With(x => x.Length, DefaultEpisodeLength)
             .Create();
         var expected = _fixture
             .Build<SearchResult>()
@@ -116,6 +143,7 @@ public class SearchResultFinderTests
             .With(x => x.Title, "Episode-title")
             .With(x => x.Title, expectedTitle)
             .With(x => x.Release, release)
+            .With(x => x.Length, DefaultEpisodeLength)
             .Create();
         var expected = _fixture
             .Build<SearchResult>()
@@ -156,6 +184,7 @@ public class SearchResultFinderTests
             .Build<RedditPodcastPoster.Models.Episode>()
             .With(x => x.Title, $"Prefix-A {episodeNumber} Suffix-A")
             .With(x => x.Release, release)
+            .With(x => x.Length, DefaultEpisodeLength)
             .Create();
         var expected = _fixture
             .Build<SearchResult>()

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Services/YouTubeChannelVideoRetrievalPolicyTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Services/YouTubeChannelVideoRetrievalPolicyTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Services;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Services;
+
+public class YouTubeChannelVideoRetrievalPolicyTests
+{
+    [Fact]
+    public void ShouldUseUploadsPlaylist_WhenSearchForbidden_ReturnsTrue()
+    {
+        var podcast = new Podcast { YouTubeChannelSearchForbidden = true };
+        var sut = CreateSut(preferUploadsPlaylist: false);
+
+        sut.ShouldUseUploadsPlaylist(podcast).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldUseUploadsPlaylist_WhenFeatureFlagEnabled_ReturnsTrue()
+    {
+        var podcast = new Podcast();
+        var sut = CreateSut(preferUploadsPlaylist: true);
+
+        sut.ShouldUseUploadsPlaylist(podcast).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldUseUploadsPlaylist_WhenNeitherSet_ReturnsFalse()
+    {
+        var podcast = new Podcast();
+        var sut = CreateSut(preferUploadsPlaylist: false);
+
+        sut.ShouldUseUploadsPlaylist(podcast).Should().BeFalse();
+        sut.GetUploadsPlaylistReason(podcast).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetUploadsPlaylistReason_WhenSearchForbidden_ReturnsExpectedReason()
+    {
+        var podcast = new Podcast { YouTubeChannelSearchForbidden = true };
+        var sut = CreateSut(preferUploadsPlaylist: false);
+
+        sut.GetUploadsPlaylistReason(podcast).Should().Be("youTubeChannelSearchForbidden");
+    }
+
+    private static YouTubeChannelVideoRetrievalPolicy CreateSut(bool preferUploadsPlaylist) =>
+        new(Options.Create(new YouTubeChannelOptions { PreferUploadsPlaylist = preferUploadsPlaylist }));
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Services/YouTubeVideoDurationMatcherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Services/YouTubeVideoDurationMatcherTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using RedditPodcastPoster.PodcastServices.YouTube.Services;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Services;
+
+public class YouTubeVideoDurationMatcherTests
+{
+    [Fact]
+    public void IsAcceptableDurationMatch_WithAnyEpisode_RejectsMissingVideoDuration()
+    {
+        YouTubeVideoDurationMatcher.IsAcceptableDurationMatch(TimeSpan.FromMinutes(3), null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAcceptableDurationMatch_WithShortEpisode_AcceptsMatchingVideoDuration()
+    {
+        YouTubeVideoDurationMatcher
+            .IsAcceptableDurationMatch(TimeSpan.FromMinutes(3), TimeSpan.FromMinutes(3))
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void IsAcceptableDurationMatch_WithLongFormEpisode_RejectsMissingVideoDuration()
+    {
+        YouTubeVideoDurationMatcher.IsAcceptableDurationMatch(TimeSpan.FromMinutes(60), null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAcceptableDurationMatch_WithLongFormEpisode_RejectsVideoMoreThanFivePercentShorter()
+    {
+        var episodeLength = TimeSpan.FromMinutes(60);
+        var videoLength = TimeSpan.FromMinutes(56);
+
+        YouTubeVideoDurationMatcher.IsAcceptableDurationMatch(episodeLength, videoLength).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAcceptableDurationMatch_WithLongFormEpisode_AcceptsVideoWithinFivePercent()
+    {
+        var episodeLength = TimeSpan.FromMinutes(60);
+        var videoLength = TimeSpan.FromMinutes(57);
+
+        YouTubeVideoDurationMatcher.IsAcceptableDurationMatch(episodeLength, videoLength).Should().BeTrue();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelSnippets/TolerantYouTubeChannelVideoSnippetsService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelSnippets/TolerantYouTubeChannelVideoSnippetsService.cs
@@ -26,10 +26,13 @@ public class TolerantYouTubeChannelVideoSnippetsService(
                     indexingContext);
                 success = true;
             }
-            catch (YouTubeQuotaException ex)
+            catch (YouTubeChannelSearchForbiddenException)
             {
-                logger.LogInformation(
-                    "Quota exceeded observed. Rotating api-key .");
+                throw;
+            }
+            catch (YouTubeQuotaException)
+            {
+                logger.LogInformation("Quota exceeded observed. Rotating api-key.");
                 try
                 {
                     youTubeService.Rotate();

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelSnippets/YouTubeChannelVideoSnippetsService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelSnippets/YouTubeChannelVideoSnippetsService.cs
@@ -53,6 +53,11 @@ public class YouTubeChannelVideoSnippetsService(
                     throw new YouTubeQuotaException();
                 }
 
+                if (IsAccountDelegationForbidden(ex))
+                {
+                    throw new YouTubeChannelSearchForbiddenException(channelId.ChannelId, ex);
+                }
+
                 logger.LogError(ex,
                     "Unrecognised google-api-exception. Failed to use {nameofYouTubeServiceWrapperYouTubeService} to obtain latest-channel-snippets for channel-id '{channelId}'.",
                     nameof(youTubeServiceWrapper.YouTubeService), channelId.ChannelId);
@@ -76,4 +81,9 @@ public class YouTubeChannelVideoSnippetsService(
 
         return result;
     }
+
+    private static bool IsAccountDelegationForbidden(GoogleApiException ex) =>
+        ex.HttpStatusCode == HttpStatusCode.Forbidden &&
+        (ex.Error?.Errors?.Any(e => e.Reason == "accountDelegationForbidden") == true ||
+         ex.Message.Contains("accountDelegationForbidden", StringComparison.OrdinalIgnoreCase));
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelVideos/YouTubeChannelVideosService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelVideos/YouTubeChannelVideosService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Google.Apis.YouTube.v3.Data;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Channel;
@@ -43,6 +44,13 @@ public class YouTubeChannelVideosService(
             indexingContext, expensivePlaylist: expensivePlaylist);
         if (response.Result != null)
         {
+            if (response.Result.Count >= 2 && !IsReverseDateOrdered(response.Result))
+            {
+                logger.LogWarning(
+                    "Uploads playlist '{UploadsChannelId}' for channel-id '{ChannelId}' is not in reverse-date order.",
+                    uploadsChannelId, channelId.ChannelId);
+            }
+
             var result = new Models.ChannelVideos(channel, response.Result);
             _cache[channelId.ChannelId] = result;
             return result;
@@ -52,5 +60,29 @@ public class YouTubeChannelVideosService(
             "{GetChannelVideosName}: Unable to find channel-upload-playlist-items for channel-id '{ChannelIdChannelId}', playlist-id '{UploadsChannelId}'.",
             nameof(GetChannelVideos), channelId.ChannelId, uploadsChannelId);
         return null;
+    }
+
+    private static bool IsReverseDateOrdered(IEnumerable<PlaylistItem> source)
+    {
+        using var iterator = source.GetEnumerator();
+        if (!iterator.MoveNext())
+        {
+            return true;
+        }
+
+        var current = iterator.Current.Snippet.PublishedAtDateTimeOffset;
+
+        while (iterator.MoveNext())
+        {
+            var next = iterator.Current.Snippet.PublishedAtDateTimeOffset;
+            if (current < next)
+            {
+                return false;
+            }
+
+            current = next;
+        }
+
+        return true;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelVideos/YouTubeChannelVideosService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelVideos/YouTubeChannelVideosService.cs
@@ -3,6 +3,7 @@ using Google.Apis.YouTube.v3.Data;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Channel;
+using RedditPodcastPoster.PodcastServices.YouTube.Extensions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 
@@ -44,14 +45,16 @@ public class YouTubeChannelVideosService(
             indexingContext, expensivePlaylist: expensivePlaylist);
         if (response.Result != null)
         {
-            if (response.Result.Count >= 2 && !IsReverseDateOrdered(response.Result))
+            var playlistItems = response.Result.ToList();
+
+            if (playlistItems.Count >= 2 && !PlaylistItemOrdering.IsReverseDateOrdered(playlistItems))
             {
                 logger.LogWarning(
                     "Uploads playlist '{UploadsChannelId}' for channel-id '{ChannelId}' is not in reverse-date order.",
                     uploadsChannelId, channelId.ChannelId);
             }
 
-            var result = new Models.ChannelVideos(channel, response.Result);
+            var result = new Models.ChannelVideos(channel, playlistItems);
             _cache[channelId.ChannelId] = result;
             return result;
         }
@@ -60,29 +63,5 @@ public class YouTubeChannelVideosService(
             "{GetChannelVideosName}: Unable to find channel-upload-playlist-items for channel-id '{ChannelIdChannelId}', playlist-id '{UploadsChannelId}'.",
             nameof(GetChannelVideos), channelId.ChannelId, uploadsChannelId);
         return null;
-    }
-
-    private static bool IsReverseDateOrdered(IEnumerable<PlaylistItem> source)
-    {
-        using var iterator = source.GetEnumerator();
-        if (!iterator.MoveNext())
-        {
-            return true;
-        }
-
-        var current = iterator.Current.Snippet.PublishedAtDateTimeOffset;
-
-        while (iterator.MoveNext())
-        {
-            var next = iterator.Current.Snippet.PublishedAtDateTimeOffset;
-            if (current < next)
-            {
-                return false;
-            }
-
-            current = next;
-        }
-
-        return true;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Configuration/YouTubeChannelOptions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Configuration/YouTubeChannelOptions.cs
@@ -1,0 +1,10 @@
+namespace RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+
+public class YouTubeChannelOptions
+{
+    /// <summary>
+    /// When true, channel-only podcasts use the uploads playlist instead of Search.List.
+    /// Env: RedditPodcastPoster_YouTubeChannel__PreferUploadsPlaylist=true
+    /// </summary>
+    public bool PreferUploadsPlaylist { get; set; }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/IYouTubeEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/IYouTubeEpisodeProvider.cs
@@ -7,7 +7,7 @@ namespace RedditPodcastPoster.PodcastServices.YouTube.Episode;
 public interface IYouTubeEpisodeProvider
 {
     Task<IList<RedditPodcastPoster.Models.Episode>?> GetEpisodes(
-        YouTubeChannelId request,
+        RedditPodcastPoster.Models.Podcast podcast,
         IndexingContext indexingContext,
         IEnumerable<string> knownIds);
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
@@ -124,6 +124,7 @@ public class YouTubeEpisodeProvider(
                     videoDetails.SingleOrDefault(videoDetail => videoDetail.Id == x.Snippet.ResourceId.VideoId)!))
             .Where(x => x.VideoDetails?.Snippet != null)
             .Where(x => YouTubeVideoDurationMatcher.HasDuration(x.VideoDetails.GetLength()))
+            .Where(x => x.VideoDetails.IsCompletedPublicVideo())
             .Where(x => x.VideoDetails.Snippet.ChannelId == request.ChannelId)
             .Select(x => GetEpisode(x.PlaylistItem.Snippet, x.VideoDetails))
             .ToList();

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
@@ -3,10 +3,13 @@ using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Models.Extensions;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.ChannelSnippets;
+using RedditPodcastPoster.PodcastServices.YouTube.ChannelVideos;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
+using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
 using RedditPodcastPoster.PodcastServices.YouTube.Extensions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+using RedditPodcastPoster.PodcastServices.YouTube.Services;
 using RedditPodcastPoster.PodcastServices.YouTube.Video;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Episode;
@@ -16,38 +19,114 @@ public class YouTubeEpisodeProvider(
     ITolerantYouTubePlaylistService youTubePlaylistService,
     IYouTubeVideoService youTubeVideoService,
     ICachedTolerantYouTubeChannelVideoSnippetsService youTubeChannelVideoSnippetsService,
-#pragma warning disable CS9113 // Parameter is unread.
+    IYouTubeChannelVideosService youTubeChannelVideosService,
+    IYouTubeChannelVideoRetrievalPolicy youTubeChannelVideoRetrievalPolicy,
     ILogger<YouTubeEpisodeProvider> logger)
-#pragma warning restore CS9113 // Parameter is unread.
     : IYouTubeEpisodeProvider
 {
     public async Task<IList<RedditPodcastPoster.Models.Episode>?> GetEpisodes(
+        RedditPodcastPoster.Models.Podcast podcast,
+        IndexingContext indexingContext,
+        IEnumerable<string> knownIds)
+    {
+        var channelId = new YouTubeChannelId(podcast.YouTubeChannelId);
+        var uploadsPlaylistReason = youTubeChannelVideoRetrievalPolicy.GetUploadsPlaylistReason(podcast);
+        if (uploadsPlaylistReason != null)
+        {
+            logger.LogInformation(
+                "Using channel uploads playlist for channel-id '{ChannelId}' ({Reason}).",
+                channelId.ChannelId, uploadsPlaylistReason);
+            return await GetEpisodesFromChannelUploadsPlaylist(channelId, indexingContext, knownIds);
+        }
+
+        try
+        {
+            var youTubeVideos =
+                await youTubeChannelVideoSnippetsService.GetLatestChannelVideoSnippets(channelId, indexingContext);
+            if (youTubeVideos != null)
+            {
+                var youTubeVideoIds =
+                    youTubeVideos.Select(x => x.Id.VideoId).Where(x => !knownIds.Contains(x)).ToArray();
+
+                if (youTubeVideoIds.Any())
+                {
+                    var videoDetails =
+                        await youTubeVideoService.GetVideoContentDetails(youTubeService, youTubeVideoIds,
+                            indexingContext,
+                            true);
+
+                    if (videoDetails != null)
+                    {
+                        return videoDetails
+                            .Where(videoDetail => YouTubeVideoDurationMatcher.HasDuration(videoDetail.GetLength()))
+                            .Select(videoDetail =>
+                                GetEpisode(
+                                    youTubeVideos.First(searchResult => searchResult.Id.VideoId == videoDetail.Id),
+                                    videoDetail))
+                            .ToList();
+                    }
+                }
+            }
+
+            return null;
+        }
+        catch (YouTubeChannelSearchForbiddenException ex)
+        {
+            logger.LogInformation(ex,
+                "Search.List is not permitted for channel-id '{ChannelId}'; falling back to channel uploads playlist.",
+                channelId.ChannelId);
+            podcast.YouTubeChannelSearchForbidden = true;
+            return await GetEpisodesFromChannelUploadsPlaylist(channelId, indexingContext, knownIds);
+        }
+    }
+
+    private async Task<IList<RedditPodcastPoster.Models.Episode>?> GetEpisodesFromChannelUploadsPlaylist(
         YouTubeChannelId request,
         IndexingContext indexingContext,
         IEnumerable<string> knownIds)
     {
-        var youTubeVideos =
-            await youTubeChannelVideoSnippetsService.GetLatestChannelVideoSnippets(request, indexingContext);
-        if (youTubeVideos != null)
+        var channelVideos = await youTubeChannelVideosService.GetChannelVideos(request, indexingContext);
+        if (channelVideos?.PlaylistItems == null)
         {
-            var youTubeVideoIds = youTubeVideos.Select(x => x.Id.VideoId).Where(x => !knownIds.Contains(x)).ToArray();
-
-            if (youTubeVideoIds.Any())
-            {
-                var videoDetails =
-                    await youTubeVideoService.GetVideoContentDetails(youTubeService, youTubeVideoIds, indexingContext,
-                        true);
-
-                if (videoDetails != null)
-                {
-                    return videoDetails.Select(videoDetail =>
-                        GetEpisode(youTubeVideos.First(searchResult => searchResult.Id.VideoId == videoDetail.Id),
-                            videoDetail)).ToList();
-                }
-            }
+            return null;
         }
 
-        return null;
+        var playlistItems = channelVideos.PlaylistItems
+            .Where(x => !knownIds.Contains(x.Snippet.ResourceId.VideoId))
+            .ToList();
+        if (indexingContext.ReleasedSince.HasValue)
+        {
+            playlistItems = playlistItems
+                .Where(x => x.Snippet.PublishedAtDateTimeOffset.ReleasedSinceDate(indexingContext.ReleasedSince))
+                .ToList();
+        }
+
+        if (!playlistItems.Any())
+        {
+            return null;
+        }
+
+        var videoDetails = await youTubeVideoService.GetVideoContentDetails(
+            youTubeService,
+            playlistItems.Select(x => x.Snippet.ResourceId.VideoId),
+            indexingContext,
+            true);
+        if (videoDetails == null || !videoDetails.Any())
+        {
+            return null;
+        }
+
+        return playlistItems
+            .Where(x => x.Snippet.Title != "Deleted video")
+            .Select(x =>
+                new PlaylistItemVideo(
+                    x,
+                    videoDetails.SingleOrDefault(videoDetail => videoDetail.Id == x.Snippet.ResourceId.VideoId)!))
+            .Where(x => x.VideoDetails?.Snippet != null)
+            .Where(x => YouTubeVideoDurationMatcher.HasDuration(x.VideoDetails.GetLength()))
+            .Where(x => x.VideoDetails.Snippet.ChannelId == request.ChannelId)
+            .Select(x => GetEpisode(x.PlaylistItem.Snippet, x.VideoDetails))
+            .ToList();
     }
 
     public RedditPodcastPoster.Models.Episode GetEpisode(SearchResult searchResult,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Exceptions/YouTubeChannelSearchForbiddenException.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Exceptions/YouTubeChannelSearchForbiddenException.cs
@@ -1,0 +1,7 @@
+namespace RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
+
+public class YouTubeChannelSearchForbiddenException(string channelId, Exception innerException)
+    : Exception($"Search.List is not permitted for channel-id '{channelId}'.", innerException)
+{
+    public string ChannelId { get; } = channelId;
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/PlaylistItemExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/PlaylistItemExtensions.cs
@@ -1,0 +1,27 @@
+using Google.Apis.YouTube.v3.Data;
+using RedditPodcastPoster.Models.Extensions;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Extensions;
+
+public static class PlaylistItemExtensions
+{
+    public const int MaxMatchCandidatesWithoutReleasedSince = 5;
+
+    public static string GetVideoId(this PlaylistItem item) =>
+        item.ContentDetails?.VideoId ?? item.Snippet.ResourceId.VideoId;
+
+    public static IList<PlaylistItem> ForEpisodeMatching(
+        this IEnumerable<PlaylistItem> items,
+        IndexingContext indexingContext)
+    {
+        if (indexingContext.ReleasedSince.HasValue)
+        {
+            return items
+                .Where(x => x.Snippet.PublishedAtDateTimeOffset.ReleasedSinceDate(indexingContext.ReleasedSince))
+                .ToList();
+        }
+
+        return items.Take(MaxMatchCandidatesWithoutReleasedSince).ToList();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/ServiceCollectionExtensions.cs
@@ -45,6 +45,8 @@ public static class ServiceCollectionExtensions
             .AddScoped<ITolerantYouTubePlaylistService, TolerantYouTubePlaylistService>()
             .AddScoped<ICachedTolerantYouTubePlaylistService, CachedTolerantYouTubePlaylistService>()
             .AddScoped<IPlaylistItemFinder, PlaylistItemFinder>()
-            .BindConfiguration<YouTubeSettings>("youtube");
+            .AddSingleton<IYouTubeChannelVideoRetrievalPolicy, YouTubeChannelVideoRetrievalPolicy>()
+            .BindConfiguration<YouTubeSettings>("youtube")
+            .BindConfiguration<YouTubeChannelOptions>("youtubeChannel");
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/VideoExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/VideoExtensions.cs
@@ -5,6 +5,12 @@ namespace RedditPodcastPoster.PodcastServices.YouTube.Extensions;
 
 public static class VideoExtensions
 {
+    public static bool IsCompletedPublicVideo(this Google.Apis.YouTube.v3.Data.Video video)
+    {
+        var liveBroadcastContent = video.Snippet?.LiveBroadcastContent;
+        return liveBroadcastContent != "live" && liveBroadcastContent != "upcoming";
+    }
+
     public static TimeSpan? GetLength(this Google.Apis.YouTube.v3.Data.Video video)
     {
         if (string.IsNullOrWhiteSpace(video.ContentDetails.Duration))

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Handlers/YouTubeEpisodeRetrievalHandler.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Handlers/YouTubeEpisodeRetrievalHandler.cs
@@ -55,7 +55,7 @@ public class YouTubeEpisodeRetrievalHandler(
                 }
 
                 var foundEpisodes = await youTubeEpisodeProvider.GetEpisodes(
-                    new YouTubeChannelId(podcast.YouTubeChannelId), indexingContext, knownIds);
+                    podcast, indexingContext, knownIds);
                 if (foundEpisodes != null)
                 {
                     newEpisodes = foundEpisodes;

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/PlaylistItemOrdering.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/PlaylistItemOrdering.cs
@@ -1,0 +1,30 @@
+using Google.Apis.YouTube.v3.Data;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+
+public static class PlaylistItemOrdering
+{
+    public static bool IsReverseDateOrdered(IEnumerable<PlaylistItem> source)
+    {
+        using var iterator = source.GetEnumerator();
+        if (!iterator.MoveNext())
+        {
+            return true;
+        }
+
+        var current = iterator.Current.Snippet.PublishedAtDateTimeOffset;
+
+        while (iterator.MoveNext())
+        {
+            var next = iterator.Current.Snippet.PublishedAtDateTimeOffset;
+            if (current < next)
+            {
+                return false;
+            }
+
+            current = next;
+        }
+
+        return true;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
@@ -99,7 +99,7 @@ public class YouTubePlaylistService(
                 {
                     if (indexingContext.ReleasedSince.HasValue)
                     {
-                        knownToBeInReverseOrder = IsReverseDateOrdered(playlistItemsListResponse.Items);
+                        knownToBeInReverseOrder = PlaylistItemOrdering.IsReverseDateOrdered(playlistItemsListResponse.Items);
                         if (knownToBeInReverseOrder)
                         {
                             batchSize = 1;
@@ -163,27 +163,4 @@ public class YouTubePlaylistService(
         return new GetPlaylistInfoResponse(snippet.Title, snippet.Description);
     }
 
-    private static bool IsReverseDateOrdered(IEnumerable<PlaylistItem> source)
-    {
-        using var iterator = source.GetEnumerator();
-        if (!iterator.MoveNext())
-        {
-            return true;
-        }
-
-        var current = iterator.Current.Snippet.PublishedAtDateTimeOffset;
-
-        while (iterator.MoveNext())
-        {
-            var next = iterator.Current.Snippet.PublishedAtDateTimeOffset;
-            if (current < next)
-            {
-                return false;
-            }
-
-            current = next;
-        }
-
-        return true;
-    }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
@@ -2,6 +2,8 @@
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Abstractions.Extensions;
 using RedditPodcastPoster.PodcastServices.YouTube.ChannelSnippets;
+using RedditPodcastPoster.PodcastServices.YouTube.ChannelVideos;
+using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 using RedditPodcastPoster.PodcastServices.YouTube.Services;
@@ -11,6 +13,8 @@ namespace RedditPodcastPoster.PodcastServices.YouTube.Resolvers;
 public class YouTubeItemResolver(
     ICachedTolerantYouTubeChannelVideoSnippetsService youTubeChannelVideoSnippetsService,
     ICachedTolerantYouTubePlaylistService youTubePlaylistService,
+    IYouTubeChannelVideosService youTubeChannelVideosService,
+    IYouTubeChannelVideoRetrievalPolicy youTubeChannelVideoRetrievalPolicy,
     ISearchResultFinder searchResultFinder,
     IPlaylistItemFinder playlistItemFinder,
     ILogger<YouTubeItemResolver> logger)
@@ -82,35 +86,82 @@ public class YouTubeItemResolver(
     private async Task<FindEpisodeResponse?> GetChannelVideos(
         EnrichmentRequest request, IndexingContext indexingContext, TimeSpan youTubePublishingDelay)
     {
-        var searchListResponse =
-            await youTubeChannelVideoSnippetsService.GetLatestChannelVideoSnippets(
-                new YouTubeChannelId(request.Podcast.YouTubeChannelId), indexingContext);
-        if (searchListResponse == null)
+        var uploadsPlaylistReason = youTubeChannelVideoRetrievalPolicy.GetUploadsPlaylistReason(request.Podcast);
+        if (uploadsPlaylistReason != null)
+        {
+            logger.LogInformation(
+                "Using channel uploads playlist for channel-id '{ChannelId}' ({Reason}).",
+                request.Podcast.YouTubeChannelId, uploadsPlaylistReason);
+            return await GetChannelUploadsPlaylistVideos(request, indexingContext, youTubePublishingDelay);
+        }
+
+        try
+        {
+            var searchListResponse =
+                await youTubeChannelVideoSnippetsService.GetLatestChannelVideoSnippets(
+                    new YouTubeChannelId(request.Podcast.YouTubeChannelId), indexingContext);
+            if (searchListResponse == null)
+            {
+                return null;
+            }
+
+            if (searchListResponse.Any())
+            {
+                LogRetrievedCount(nameof(GetChannelVideos), searchListResponse.Count, indexingContext);
+            }
+
+            return await searchResultFinder.FindMatchingYouTubeVideo(
+                request.Episode,
+                searchListResponse,
+                youTubePublishingDelay,
+                indexingContext);
+        }
+        catch (YouTubeChannelSearchForbiddenException ex)
+        {
+            logger.LogInformation(ex,
+                "Search.List is not permitted for channel-id '{ChannelId}'; falling back to channel uploads playlist.",
+                request.Podcast.YouTubeChannelId);
+            request.Podcast.YouTubeChannelSearchForbidden = true;
+            return await GetChannelUploadsPlaylistVideos(request, indexingContext, youTubePublishingDelay);
+        }
+    }
+
+    private async Task<FindEpisodeResponse?> GetChannelUploadsPlaylistVideos(
+        EnrichmentRequest request, IndexingContext indexingContext, TimeSpan youTubePublishingDelay)
+    {
+        var channelVideos = await youTubeChannelVideosService.GetChannelVideos(
+            new YouTubeChannelId(request.Podcast.YouTubeChannelId), indexingContext);
+        if (channelVideos?.PlaylistItems == null)
         {
             return null;
         }
 
-        if (searchListResponse.Any())
+        if (channelVideos.PlaylistItems.Any())
         {
-            if (indexingContext.ReleasedSince.HasValue)
-            {
-                logger.LogInformation(
-                    "{method} Retrieved {count} items published on YouTube since '{releasedSince:R}'",
-                    nameof(GetChannelVideos), searchListResponse.Count, indexingContext.ReleasedSince.Value);
-            }
-            else
-            {
-                logger.LogInformation(
-                    "{method} Retrieved {count} items published on YouTube. {releasedSince} is Null.",
-                    nameof(GetChannelVideos), searchListResponse.Count, nameof(indexingContext.ReleasedSince));
-            }
+            LogRetrievedCount(nameof(GetChannelUploadsPlaylistVideos), channelVideos.PlaylistItems.Count,
+                indexingContext);
         }
 
-        var matchedYouTubeVideo = await searchResultFinder.FindMatchingYouTubeVideo(
+        return await playlistItemFinder.FindMatchingYouTubeVideo(
             request.Episode,
-            searchListResponse,
+            channelVideos.PlaylistItems,
             youTubePublishingDelay,
             indexingContext);
-        return matchedYouTubeVideo;
+    }
+
+    private void LogRetrievedCount(string method, int count, IndexingContext indexingContext)
+    {
+        if (indexingContext.ReleasedSince.HasValue)
+        {
+            logger.LogInformation(
+                "{method} Retrieved {count} items published on YouTube since '{releasedSince:R}'",
+                method, count, indexingContext.ReleasedSince.Value);
+        }
+        else
+        {
+            logger.LogInformation(
+                "{method} Retrieved {count} items published on YouTube. {releasedSince} is Null.",
+                method, count, nameof(indexingContext.ReleasedSince));
+        }
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
@@ -4,6 +4,7 @@ using RedditPodcastPoster.PodcastServices.Abstractions.Extensions;
 using RedditPodcastPoster.PodcastServices.YouTube.ChannelSnippets;
 using RedditPodcastPoster.PodcastServices.YouTube.ChannelVideos;
 using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
+using RedditPodcastPoster.PodcastServices.YouTube.Extensions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 using RedditPodcastPoster.PodcastServices.YouTube.Services;
@@ -136,15 +137,15 @@ public class YouTubeItemResolver(
             return null;
         }
 
-        if (channelVideos.PlaylistItems.Any())
+        var playlistItems = channelVideos.PlaylistItems.ForEpisodeMatching(indexingContext);
+        if (playlistItems.Any())
         {
-            LogRetrievedCount(nameof(GetChannelUploadsPlaylistVideos), channelVideos.PlaylistItems.Count,
-                indexingContext);
+            LogRetrievedCount(nameof(GetChannelUploadsPlaylistVideos), playlistItems.Count, indexingContext);
         }
 
         return await playlistItemFinder.FindMatchingYouTubeVideo(
             request.Episode,
-            channelVideos.PlaylistItems,
+            playlistItems,
             youTubePublishingDelay,
             indexingContext);
     }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/IYouTubeChannelVideoRetrievalPolicy.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/IYouTubeChannelVideoRetrievalPolicy.cs
@@ -1,0 +1,10 @@
+using RedditPodcastPoster.Models;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Services;
+
+public interface IYouTubeChannelVideoRetrievalPolicy
+{
+    bool ShouldUseUploadsPlaylist(Podcast podcast);
+
+    string? GetUploadsPlaylistReason(Podcast podcast);
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/PlaylistItemFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/PlaylistItemFinder.cs
@@ -29,12 +29,13 @@ public partial class PlaylistItemFinder(
         TimeSpan? youTubePublishDelay,
         IndexingContext indexingContext)
     {
-        var match = MatchOnExactTitle(episode, playlistItems);
-        if (match != null)
+        var exactTitleMatch = await MatchOnExactTitleWithDuration(episode, playlistItems, indexingContext);
+        if (exactTitleMatch != null)
         {
-            return new FindEpisodeResponse(PlaylistItem: match);
+            return exactTitleMatch;
         }
 
+        PlaylistItem? match;
         match = MatchOnEpisodeNumber(episode, playlistItems);
         if (match != null)
         {
@@ -97,10 +98,13 @@ public partial class PlaylistItemFinder(
         IList<Google.Apis.YouTube.v3.Data.Video>? videoDetails,
         IndexingContext indexingContext)
     {
-        if (videoDetails != null && videoDetails.Any())
+        var videosWithDuration = videoDetails?
+            .Where(x => YouTubeVideoDurationMatcher.HasDuration(x.GetLength()))
+            .ToList();
+        if (videosWithDuration != null && videosWithDuration.Any())
         {
             var matchingVideo =
-                videoDetails.MinBy(x => Math.Abs((episode.Length - x.GetLength() ?? TimeSpan.Zero).Ticks));
+                videosWithDuration.MinBy(x => Math.Abs((episode.Length - x.GetLength()!.Value).Ticks));
             var searchResult = searchResults.FirstOrDefault(x => x.ContentDetails.VideoId == matchingVideo!.Id);
             if (searchResult != null)
             {
@@ -177,6 +181,37 @@ public partial class PlaylistItemFinder(
         return null;
     }
 
+    private async Task<FindEpisodeResponse?> MatchOnExactTitleWithDuration(
+        RedditPodcastPoster.Models.Episode episode,
+        IList<PlaylistItem> playlistItems,
+        IndexingContext indexingContext)
+    {
+        var match = MatchOnExactTitle(episode, playlistItems);
+        if (match == null)
+        {
+            return null;
+        }
+
+        var videoDetails = await videoService.GetVideoContentDetails(
+            youTubeService, [match.ContentDetails.VideoId], indexingContext);
+        var video = videoDetails?.FirstOrDefault();
+        if (video == null)
+        {
+            return null;
+        }
+
+        if (!YouTubeVideoDurationMatcher.IsAcceptableDurationMatch(episode.Length, video.GetLength()))
+        {
+            logger.LogInformation(
+                "Rejected exact title match '{episodeTitle}' (length '{episodeLength:g}') with video '{videoTitle}' (length '{videoLength:g}') due to duration mismatch.",
+                episode.Title, episode.Length, match.Snippet.Title, video.GetLength());
+            return null;
+        }
+
+        logger.LogInformation("Matched on episode-title '{episodeTitle}'.", episode.Title);
+        return new FindEpisodeResponse(PlaylistItem: match, Video: video);
+    }
+
     private PlaylistItem? MatchOnExactTitle(RedditPodcastPoster.Models.Episode episode,
         IList<PlaylistItem> searchResults)
     {
@@ -186,12 +221,11 @@ public partial class PlaylistItemFinder(
             var snippetTitle = x.Snippet.Title.Trim().ToLower();
             return snippetTitle == episodeTitle ||
                    snippetTitle.Contains(episodeTitle) ||
-                   episodeTitle.Contains(episodeTitle);
+                   episodeTitle.Contains(snippetTitle);
         });
 
         if (matchingSearchResult.Count() == 1)
         {
-            logger.LogInformation("Matched on episode-title '{episodeTitle}'.", episode.Title);
             return matchingSearchResult.Single();
         }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/PlaylistItemFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/PlaylistItemFinder.cs
@@ -29,20 +29,25 @@ public partial class PlaylistItemFinder(
         TimeSpan? youTubePublishDelay,
         IndexingContext indexingContext)
     {
+        playlistItems = await ExcludeLiveAndUpcoming(playlistItems, indexingContext);
+        if (!playlistItems.Any())
+        {
+            return null;
+        }
+
         var exactTitleMatch = await MatchOnExactTitleWithDuration(episode, playlistItems, indexingContext);
         if (exactTitleMatch != null)
         {
             return exactTitleMatch;
         }
 
-        PlaylistItem? match;
-        match = MatchOnEpisodeNumber(episode, playlistItems);
-        if (match != null)
+        var episodeNumberMatch = await MatchOnEpisodeNumberWithDuration(episode, playlistItems, indexingContext);
+        if (episodeNumberMatch != null)
         {
-            return new FindEpisodeResponse(PlaylistItem: match);
+            return episodeNumberMatch;
         }
 
-        var videoIds = playlistItems.Select(x => x.ContentDetails.VideoId).ToList();
+        var videoIds = playlistItems.Select(x => x.GetVideoId()).ToList();
         var videoDetails = await videoService.GetVideoContentDetails(youTubeService, videoIds, indexingContext);
 
 
@@ -52,6 +57,7 @@ public partial class PlaylistItemFinder(
             return videoMatch;
         }
 
+        PlaylistItem? match;
         if (episode.HasAccurateReleaseTime() && youTubePublishDelay.HasValue)
         {
             match = MatchOnPublishTimeComparedToPublishDelay(episode, playlistItems, youTubePublishDelay.Value);
@@ -60,7 +66,7 @@ public partial class PlaylistItemFinder(
                 if (videoDetails != null)
                 {
                     // verify duration is similar
-                    var videoDetail = videoDetails.SingleOrDefault(x => x.Id == match.ContentDetails.VideoId);
+                    var videoDetail = videoDetails.SingleOrDefault(x => x.Id == match.GetVideoId());
                     if (videoDetail != null)
                     {
                         var matchingVideoLength = videoDetail.GetLength();
@@ -83,13 +89,7 @@ public partial class PlaylistItemFinder(
             }
         }
 
-        match = MatchOnTextCloseness(episode, playlistItems);
-        if (match != null)
-        {
-            return new FindEpisodeResponse(PlaylistItem: match);
-        }
-
-        return null;
+        return await MatchOnTextClosenessWithDuration(episode, playlistItems, indexingContext);
     }
 
     private FindEpisodeResponse? MatchOnEpisodeDuration(
@@ -105,7 +105,7 @@ public partial class PlaylistItemFinder(
         {
             var matchingVideo =
                 videosWithDuration.MinBy(x => Math.Abs((episode.Length - x.GetLength()!.Value).Ticks));
-            var searchResult = searchResults.FirstOrDefault(x => x.ContentDetails.VideoId == matchingVideo!.Id);
+            var searchResult = searchResults.FirstOrDefault(x => x.GetVideoId() == matchingVideo!.Id);
             if (searchResult != null)
             {
                 var matchingPair = new FindEpisodeResponse(PlaylistItem: searchResult, Video: matchingVideo);
@@ -147,7 +147,6 @@ public partial class PlaylistItemFinder(
 
                 if (matchingSearchResult.Count() == 1)
                 {
-                    logger.LogInformation("Matched on episode-number '{episodeNumber}'.", episodeNumber);
                     return matchingSearchResult.Single();
                 }
 
@@ -181,6 +180,34 @@ public partial class PlaylistItemFinder(
         return null;
     }
 
+    private async Task<FindEpisodeResponse?> MatchOnEpisodeNumberWithDuration(
+        RedditPodcastPoster.Models.Episode episode,
+        IList<PlaylistItem> playlistItems,
+        IndexingContext indexingContext)
+    {
+        var match = MatchOnEpisodeNumber(episode, playlistItems);
+        if (match == null)
+        {
+            return null;
+        }
+
+        return await ValidatePlaylistMatchWithDuration(episode, match, "episode-number", indexingContext);
+    }
+
+    private async Task<FindEpisodeResponse?> MatchOnTextClosenessWithDuration(
+        RedditPodcastPoster.Models.Episode episode,
+        IList<PlaylistItem> playlistItems,
+        IndexingContext indexingContext)
+    {
+        var match = MatchOnTextCloseness(episode, playlistItems);
+        if (match == null)
+        {
+            return null;
+        }
+
+        return await ValidatePlaylistMatchWithDuration(episode, match, "fuzzy title", indexingContext);
+    }
+
     private async Task<FindEpisodeResponse?> MatchOnExactTitleWithDuration(
         RedditPodcastPoster.Models.Episode episode,
         IList<PlaylistItem> playlistItems,
@@ -192,8 +219,17 @@ public partial class PlaylistItemFinder(
             return null;
         }
 
+        return await ValidatePlaylistMatchWithDuration(episode, match, "episode-title", indexingContext);
+    }
+
+    private async Task<FindEpisodeResponse?> ValidatePlaylistMatchWithDuration(
+        RedditPodcastPoster.Models.Episode episode,
+        PlaylistItem match,
+        string matchKind,
+        IndexingContext indexingContext)
+    {
         var videoDetails = await videoService.GetVideoContentDetails(
-            youTubeService, [match.ContentDetails.VideoId], indexingContext);
+            youTubeService, [match.GetVideoId()], indexingContext);
         var video = videoDetails?.FirstOrDefault();
         if (video == null)
         {
@@ -203,13 +239,32 @@ public partial class PlaylistItemFinder(
         if (!YouTubeVideoDurationMatcher.IsAcceptableDurationMatch(episode.Length, video.GetLength()))
         {
             logger.LogInformation(
-                "Rejected exact title match '{episodeTitle}' (length '{episodeLength:g}') with video '{videoTitle}' (length '{videoLength:g}') due to duration mismatch.",
-                episode.Title, episode.Length, match.Snippet.Title, video.GetLength());
+                "Rejected {matchKind} match '{episodeTitle}' (length '{episodeLength:g}') with video '{videoTitle}' (length '{videoLength:g}') due to duration mismatch.",
+                matchKind, episode.Title, episode.Length, match.Snippet.Title, video.GetLength());
             return null;
         }
 
-        logger.LogInformation("Matched on episode-title '{episodeTitle}'.", episode.Title);
+        logger.LogInformation("Matched on {matchKind} '{episodeTitle}'.", matchKind, episode.Title);
         return new FindEpisodeResponse(PlaylistItem: match, Video: video);
+    }
+
+    private async Task<IList<PlaylistItem>> ExcludeLiveAndUpcoming(
+        IList<PlaylistItem> playlistItems,
+        IndexingContext indexingContext)
+    {
+        var videoIds = playlistItems.Select(x => x.GetVideoId()).ToList();
+        var videos = await videoService.GetVideoContentDetails(
+            youTubeService, videoIds, indexingContext, withSnippets: true);
+        if (videos == null)
+        {
+            return playlistItems;
+        }
+
+        var completedVideoIds = videos
+            .Where(x => x.IsCompletedPublicVideo())
+            .Select(x => x.Id)
+            .ToHashSet();
+        return playlistItems.Where(x => completedVideoIds.Contains(x.GetVideoId())).ToList();
     }
 
     private PlaylistItem? MatchOnExactTitle(RedditPodcastPoster.Models.Episode episode,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/PlaylistItemFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/PlaylistItemFinder.cs
@@ -81,10 +81,6 @@ public partial class PlaylistItemFinder(
                             }
                         }
                     }
-                    else
-                    {
-                        return new FindEpisodeResponse(PlaylistItem: match);
-                    }
                 }
             }
         }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/SearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/SearchResultFinder.cs
@@ -76,10 +76,6 @@ public partial class SearchResultFinder(
                             }
                         }
                     }
-                    else
-                    {
-                        return new FindEpisodeResponse(match);
-                    }
                 }
             }
         }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/SearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/SearchResultFinder.cs
@@ -29,12 +29,13 @@ public partial class SearchResultFinder(
         TimeSpan? youTubePublishDelay,
         IndexingContext indexingContext)
     {
-        var match = MatchOnExactTitle(episode, searchResults);
-        if (match != null)
+        var exactTitleMatch = await MatchOnExactTitleWithDuration(episode, searchResults, indexingContext);
+        if (exactTitleMatch != null)
         {
-            return new FindEpisodeResponse(match);
+            return exactTitleMatch;
         }
 
+        SearchResult? match;
         match = await MatchOnEpisodeNumberAndDuration(episode, searchResults, indexingContext);
         if (match != null)
         {
@@ -98,10 +99,13 @@ public partial class SearchResultFinder(
         IList<Google.Apis.YouTube.v3.Data.Video>? videoDetails,
         IndexingContext indexingContext)
     {
-        if (videoDetails != null && videoDetails.Any())
+        var videosWithDuration = videoDetails?
+            .Where(x => YouTubeVideoDurationMatcher.HasDuration(x.GetLength()))
+            .ToList();
+        if (videosWithDuration != null && videosWithDuration.Any())
         {
             var matchingVideo =
-                videoDetails.MinBy(x => Math.Abs((episode.Length - x.GetLength() ?? TimeSpan.Zero).Ticks));
+                videosWithDuration.MinBy(x => Math.Abs((episode.Length - x.GetLength()!.Value).Ticks));
             var searchResult = searchResults.FirstOrDefault(x => x.Id.VideoId == matchingVideo!.Id);
             if (searchResult != null)
             {
@@ -215,6 +219,37 @@ public partial class SearchResultFinder(
         return null;
     }
 
+    private async Task<FindEpisodeResponse?> MatchOnExactTitleWithDuration(
+        RedditPodcastPoster.Models.Episode episode,
+        IList<SearchResult> searchResults,
+        IndexingContext indexingContext)
+    {
+        var match = MatchOnExactTitle(episode, searchResults);
+        if (match == null)
+        {
+            return null;
+        }
+
+        var videoDetails =
+            await videoService.GetVideoContentDetails(youTubeService, [match.Id.VideoId], indexingContext);
+        var video = videoDetails?.FirstOrDefault();
+        if (video == null)
+        {
+            return null;
+        }
+
+        if (!YouTubeVideoDurationMatcher.IsAcceptableDurationMatch(episode.Length, video.GetLength()))
+        {
+            logger.LogInformation(
+                "Rejected exact title match '{episodeTitle}' (length '{episodeLength:g}') with video '{videoTitle}' (length '{videoLength:g}') due to duration mismatch.",
+                episode.Title, episode.Length, match.Snippet.Title, video.GetLength());
+            return null;
+        }
+
+        logger.LogInformation("Matched on episode-title '{episodeTitle}'.", episode.Title);
+        return new FindEpisodeResponse(match, Video: video);
+    }
+
     private SearchResult? MatchOnExactTitle(RedditPodcastPoster.Models.Episode episode,
         IList<SearchResult> searchResults)
     {
@@ -230,7 +265,6 @@ public partial class SearchResultFinder(
 
         if (matchingSearchResult.Count() == 1)
         {
-            logger.LogInformation("Matched on episode-number '{episodeTitle}'.", episode.Title);
             return matchingSearchResult.Single();
         }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/SearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/SearchResultFinder.cs
@@ -35,11 +35,10 @@ public partial class SearchResultFinder(
             return exactTitleMatch;
         }
 
-        SearchResult? match;
-        match = await MatchOnEpisodeNumberAndDuration(episode, searchResults, indexingContext);
-        if (match != null)
+        var episodeNumberMatch = await MatchOnEpisodeNumberWithDuration(episode, searchResults, indexingContext);
+        if (episodeNumberMatch != null)
         {
-            return new FindEpisodeResponse(match);
+            return episodeNumberMatch;
         }
 
         var videoDetails =
@@ -53,6 +52,7 @@ public partial class SearchResultFinder(
             return videoMatch;
         }
 
+        SearchResult? match;
         if (episode.HasAccurateReleaseTime() && youTubePublishDelay.HasValue)
         {
             match = MatchOnPublishTimeComparedToPublishDelay(episode, searchResults, youTubePublishDelay.Value);
@@ -84,13 +84,7 @@ public partial class SearchResultFinder(
             }
         }
 
-        match = MatchOnTextCloseness(episode, searchResults);
-        if (match != null)
-        {
-            return new FindEpisodeResponse(match);
-        }
-
-        return null;
+        return await MatchOnTextClosenessWithDuration(episode, searchResults, indexingContext);
     }
 
     private FindEpisodeResponse? MatchOnEpisodeDuration(
@@ -139,10 +133,37 @@ public partial class SearchResultFinder(
         return FuzzyMatcher.Match(episode.Title, searchResults, x => x.Snippet.Title, MinFuzzyScore);
     }
 
-    private async Task<SearchResult?> MatchOnEpisodeNumberAndDuration(
+    private async Task<FindEpisodeResponse?> MatchOnEpisodeNumberWithDuration(
         RedditPodcastPoster.Models.Episode episode,
         IList<SearchResult> searchResults,
         IndexingContext indexingContext)
+    {
+        var match = MatchOnEpisodeNumber(episode, searchResults);
+        if (match == null)
+        {
+            return null;
+        }
+
+        return await ValidateSearchMatchWithDuration(episode, match, "episode-number", indexingContext);
+    }
+
+    private async Task<FindEpisodeResponse?> MatchOnTextClosenessWithDuration(
+        RedditPodcastPoster.Models.Episode episode,
+        IList<SearchResult> searchResults,
+        IndexingContext indexingContext)
+    {
+        var match = MatchOnTextCloseness(episode, searchResults);
+        if (match == null)
+        {
+            return null;
+        }
+
+        return await ValidateSearchMatchWithDuration(episode, match, "fuzzy title", indexingContext);
+    }
+
+    private SearchResult? MatchOnEpisodeNumber(
+        RedditPodcastPoster.Models.Episode episode,
+        IList<SearchResult> searchResults)
     {
         var episodeNumberMatch = NumberMatch.Match(episode.Title);
         if (episodeNumberMatch.Success)
@@ -157,36 +178,7 @@ public partial class SearchResultFinder(
 
                 if (matchingSearchResult.Count() == 1)
                 {
-                    logger.LogInformation("Matched on episode-number '{episodeNumber}'.", episodeNumber);
-
-                    var requestVideoIds = searchResults.Select(x => x.Id.VideoId).Distinct().ToList();
-                    var videoDetails = await videoService.GetVideoContentDetails(youTubeService,
-                        requestVideoIds, indexingContext);
-                    if ((videoDetails?.Count ?? 0) > 1)
-                    {
-                        logger.LogError("{method}: More than one video-detail. Should only request single video-id - uses distinct(). Requested-ids: {requestedIds}. Retrieved-ids: {retrievedIds}",
-                            nameof(MatchOnEpisodeNumberAndDuration),
-                            string.Join(", ", $"'{requestVideoIds}'"),
-                            string.Join(", ", $"'{videoDetails!.Select(x => x.Id)}'"));
-                    }
-
-                    var video = videoDetails?.FirstOrDefault();
-                    if (video == null)
-                    {
-                        return null;
-                    }
-
-                    if (IsDurationMatch(episode, video))
-                    {
-                        if (IsDurationMatch(episode, video))
-                        {
-                            logger.LogInformation(
-                                "Matched episode '{episodeTitle}' and length: '{episodeLength:g}' with episode '{snippetTitle}' having length: '{matchingPairVideoLength:g}'.",
-                                episode.Title, episode.Length, matchingSearchResult.Single().Snippet.Title,
-                                video.GetLength());
-                            return matchingSearchResult.Single();
-                        }
-                    }
+                    return matchingSearchResult.Single();
                 }
 
                 if (matchingSearchResult.Any())
@@ -230,6 +222,15 @@ public partial class SearchResultFinder(
             return null;
         }
 
+        return await ValidateSearchMatchWithDuration(episode, match, "episode-title", indexingContext);
+    }
+
+    private async Task<FindEpisodeResponse?> ValidateSearchMatchWithDuration(
+        RedditPodcastPoster.Models.Episode episode,
+        SearchResult match,
+        string matchKind,
+        IndexingContext indexingContext)
+    {
         var videoDetails =
             await videoService.GetVideoContentDetails(youTubeService, [match.Id.VideoId], indexingContext);
         var video = videoDetails?.FirstOrDefault();
@@ -241,12 +242,12 @@ public partial class SearchResultFinder(
         if (!YouTubeVideoDurationMatcher.IsAcceptableDurationMatch(episode.Length, video.GetLength()))
         {
             logger.LogInformation(
-                "Rejected exact title match '{episodeTitle}' (length '{episodeLength:g}') with video '{videoTitle}' (length '{videoLength:g}') due to duration mismatch.",
-                episode.Title, episode.Length, match.Snippet.Title, video.GetLength());
+                "Rejected {matchKind} match '{episodeTitle}' (length '{episodeLength:g}') with video '{videoTitle}' (length '{videoLength:g}') due to duration mismatch.",
+                matchKind, episode.Title, episode.Length, match.Snippet.Title, video.GetLength());
             return null;
         }
 
-        logger.LogInformation("Matched on episode-title '{episodeTitle}'.", episode.Title);
+        logger.LogInformation("Matched on {matchKind} '{episodeTitle}'.", matchKind, episode.Title);
         return new FindEpisodeResponse(match, Video: video);
     }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeChannelVideoRetrievalPolicy.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeChannelVideoRetrievalPolicy.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Options;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Services;
+
+public class YouTubeChannelVideoRetrievalPolicy(IOptions<YouTubeChannelOptions> options)
+    : IYouTubeChannelVideoRetrievalPolicy
+{
+    public bool ShouldUseUploadsPlaylist(Podcast podcast) =>
+        GetUploadsPlaylistReason(podcast) != null;
+
+    public string? GetUploadsPlaylistReason(Podcast podcast)
+    {
+        if (podcast.HasYouTubeChannelSearchForbidden())
+        {
+            return "youTubeChannelSearchForbidden";
+        }
+
+        if (options.Value.PreferUploadsPlaylist)
+        {
+            return "PreferUploadsPlaylist";
+        }
+
+        return null;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeVideoDurationMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeVideoDurationMatcher.cs
@@ -1,0 +1,26 @@
+namespace RedditPodcastPoster.PodcastServices.YouTube.Services;
+
+public static class YouTubeVideoDurationMatcher
+{
+    private static readonly TimeSpan LongFormEpisodeDuration = TimeSpan.FromMinutes(5);
+    private const double MaxShortfallRatio = 0.05;
+
+    public static bool HasDuration(TimeSpan? videoLength) =>
+        videoLength.HasValue && videoLength.Value > TimeSpan.Zero;
+
+    public static bool IsAcceptableDurationMatch(TimeSpan episodeLength, TimeSpan? videoLength)
+    {
+        if (!HasDuration(videoLength))
+        {
+            return false;
+        }
+
+        if (episodeLength < LongFormEpisodeDuration)
+        {
+            return true;
+        }
+
+        var minimumAcceptableTicks = (long)(episodeLength.Ticks * (1 - MaxShortfallRatio));
+        return videoLength!.Value.Ticks >= minimumAcceptableTicks;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
@@ -30,6 +30,7 @@ public class PodcastUpdater(
         var initialSkipSpotify = indexingContext.SkipSpotifyUrlResolving;
         var initialSkipYouTube = indexingContext.SkipYouTubeUrlResolving;
         var knownYouTubeExpensiveQuery = podcast.HasExpensiveYouTubePlaylistQuery();
+        var knownYouTubeChannelSearchForbidden = podcast.HasYouTubeChannelSearchForbidden();
         var knownSpotifyExpensiveQuery = podcast.HasExpensiveSpotifyEpisodesQuery();
         IList<Episode> episodes;
         EpisodeMergeResult mergeResult;
@@ -150,6 +151,15 @@ public class PodcastUpdater(
                 podcast.Name, podcast.Id, podcast.YouTubeChannelId);
         }
 
+        var discoveredYouTubeChannelSearchForbidden = !knownYouTubeChannelSearchForbidden &&
+                                                      podcast.HasYouTubeChannelSearchForbidden();
+        if (discoveredYouTubeChannelSearchForbidden)
+        {
+            logger.LogInformation(
+                "YouTube channel Search.List forbidden for podcast '{podcastName}' with id '{podcastId}' and youtube-channel-id '{podcastYouTubeChannelId}'; persisting uploads-playlist strategy.",
+                podcast.Name, podcast.Id, podcast.YouTubeChannelId);
+        }
+
         var discoveredSpotifyExpensiveQuery = !knownSpotifyExpensiveQuery && podcast.HasExpensiveSpotifyEpisodesQuery();
         if (discoveredSpotifyExpensiveQuery)
         {
@@ -160,7 +170,8 @@ public class PodcastUpdater(
 
         if (mergeResult.MergedEpisodes.Any() || mergeResult.AddedEpisodes.Any() ||
             filterResult.FilteredEpisodes.Any() || enrichmentResult.UpdatedEpisodes.Any() ||
-            discoveredYouTubeExpensiveQuery || discoveredSpotifyExpensiveQuery)
+            discoveredYouTubeExpensiveQuery || discoveredYouTubeChannelSearchForbidden ||
+            discoveredSpotifyExpensiveQuery)
         {
             // Update LatestReleased if new episodes were added or merged
             if (mergeResult.AddedEpisodes.Any())


### PR DESCRIPTION
- Introduced YouTubeChannelSearchForbidden property in Podcast model to track search restrictions.
- Enhanced PodcastUpdater to log and handle cases where YouTube channel search is forbidden.
- Added YouTubeChannelSearchForbiddenException to manage exceptions related to search restrictions.
- Implemented YouTubeChannelVideoRetrievalPolicy to determine when to use uploads playlist based on search permissions.
- Updated YouTubeEpisodeProvider and related services to utilize the new policy and handle uploads playlist logic.
- Added tests for YouTubeChannelVideoRetrievalPolicy and YouTubeVideoDurationMatcher to ensure correct behavior.
- Improved logging for video retrieval processes to enhance traceability and debugging.