### PR TITLE
Bump packages and harden search indexing

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.AI/RedditPodcastPoster.AI.csproj
+++ b/Class-Libraries/RedditPodcastPoster.AI/RedditPodcastPoster.AI.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.TextAnalytics" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Auth0/RedditPodcastPoster.Auth0.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Auth0/RedditPodcastPoster.Auth0.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.17.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.BBC.Tests/RedditPodcastPoster.BBC.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.BBC.Tests/RedditPodcastPoster.BBC.Tests.csproj
@@ -9,15 +9,15 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq.AutoMock" Version="4.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	    <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	    <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Class-Libraries/RedditPodcastPoster.BBC/RedditPodcastPoster.BBC.csproj
+++ b/Class-Libraries/RedditPodcastPoster.BBC/RedditPodcastPoster.BBC.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/RedditPodcastPoster.Bluesky.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/RedditPodcastPoster.Bluesky.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="idunno.Bluesky" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageReference Include="X.Bluesky" Version="1.3.0" />
   </ItemGroup>
 

--- a/Class-Libraries/RedditPodcastPoster.Cloudflare/RedditPodcastPoster.Cloudflare.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Cloudflare/RedditPodcastPoster.Cloudflare.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.28" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.19.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.4.5" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.24.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.CloudflareRedirect/RedditPodcastPoster.CloudflareRedirect.csproj
+++ b/Class-Libraries/RedditPodcastPoster.CloudflareRedirect/RedditPodcastPoster.CloudflareRedirect.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Common/RedditPodcastPoster.Common.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Common/RedditPodcastPoster.Common.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Configuration/RedditPodcastPoster.Configuration.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Configuration/RedditPodcastPoster.Configuration.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/LanguagesPublisher.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/LanguagesPublisher.cs
@@ -28,7 +28,7 @@ public class LanguagesPublisher(
         {
             "French", "Spanish", "German", "Portuguese", "Turkish", "Dutch", "Italian", "Japanese", "Chinese", "Korean",
             "Hindi", "Russian", "Hebrew", "Arabic", "Bangla", "Indonesian", "Filipino", "Urdu", "Kiswahili",
-            "Vietnamese", "Slovak", "Czech", "Telugu", "Afrikaans", "Persian", "Malay", "Norwegian", "Punjabi", "Thai",
+            "Vietnamese", "Slovak", "Czech", "Telugu", "Afrikaans", "Persian", "Malay", "Norwegian", "Polish", "Punjabi", "Thai",
             "Ukrainian", "Marathi", "Finnish", "Danish", "Greek", "Hungarian", "Swedish", "Bulgarian", "Serbian", "Croatian", "Lithuanian", "Latvian", "Slovenian", "Bosnian", "Macedonian", "Albanian", "Estonian", "Catalan", "Sinhala"
         }.Select(x => allCultures.Single(y => y.IsNeutralCulture && y.EnglishName == x));
 

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/RedditPodcastPoster.ContentPublisher.csproj
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/RedditPodcastPoster.ContentPublisher.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Discovery/RedditPodcastPoster.Discovery.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Discovery/RedditPodcastPoster.Discovery.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="PodcastAPI" Version="1.1.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/RedditPodcastPoster.EdgeApi.csproj
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/RedditPodcastPoster.EdgeApi.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/EpisodeSearchIndexerService.cs
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/EpisodeSearchIndexerService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Azure;
 using Azure.Search.Documents;
 using Microsoft.Extensions.Logging;
@@ -67,7 +68,7 @@ public class EpisodeSearchIndexerService(
             logger.LogError(ex,
                 "Failed to index episode with id '{episodeId}'. Status-code: {statusCode}, message: '{message}'.",
                 episodeId, ex.Status, ex.Message);
-            return new EntitySearchIndexerResponse { IndexerState = IndexerState.Failure };
+            return new EntitySearchIndexerResponse { IndexerState = MapRequestFailedException(ex) };
         }
     }
 
@@ -103,29 +104,44 @@ public class EpisodeSearchIndexerService(
 
         if (documents.Count > 0)
         {
-            var result =
-                await searchClient.MergeOrUploadDocumentsAsync(documents,
-                    new IndexDocumentsOptions { ThrowOnAnyError = false }, c);
-            var failures = result.Value.Results.Where(x => x.Succeeded == false).ToArray();
-            foreach (var failure in failures)
+            try
             {
-                logger.LogError("Failed to index episode with key '{Key}': {ErrorMessage}", failure.Key,
-                    failure.ErrorMessage);
-            }
+                var result =
+                    await searchClient.MergeOrUploadDocumentsAsync(documents,
+                        new IndexDocumentsOptions { ThrowOnAnyError = false }, c);
+                var failures = result.Value.Results.Where(x => x.Succeeded == false).ToArray();
+                foreach (var failure in failures)
+                {
+                    logger.LogError("Failed to index episode with key '{Key}': {ErrorMessage}", failure.Key,
+                        failure.ErrorMessage);
+                }
 
-            if (failures.Any())
+                if (failures.Any())
+                {
+                    var ex = new RequestFailedException(result.GetRawResponse());
+                    logger.LogError(ex,
+                        "Failed to index episodes with id '{episodeIds}'. Status-code: {statusCode}, message: '{message}'.",
+                        string.Join(", ", failures.Select(x => $"'{x.Key}'")), ex.Status, ex.Message);
+                    return new EntitySearchIndexerResponse { IndexerState = MapRequestFailedException(ex) };
+                }
+
+                return new EntitySearchIndexerResponse { IndexerState = IndexerState.Executed };
+            }
+            catch (RequestFailedException ex)
             {
-                var ex = new RequestFailedException(result.GetRawResponse());
                 logger.LogError(ex,
-                    "Failed to index episodes with id '{episodeIds}'. Status-code: {statusCode}, message: '{message}'.",
-                    string.Join(", ", failures.Select(x => $"'{x.Key}'")), ex.Status, ex.Message);
-                return new EntitySearchIndexerResponse { IndexerState = IndexerState.Failure };
+                    "Failed to index episodes. Status-code: {statusCode}, message: '{message}'.",
+                    ex.Status, ex.Message);
+                return new EntitySearchIndexerResponse { IndexerState = MapRequestFailedException(ex) };
             }
-
-            return new EntitySearchIndexerResponse { IndexerState = IndexerState.Executed };
         }
 
         logger.LogWarning("No documents to update in search-index");
         return new EntitySearchIndexerResponse { EpisodeIndexRequestState = EpisodeIndexRequestState.NoDocuments };
     }
+
+    private static IndexerState MapRequestFailedException(RequestFailedException ex) =>
+        ex.Status == (int)HttpStatusCode.TooManyRequests
+            ? IndexerState.TooManyRequests
+            : IndexerState.Failure;
 }

--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/RedditPodcastPoster.EntitySearchIndexer.csproj
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/RedditPodcastPoster.EntitySearchIndexer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.InternetArchive/RedditPodcastPoster.InternetArchive.csproj
+++ b/Class-Libraries/RedditPodcastPoster.InternetArchive/RedditPodcastPoster.InternetArchive.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Abstractions/RedditPodcastPoster.Persistence.Abstractions.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Abstractions/RedditPodcastPoster.Persistence.Abstractions.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Legacy/RedditPodcastPoster.Persistence.Legacy.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Legacy/RedditPodcastPoster.Persistence.Legacy.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Persistence/RedditPodcastPoster.Persistence.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/RedditPodcastPoster.Persistence.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/RedditPodcastPoster.PodcastServices.Apple.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/RedditPodcastPoster.PodcastServices.Apple.Tests.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/RedditPodcastPoster.PodcastServices.Apple.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/RedditPodcastPoster.PodcastServices.Apple.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="iTunesSearch" Version="1.0.44" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/RedditPodcastPoster.PodcastServices.Spotify.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/RedditPodcastPoster.PodcastServices.Spotify.Tests.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="SpotifyAPI.Web" Version="7.4.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/RedditPodcastPoster.PodcastServices.Spotify.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/RedditPodcastPoster.PodcastServices.Spotify.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageReference Include="SpotifyAPI.Web" Version="7.4.2" />
   </ItemGroup>
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/RedditPodcastPoster.PodcastServices.YouTube.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/RedditPodcastPoster.PodcastServices.YouTube.Tests.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq.AutoMock" Version="4.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/RedditPodcastPoster.PodcastServices.YouTube.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/RedditPodcastPoster.PodcastServices.YouTube.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.73.0.4099" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.75.0.4172" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/RedditPodcastPoster.PodcastServices.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/RedditPodcastPoster.PodcastServices.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.PushSubscriptions/RedditPodcastPoster.PushSubscriptions.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PushSubscriptions/RedditPodcastPoster.PushSubscriptions.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="WebPush" Version="1.0.12" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="WebPush" Version="1.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Reddit.Tests/RedditPodcastPoster.Reddit.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Reddit.Tests/RedditPodcastPoster.Reddit.Tests.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Moq.AutoMock" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Class-Libraries/RedditPodcastPoster.Reddit/RedditPodcastPoster.Reddit.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Reddit/RedditPodcastPoster.Reddit.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
   
 

--- a/Class-Libraries/RedditPodcastPoster.Search/RedditPodcastPoster.Search.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Search/RedditPodcastPoster.Search.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Azure.Search.Documents" Version="11.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Azure.Search.Documents" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/RedditPodcastPoster.Subjects.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/RedditPodcastPoster.Subjects.Tests.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq.AutoMock" Version="4.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Class-Libraries/RedditPodcastPoster.Subjects/RedditPodcastPoster.Subjects.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/RedditPodcastPoster.Subjects.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Subreddit/RedditPodcastPoster.Subreddit.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Subreddit/RedditPodcastPoster.Subreddit.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Text.Tests/RedditPodcastPoster.Text.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Text.Tests/RedditPodcastPoster.Text.Tests.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq.AutoMock" Version="4.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Class-Libraries/RedditPodcastPoster.Text/RedditPodcastPoster.Text.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Text/RedditPodcastPoster.Text.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Twitter/RedditPodcastPoster.Twitter.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Twitter/RedditPodcastPoster.Twitter.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="OAuth.Net" Version="1.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.UrlShortening/RedditPodcastPoster.UrlShortening.csproj
+++ b/Class-Libraries/RedditPodcastPoster.UrlShortening/RedditPodcastPoster.UrlShortening.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/RedditPodcastPoster.UrlSubmission.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/RedditPodcastPoster.UrlSubmission.Tests.csproj
@@ -8,15 +8,15 @@
   
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq.AutoMock" Version="4.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/RedditPodcastPoster.UrlSubmission.csproj
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/RedditPodcastPoster.UrlSubmission.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.YouTubePushNotifications.Tests/RedditPodcastPoster.YouTubePushNotifications.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.YouTubePushNotifications.Tests/RedditPodcastPoster.YouTubePushNotifications.Tests.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq.AutoMock" Version="4.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Class-Libraries/RedditPodcastPoster.YouTubePushNotifications/RedditPodcastPoster.YouTubePushNotifications.csproj
+++ b/Class-Libraries/RedditPodcastPoster.YouTubePushNotifications/RedditPodcastPoster.YouTubePushNotifications.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Cloud/Api/Api.csproj
+++ b/Cloud/Api/Api.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Auth0\RedditPodcastPoster.Auth0.csproj" />

--- a/Cloud/Azure/Azure.csproj
+++ b/Cloud/Azure/Azure.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.1.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Cloud/Discovery/Discovery.csproj
+++ b/Cloud/Discovery/Discovery.csproj
@@ -13,11 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.DurableTask.Client" Version="1.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.DurableTask.Client" Version="1.24.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <!--<PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />-->
   </ItemGroup>
   <ItemGroup>

--- a/Cloud/Indexer/Indexer.csproj
+++ b/Cloud/Indexer/Indexer.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.DurableTask.Client" Version="1.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.3" />
+    <PackageReference Include="Microsoft.DurableTask.Client" Version="1.24.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.5" />
     <!--<PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />-->
   </ItemGroup>
   <ItemGroup>

--- a/Console-Apps/AddAudioPodcast/AddAudioPodcast.csproj
+++ b/Console-Apps/AddAudioPodcast/AddAudioPodcast.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="iTunesSearch" Version="1.0.44" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/AddSubjectToSearchMatches/AddSubjectToSearchMatches.csproj
+++ b/Console-Apps/AddSubjectToSearchMatches/AddSubjectToSearchMatches.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 

--- a/Console-Apps/AddYouTubeChannelAsPodcast/AddYouTubeChannelAsPodcast.csproj
+++ b/Console-Apps/AddYouTubeChannelAsPodcast/AddYouTubeChannelAsPodcast.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/CategorisePodcastEpisodes/CategorisePodcastEpisodes.csproj
+++ b/Console-Apps/CategorisePodcastEpisodes/CategorisePodcastEpisodes.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/CosmosDbDownloader/CosmosDbDownloader.csproj
+++ b/Console-Apps/CosmosDbDownloader/CosmosDbDownloader.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Goblinfactory.Konsole" Version="7.0.0.7-alpha" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/CosmosDbFixer/CosmosDbFixer.csproj
+++ b/Console-Apps/CosmosDbFixer/CosmosDbFixer.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/CosmosDbUploader/CosmosDbUploader.csproj
+++ b/Console-Apps/CosmosDbUploader/CosmosDbUploader.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/CreateSearchIndex/CreateSearchIndex.csproj
+++ b/Console-Apps/CreateSearchIndex/CreateSearchIndex.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/CreateSearchIndex/CreateSearchIndexProcessor.cs
+++ b/Console-Apps/CreateSearchIndex/CreateSearchIndexProcessor.cs
@@ -435,7 +435,7 @@ public partial class CreateSearchIndexProcessor(
         Response result;
         if (!string.IsNullOrWhiteSpace(request.IndexerName))
         {
-            result = await searchIndexerClient.DeleteIndexerAsync(request.IndexerName);
+            result = await searchIndexerClient.DeleteIndexerAsync(request.IndexerName, CancellationToken.None);
             if (result.Status != (int)HttpStatusCode.NoContent && result.Status != (int)HttpStatusCode.NotFound)
             {
                 throw new InvalidOperationException(
@@ -447,7 +447,7 @@ public partial class CreateSearchIndexProcessor(
 
         if (!string.IsNullOrWhiteSpace(request.IndexName))
         {
-            result = await searchIndexClient.DeleteIndexAsync(request.IndexName);
+            result = await searchIndexClient.DeleteIndexAsync(request.IndexName, CancellationToken.None);
             if (result.Status != (int)HttpStatusCode.NoContent && result.Status != (int)HttpStatusCode.NotFound)
             {
                 throw new InvalidOperationException(
@@ -459,7 +459,7 @@ public partial class CreateSearchIndexProcessor(
 
         if (!string.IsNullOrWhiteSpace(request.DataSourceName))
         {
-            result = await searchIndexerClient.DeleteDataSourceConnectionAsync(request.DataSourceName);
+            result = await searchIndexerClient.DeleteDataSourceConnectionAsync(request.DataSourceName, CancellationToken.None);
             if (result.Status != (int)HttpStatusCode.NoContent && result.Status != (int)HttpStatusCode.NotFound)
             {
                 throw new InvalidOperationException(

--- a/Console-Apps/CultPodcasts.DatabasePublisher/CultPodcasts.DatabasePublisher.csproj
+++ b/Console-Apps/CultPodcasts.DatabasePublisher/CultPodcasts.DatabasePublisher.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Goblinfactory.Konsole" Version="7.0.0.7-alpha" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/DeleteSearchDocument/DeleteSearchDocument.csproj
+++ b/Console-Apps/DeleteSearchDocument/DeleteSearchDocument.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Search.Documents" Version="11.7.0" />
+    <PackageReference Include="Azure.Search.Documents" Version="12.0.0" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 

--- a/Console-Apps/Discover/Discover.csproj
+++ b/Console-Apps/Discover/Discover.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="PodcastAPI" Version="1.1.6" />
   </ItemGroup>
 

--- a/Console-Apps/EliminateExistingEpisodes/EliminateExistingEpisodes.csproj
+++ b/Console-Apps/EliminateExistingEpisodes/EliminateExistingEpisodes.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/EnrichEpisodesFromPostFlare/EnrichEpisodesFromPostFlare.csproj
+++ b/Console-Apps/EnrichEpisodesFromPostFlare/EnrichEpisodesFromPostFlare.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/EnrichExistingEpisodesFromPodcastServices/EnrichExistingEpisodesFromPodcastServices.csproj
+++ b/Console-Apps/EnrichExistingEpisodesFromPodcastServices/EnrichExistingEpisodesFromPodcastServices.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/EnrichPodcastWithImages/EnrichPodcastWithImages.csproj
+++ b/Console-Apps/EnrichPodcastWithImages/EnrichPodcastWithImages.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubeOnlyPodcasts.csproj
+++ b/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubeOnlyPodcasts.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/EpisodeDriftDetector/EpisodeDriftDetector.csproj
+++ b/Console-Apps/EpisodeDriftDetector/EpisodeDriftDetector.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/FindDuplicateEpisodes/FindDuplicateEpisodes.csproj
+++ b/Console-Apps/FindDuplicateEpisodes/FindDuplicateEpisodes.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/FixDatesFromApple/FixDatesFromApple.csproj
+++ b/Console-Apps/FixDatesFromApple/FixDatesFromApple.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/FlairPublisher/FlairPublisher.csproj
+++ b/Console-Apps/FlairPublisher/FlairPublisher.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/Index/Index.csproj
+++ b/Console-Apps/Index/Index.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/IndexAllEpisodesAudit/IndexAllEpisodesAudit.csproj
+++ b/Console-Apps/IndexAllEpisodesAudit/IndexAllEpisodesAudit.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/JsonSplitCosmosDbUploader/JsonSplitCosmosDbUploader.csproj
+++ b/Console-Apps/JsonSplitCosmosDbUploader/JsonSplitCosmosDbUploader.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/KVWriter/KVWriter.csproj
+++ b/Console-Apps/KVWriter/KVWriter.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/LanguagesPublisher/LanguagesPublisher.csproj
+++ b/Console-Apps/LanguagesPublisher/LanguagesPublisher.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Console-Apps/LegacyPodcastToV2Migration/LegacyPodcastToV2Migration.csproj
+++ b/Console-Apps/LegacyPodcastToV2Migration/LegacyPodcastToV2Migration.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/MachineAuth0/MachineAuth0.csproj
+++ b/Console-Apps/MachineAuth0/MachineAuth0.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/Poster/Poster.csproj
+++ b/Console-Apps/Poster/Poster.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/RemoveEpisodes/RemoveEpisodes.csproj
+++ b/Console-Apps/RemoveEpisodes/RemoveEpisodes.csproj
@@ -11,8 +11,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 

--- a/Console-Apps/RenamePodcast/RenamePodcast.csproj
+++ b/Console-Apps/RenamePodcast/RenamePodcast.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/SeedEliminationTerms/SeedEliminationTerms.csproj
+++ b/Console-Apps/SeedEliminationTerms/SeedEliminationTerms.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/SeedKnownTerms/SeedKnownTerms.csproj
+++ b/Console-Apps/SeedKnownTerms/SeedKnownTerms.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/SubjectSeeder/SubjectSeeder.csproj
+++ b/Console-Apps/SubjectSeeder/SubjectSeeder.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/SubmitUrl/SubmitUrl.csproj
+++ b/Console-Apps/SubmitUrl/SubmitUrl.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/TextClassifierTraining.Tests/TextClassifierTraining.Tests.csproj
+++ b/Console-Apps/TextClassifierTraining.Tests/TextClassifierTraining.Tests.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq.AutoMock" Version="4.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Console-Apps/TextClassifierTraining/TextClassifierTraining.csproj
+++ b/Console-Apps/TextClassifierTraining/TextClassifierTraining.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/ThrowawayConsole/Program.cs
+++ b/Console-Apps/ThrowawayConsole/Program.cs
@@ -1,22 +1,18 @@
 using System.Diagnostics;
 using System.Reflection;
-using Microsoft.Azure.Cosmos.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using RedditPodcastPoster.Common.Extensions;
+using RedditPodcastPoster.BBC;
+using RedditPodcastPoster.BBC.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
-using RedditPodcastPoster.Persistence.Abstractions;
-using RedditPodcastPoster.Persistence.Extensions;
-using RedditPodcastPoster.Subjects.Extensions;
-using RedditPodcastPoster.Text.Extensions;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.Configuration.SetBasePath(GetBasePath());
+builder.Environment.ContentRootPath = Directory.GetCurrentDirectory();
 
 builder.Configuration
-    .SetBasePath(Directory.GetCurrentDirectory())
+    .SetBasePath(GetBasePath())
     .AddJsonFile("appsettings.json", true)
     .AddEnvironmentVariables("RedditPodcastPoster_")
     .AddCommandLine(args)
@@ -24,36 +20,24 @@ builder.Configuration
 
 builder.Services
     .AddLogging()
-    .AddRepositories()
-    .AddSubjectServices()
-    .AddSubjectProvider()
-    .AddTextSanitiser()
-    .AddCommonServices()
-    .AddPostingCriteria();
+    .AddBBCServices()
+    .AddHttpClient();
 
 using var host = builder.Build();
 
-var podcastRepository = host.Services.GetRequiredService<IPodcastRepository>();
-var episodeRepository = host.Services.GetRequiredService<IEpisodeRepository>();
-
-var podcast= await podcastRepository.GetBy(x => x.Name == args[0]);
-if (podcast == null) 
+if (args.Length == 0 || !Uri.TryCreate(args[0], UriKind.Absolute, out var url))
 {
-    Console.WriteLine($"Podcast with name '{args[0]}' not found.");
-    return;
-}
-var episodes =  episodeRepository.GetByPodcastId(podcast.Id);
-await foreach (var episode in episodes)
-{
-    episode.SpotifyId= string.Empty;
-    episode.Urls.Spotify = null;
-    if (episode.Images != null)
-    {
-        episode.Images.Spotify = null;
-    }
-    await episodeRepository.Save(episode);
+    Console.Error.WriteLine("Usage: ThrowawayConsole <bbc-url>");
+    return 1;
 }
 
+var service = host.Services.GetRequiredService<IBBCPageMetaDataExtractor>();
+var pageData = await service.GetMetaData(url);
+
+Console.WriteLine($"Title: {pageData.Title}");
+Console.WriteLine($"Description: {pageData.Description}");
+
+return 0;
 
 string GetBasePath()
 {

--- a/Console-Apps/ThrowawayConsole/Properties/launchSettings.json
+++ b/Console-Apps/ThrowawayConsole/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ThrowawayConsole": {
       "commandName": "Project",
-      "commandLineArgs": "f32965f7-4ae1-4e41-9e31-31584d6922eb"
+      "commandLineArgs": "https://www.bbc.co.uk/sounds/play/p0jqc492"
     }
   }
 }

--- a/Console-Apps/ThrowawayConsole/ThrowawayConsole.csproj
+++ b/Console-Apps/ThrowawayConsole/ThrowawayConsole.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/Tweet/Tweet.csproj
+++ b/Console-Apps/Tweet/Tweet.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/UnremoveEpisodes/UnremoveEpisodes.csproj
+++ b/Console-Apps/UnremoveEpisodes/UnremoveEpisodes.csproj
@@ -11,8 +11,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 

--- a/Console-Apps/WebsubStatus/WebsubStatus.csproj
+++ b/Console-Apps/WebsubStatus/WebsubStatus.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Console-Apps/WikipediaEpisodeEnricher/WikipediaEpisodeEnricher.csproj
+++ b/Console-Apps/WikipediaEpisodeEnricher/WikipediaEpisodeEnricher.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Tvdb.Sdk" Version="4.7.10" />
   </ItemGroup>
 

--- a/Console-Apps/YouTubePushNotificationSubscribe/YouTubePushNotificationSubscribe.csproj
+++ b/Console-Apps/YouTubePushNotificationSubscribe/YouTubePushNotificationSubscribe.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <AzureCosmosDisableNewtonsoftJsonCheck>true</AzureCosmosDisableNewtonsoftJsonCheck>
+  </PropertyGroup>
+
   <!-- Ensure low-level dependency-injection projects are built before other projects to avoid CS0006 metadata not found errors. -->
   <Target Name="EnsureDependencyInjectionBuilt" BeforeTargets="Build"
           Condition="'$(MSBuildProjectName)' != 'RedditPodcastPoster.DependencyInjection' and '$(MSBuildProjectName)' != 'RedditPodcastPoster.DependencyInjection.Abstractions'">


### PR DESCRIPTION
## Summary
- Bump project package dependencies across the solution.
- Add `AzureCosmosDisableNewtonsoftJsonCheck` to `Directory.Build.targets` for Cosmos SDK compatibility.
- Handle Azure Search quota/429 failures in `IndexEpisodes` without failing the caller; return `TooManyRequests` in the API response.
- Simplify `ThrowawayConsole` into a minimal BBC metadata probing harness.

## Test plan
- [ ] `dotnet build` succeeds for affected projects
- [ ] Discovery curation submit returns 200 with `searchIndexerState: TooManyRequests` when search quota is exceeded (instead of 500)
- [ ] `ThrowawayConsole` runs against a BBC Sounds URL and prints title/description