### PR TITLE
YouTube quota reporting overhaul and indexer key ring

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Common/Episodes/EpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.Common/Episodes/EpisodeProvider.cs
@@ -1,74 +1,110 @@
-﻿using Microsoft.Extensions.Logging;
-using RedditPodcastPoster.Models;
-using RedditPodcastPoster.PodcastServices.Abstractions;
-
-namespace RedditPodcastPoster.Common.Episodes;
-
-public class EpisodeProvider(
-    IAppleEpisodeRetrievalHandler appleEpisodeRetrievalHandler,
-    IYouTubeEpisodeRetrievalHandler youTubeEpisodeRetrievalHandler,
-    ISpotifyEpisodeRetrievalHandler spotifyEpisodeRetrievalHandler,
-    IFoundEpisodeFilter foundEpisodeFilter,
-    ILogger<EpisodeProvider> logger)
-    : IEpisodeProvider
-{
-    public async Task<IList<Episode>> GetEpisodes(Podcast podcast, IEnumerable<Episode> episodes,
-        IndexingContext indexingContext)
-    {
-        IList<Episode>? newEpisodes = null;
-        var handled = false;
-        if (indexingContext.IndexSpotify && podcast.ReleaseAuthority is null or Service.Spotify &&
-            !string.IsNullOrWhiteSpace(podcast.SpotifyId))
-        {
-            (newEpisodes, handled) = await spotifyEpisodeRetrievalHandler.GetEpisodes(podcast, indexingContext);
-            if (handled)
-            {
-                logger.LogInformation(
-                    "Get Episodes for podcast '{podcastName}' handled by '{spotifyEpisodeRetrievalHandlerName}'.",
-                    podcast.Name, nameof(ISpotifyEpisodeRetrievalHandler));
-            }
-        }
-
-        if (!handled && podcast.ReleaseAuthority != Service.YouTube && podcast.AppleId != null)
-        {
-            (newEpisodes, handled) = await appleEpisodeRetrievalHandler.GetEpisodes(podcast, indexingContext);
-            if (handled)
-            {
-                logger.LogInformation(
-                    "Get Episodes for podcast '{podcastName}' handled by '{appleEpisodeRetrievalHandlerName}'.",
-                    podcast.Name, nameof(IAppleEpisodeRetrievalHandler));
-            }
-        }
-
-        if (!handled || (podcast.ReleaseAuthority is Service.YouTube &&
-                         !string.IsNullOrWhiteSpace(podcast.YouTubeChannelId)))
-        {
-            (newEpisodes, handled) =
-                await youTubeEpisodeRetrievalHandler.GetEpisodes(podcast, episodes, indexingContext);
-            if (handled)
-            {
-                logger.LogInformation(
-                    "Get Episodes for podcast '{podcastName}' handled by '{youTubeEpisodeRetrievalHandlerName}'.",
-                    podcast.Name, nameof(IYouTubeEpisodeRetrievalHandler));
-            }
-        }
-
-        if (!handled)
-        {
-            logger.LogInformation(
-                "Unable to handle podcast with name: '{podcastName}', id: {podcastId}. Spotify-Id: '{podcastSpotifyId}', Apple-Id: '{podcastAppleId}', YouTube-ChannelId: '{podcastYouTubeChannelId}', YouTube-PlayListId: '{podcastYouTubePlaylistId}'. Expensive-Queries? {hasExpensiveSpotifyEpisodesQueryName}= '{HasExpensiveSpotifyEpisodesQuery}', {HasExpensiveYouTubePlaylistQueryName}= '{HasExpensiveYouTubePlaylistQuery}'.",
-                podcast.Name, podcast.Id, podcast.SpotifyId, podcast.AppleId, podcast.YouTubeChannelId,
-                podcast.YouTubePlaylistId, nameof(podcast.HasExpensiveSpotifyEpisodesQuery),
-                podcast.HasExpensiveSpotifyEpisodesQuery(), nameof(podcast.HasExpensiveYouTubePlaylistQuery),
-                podcast.HasExpensiveYouTubePlaylistQuery());
-        }
-
-        if (newEpisodes != null && newEpisodes.Any() && !podcast.IndexAllEpisodes &&
-            !string.IsNullOrWhiteSpace(podcast.EpisodeIncludeTitleRegex))
-        {
-            newEpisodes = foundEpisodeFilter.ReduceEpisodes(podcast, newEpisodes);
-        }
-
-        return newEpisodes ?? new List<Episode>();
-    }
-}
+﻿using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+
+namespace RedditPodcastPoster.Common.Episodes;
+
+public class EpisodeProvider(
+    IAppleEpisodeRetrievalHandler appleEpisodeRetrievalHandler,
+    IYouTubeEpisodeRetrievalHandler youTubeEpisodeRetrievalHandler,
+    ISpotifyEpisodeRetrievalHandler spotifyEpisodeRetrievalHandler,
+    IFoundEpisodeFilter foundEpisodeFilter,
+    ILogger<EpisodeProvider> logger)
+    : IEpisodeProvider
+{
+    public async Task<IList<Episode>> GetEpisodes(Podcast podcast, IEnumerable<Episode> episodes,
+        IndexingContext indexingContext)
+    {
+        IList<Episode>? newEpisodes = null;
+        var handled = false;
+
+        if (!indexingContext.SkipYouTubeUrlResolving && podcast.DependsOnYouTubeForEpisodeDiscovery())
+        {
+            (newEpisodes, handled) = await RetrieveYouTubeEpisodes(podcast, episodes, indexingContext, newEpisodes);
+        }
+
+        if (indexingContext.IndexSpotify && podcast.ReleaseAuthority is null or Service.Spotify &&
+            !string.IsNullOrWhiteSpace(podcast.SpotifyId))
+        {
+            (newEpisodes, handled) = await spotifyEpisodeRetrievalHandler.GetEpisodes(podcast, indexingContext);
+            if (handled)
+            {
+                logger.LogInformation(
+                    "Get Episodes for podcast '{podcastName}' handled by '{spotifyEpisodeRetrievalHandlerName}'.",
+                    podcast.Name, nameof(ISpotifyEpisodeRetrievalHandler));
+            }
+        }
+
+        if (!handled && podcast.ReleaseAuthority != Service.YouTube && podcast.AppleId != null)
+        {
+            (newEpisodes, handled) = await appleEpisodeRetrievalHandler.GetEpisodes(podcast, indexingContext);
+            if (handled)
+            {
+                logger.LogInformation(
+                    "Get Episodes for podcast '{podcastName}' handled by '{appleEpisodeRetrievalHandlerName}'.",
+                    podcast.Name, nameof(IAppleEpisodeRetrievalHandler));
+            }
+        }
+
+        if (!indexingContext.SkipYouTubeUrlResolving &&
+            !string.IsNullOrWhiteSpace(podcast.YouTubeChannelId) &&
+            !podcast.DependsOnYouTubeForEpisodeDiscovery())
+        {
+            (newEpisodes, handled) = await RetrieveYouTubeEpisodes(podcast, episodes, indexingContext, newEpisodes);
+        }
+
+        if (!handled)
+        {
+            logger.LogInformation(
+                "Unable to handle podcast with name: '{podcastName}', id: {podcastId}. Spotify-Id: '{podcastSpotifyId}', Apple-Id: '{podcastAppleId}', YouTube-ChannelId: '{podcastYouTubeChannelId}', YouTube-PlayListId: '{podcastYouTubePlaylistId}'. Expensive-Queries? {hasExpensiveSpotifyEpisodesQueryName}= '{HasExpensiveSpotifyEpisodesQuery}', {HasExpensiveYouTubePlaylistQueryName}= '{HasExpensiveYouTubePlaylistQuery}'.",
+                podcast.Name, podcast.Id, podcast.SpotifyId, podcast.AppleId, podcast.YouTubeChannelId,
+                podcast.YouTubePlaylistId, nameof(podcast.HasExpensiveSpotifyEpisodesQuery),
+                podcast.HasExpensiveSpotifyEpisodesQuery(), nameof(podcast.HasExpensiveYouTubePlaylistQuery),
+                podcast.HasExpensiveYouTubePlaylistQuery());
+        }
+
+        if (newEpisodes != null && newEpisodes.Any() && !podcast.IndexAllEpisodes &&
+            !string.IsNullOrWhiteSpace(podcast.EpisodeIncludeTitleRegex))
+        {
+            newEpisodes = foundEpisodeFilter.ReduceEpisodes(podcast, newEpisodes);
+        }
+
+        return newEpisodes ?? new List<Episode>();
+    }
+
+    private async Task<(IList<Episode>? NewEpisodes, bool Handled)> RetrieveYouTubeEpisodes(
+        Podcast podcast,
+        IEnumerable<Episode> episodes,
+        IndexingContext indexingContext,
+        IList<Episode>? existingEpisodes)
+    {
+        var (youTubeEpisodes, youTubeHandled) =
+            await youTubeEpisodeRetrievalHandler.GetEpisodes(podcast, episodes, indexingContext);
+        if (!youTubeHandled)
+        {
+            return (existingEpisodes, false);
+        }
+
+        IList<Episode>? newEpisodes = existingEpisodes;
+        if (youTubeEpisodes is { Count: > 0 })
+        {
+            newEpisodes = CombineDiscoveredEpisodes(existingEpisodes, youTubeEpisodes);
+        }
+
+        logger.LogInformation(
+            "Get Episodes for podcast '{podcastName}' handled by '{youTubeEpisodeRetrievalHandlerName}'.",
+            podcast.Name, nameof(IYouTubeEpisodeRetrievalHandler));
+
+        return (newEpisodes, true);
+    }
+
+    private static IList<Episode> CombineDiscoveredEpisodes(IList<Episode>? existing, IList<Episode> additional)
+    {
+        if (existing == null || existing.Count == 0)
+        {
+            return additional;
+        }
+
+        return existing.Concat(additional).ToList();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Models/ModelType.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/ModelType.cs
@@ -35,6 +35,15 @@ public enum ModelType
     PushSubscription = 10,
 
     [JsonPropertyName(nameof(HomePageCache))]
-    HomePageCache = 11
+    HomePageCache = 11,
+
+    [JsonPropertyName(nameof(YouTubeQuotaReport))]
+    YouTubeQuotaReport = 12,
+
+    [JsonPropertyName(nameof(YouTubeIndexerKeyState))]
+    YouTubeIndexerKeyState = 13,
+
+    [JsonPropertyName(nameof(YouTubeQuotaUsageState))]
+    YouTubeQuotaUsageState = 14
 
 }

--- a/Class-Libraries/RedditPodcastPoster.Models/YouTubeIndexerKeyState.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/YouTubeIndexerKeyState.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace RedditPodcastPoster.Models;
+
+[CosmosSelector(ModelType.YouTubeIndexerKeyState)]
+public sealed class YouTubeIndexerKeyState : CosmosSelector
+{
+    public static readonly Guid _Id = Guid.Parse("a7c3e1f4-9b2d-4f6a-8c5e-1d3f7a9b2c4e");
+
+    public YouTubeIndexerKeyState()
+    {
+        Id = _Id;
+        ModelType = ModelType.YouTubeIndexerKeyState;
+    }
+
+    [JsonPropertyName("pacificQuotaDate")]
+    [JsonPropertyOrder(10)]
+    public DateOnly PacificQuotaDate { get; set; }
+
+    [JsonPropertyName("lastRingIndex")]
+    [JsonPropertyOrder(11)]
+    public int LastRingIndex { get; set; }
+
+    [JsonPropertyName("lastApiKey")]
+    [JsonPropertyOrder(12)]
+    public string? LastApiKey { get; set; }
+
+    [JsonPropertyName("updatedUtc")]
+    [JsonPropertyOrder(13)]
+    public DateTime UpdatedUtc { get; set; }
+
+    public override string FileKey => nameof(YouTubeIndexerKeyState);
+}

--- a/Class-Libraries/RedditPodcastPoster.Models/YouTubeQuotaDailyReport.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/YouTubeQuotaDailyReport.cs
@@ -1,0 +1,174 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace RedditPodcastPoster.Models;
+
+[CosmosSelector(ModelType.YouTubeQuotaReport)]
+public sealed class YouTubeQuotaDailyReport : CosmosSelector
+{
+    public YouTubeQuotaDailyReport()
+    {
+        ModelType = ModelType.YouTubeQuotaReport;
+    }
+
+    public static Guid CreateId(DateOnly reportDate, string sourceApplication)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"{reportDate:yyyyMMdd}:{sourceApplication}"));
+        var guidBytes = hash.AsSpan(0, 16).ToArray();
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x40);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
+    }
+
+    [JsonPropertyName("reportDate")]
+    [JsonPropertyOrder(10)]
+    public DateOnly ReportDate { get; set; }
+
+    [JsonPropertyName("sourceApplication")]
+    [JsonPropertyOrder(11)]
+    public required string SourceApplication { get; set; }
+
+    [JsonPropertyName("keys")]
+    [JsonPropertyOrder(12)]
+    public List<YouTubeQuotaKeyStats> Keys { get; set; } = [];
+
+    [JsonPropertyName("usedIndexerKeys")]
+    [JsonPropertyOrder(13)]
+    public List<YouTubeIndexerKeySummary> UsedIndexerKeys { get; set; } = [];
+
+    [JsonPropertyName("unusedIndexerKeys")]
+    [JsonPropertyOrder(14)]
+    public List<YouTubeIndexerKeySummary> UnusedIndexerKeys { get; set; } = [];
+
+    [JsonPropertyName("podcastsNotIndexedDueToQuota")]
+    [JsonPropertyOrder(15)]
+    public int PodcastsNotIndexedDueToQuota { get; set; }
+
+    [JsonPropertyName("podcastsNotEnrichedDueToQuota")]
+    [JsonPropertyOrder(16)]
+    public int PodcastsNotEnrichedDueToQuota { get; set; }
+
+    [JsonPropertyName("ringExhaustionCount")]
+    [JsonPropertyOrder(17)]
+    public int RingExhaustionCount { get; set; }
+
+    [JsonPropertyName("nonQuotaErrorCount")]
+    [JsonPropertyOrder(18)]
+    public int NonQuotaErrorCount { get; set; }
+
+    public override string FileKey => $"{nameof(YouTubeQuotaDailyReport)}-{ReportDate:yyyy-MM-dd}-{SourceApplication}";
+}
+
+public sealed class YouTubeQuotaKeyStats
+{
+    [JsonPropertyName("displayName")]
+    [JsonPropertyOrder(10)]
+    public required string DisplayName { get; set; }
+
+    [JsonPropertyName("project")]
+    [JsonPropertyOrder(11)]
+    public required string Project { get; set; }
+
+    [JsonPropertyName("usage")]
+    [JsonPropertyOrder(12)]
+    public required string Usage { get; set; }
+
+    [JsonPropertyName("callsAttempted")]
+    [JsonPropertyOrder(13)]
+    public int CallsAttempted { get; set; }
+
+    [JsonPropertyName("quotaHits")]
+    [JsonPropertyOrder(14)]
+    public int QuotaHits { get; set; }
+
+    [JsonPropertyName("quotaUsed")]
+    [JsonPropertyOrder(15)]
+    public int QuotaUsed { get; set; }
+
+    [JsonPropertyName("estimatedQuotaUsed")]
+    [JsonPropertyOrder(16)]
+    public int EstimatedQuotaUsed { get; set; }
+
+    [JsonPropertyName("dailyLimit")]
+    [JsonPropertyOrder(17)]
+    public int DailyLimit { get; set; }
+
+    [JsonPropertyName("quotaConsumedByOperation")]
+    [JsonPropertyOrder(18)]
+    public YouTubeQuotaConsumedByOperation QuotaConsumedByOperation { get; set; } = new();
+
+    [JsonPropertyName("capacityHint")]
+    [JsonPropertyOrder(19)]
+    public string? CapacityHint { get; set; }
+}
+
+public sealed class YouTubeIndexerKeySummary
+{
+    [JsonPropertyName("displayName")]
+    [JsonPropertyOrder(10)]
+    public required string DisplayName { get; set; }
+
+    [JsonPropertyName("project")]
+    [JsonPropertyOrder(11)]
+    public required string Project { get; set; }
+
+    [JsonPropertyName("hourPrimary")]
+    [JsonPropertyOrder(12)]
+    public int HourPrimary { get; set; }
+
+    [JsonPropertyName("reattempt")]
+    [JsonPropertyOrder(13)]
+    public int? Reattempt { get; set; }
+
+    [JsonPropertyName("apiKeySuffix")]
+    [JsonPropertyOrder(14)]
+    public required string ApiKeySuffix { get; set; }
+
+    [JsonPropertyName("callsAttempted")]
+    [JsonPropertyOrder(15)]
+    public int CallsAttempted { get; set; }
+
+    [JsonPropertyName("quotaHits")]
+    [JsonPropertyOrder(16)]
+    public int QuotaHits { get; set; }
+
+    [JsonPropertyName("quotaUsed")]
+    [JsonPropertyOrder(17)]
+    public int QuotaUsed { get; set; }
+
+    [JsonPropertyName("estimatedQuotaUsed")]
+    [JsonPropertyOrder(18)]
+    public int EstimatedQuotaUsed { get; set; }
+
+    [JsonPropertyName("dailyLimit")]
+    [JsonPropertyOrder(19)]
+    public int DailyLimit { get; set; }
+
+    [JsonPropertyName("quotaConsumedByOperation")]
+    [JsonPropertyOrder(20)]
+    public YouTubeQuotaConsumedByOperation QuotaConsumedByOperation { get; set; } = new();
+}
+
+public sealed class YouTubeQuotaConsumedByOperation
+{
+    [JsonPropertyName("searchList")]
+    [JsonPropertyOrder(10)]
+    public int SearchList { get; set; }
+
+    [JsonPropertyName("channelsList")]
+    [JsonPropertyOrder(11)]
+    public int ChannelsList { get; set; }
+
+    [JsonPropertyName("playlistItemsList")]
+    [JsonPropertyOrder(12)]
+    public int PlaylistItemsList { get; set; }
+
+    [JsonPropertyName("playlistsList")]
+    [JsonPropertyOrder(13)]
+    public int PlaylistsList { get; set; }
+
+    [JsonPropertyName("videosList")]
+    [JsonPropertyOrder(14)]
+    public int VideosList { get; set; }
+}

--- a/Class-Libraries/RedditPodcastPoster.Models/YouTubeQuotaUsageState.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/YouTubeQuotaUsageState.cs
@@ -1,0 +1,84 @@
+using System.Text.Json.Serialization;
+
+namespace RedditPodcastPoster.Models;
+
+[CosmosSelector(ModelType.YouTubeQuotaUsageState)]
+public sealed class YouTubeQuotaUsageState : CosmosSelector
+{
+    public static readonly Guid _Id = Guid.Parse("b8d4e2f5-0c3a-4d7e-9a1b-2c5f8e3d6a7b");
+
+    public YouTubeQuotaUsageState()
+    {
+        Id = _Id;
+        ModelType = ModelType.YouTubeQuotaUsageState;
+    }
+
+    [JsonPropertyName("pacificQuotaDate")]
+    [JsonPropertyOrder(10)]
+    public DateOnly PacificQuotaDate { get; set; }
+
+    [JsonPropertyName("sourceApplication")]
+    [JsonPropertyOrder(11)]
+    public required string SourceApplication { get; set; }
+
+    [JsonPropertyName("entries")]
+    [JsonPropertyOrder(12)]
+    public List<YouTubeQuotaUsageEntry> Entries { get; set; } = [];
+
+    [JsonPropertyName("updatedUtc")]
+    [JsonPropertyOrder(13)]
+    public DateTime UpdatedUtc { get; set; }
+
+    [JsonPropertyName("podcastsNotIndexedDueToQuota")]
+    [JsonPropertyOrder(14)]
+    public int PodcastsNotIndexedDueToQuota { get; set; }
+
+    [JsonPropertyName("podcastsNotEnrichedDueToQuota")]
+    [JsonPropertyOrder(15)]
+    public int PodcastsNotEnrichedDueToQuota { get; set; }
+
+    [JsonPropertyName("ringExhaustionCount")]
+    [JsonPropertyOrder(16)]
+    public int RingExhaustionCount { get; set; }
+
+    [JsonPropertyName("nonQuotaErrorCount")]
+    [JsonPropertyOrder(17)]
+    public int NonQuotaErrorCount { get; set; }
+
+    public override string FileKey => nameof(YouTubeQuotaUsageState);
+}
+
+public sealed class YouTubeQuotaUsageEntry
+{
+    [JsonPropertyName("statsKey")]
+    [JsonPropertyOrder(10)]
+    public required string StatsKey { get; set; }
+
+    [JsonPropertyName("displayName")]
+    [JsonPropertyOrder(11)]
+    public required string DisplayName { get; set; }
+
+    [JsonPropertyName("project")]
+    [JsonPropertyOrder(12)]
+    public required string Project { get; set; }
+
+    [JsonPropertyName("usage")]
+    [JsonPropertyOrder(13)]
+    public required string Usage { get; set; }
+
+    [JsonPropertyName("callsAttempted")]
+    [JsonPropertyOrder(14)]
+    public int CallsAttempted { get; set; }
+
+    [JsonPropertyName("quotaHits")]
+    [JsonPropertyOrder(15)]
+    public int QuotaHits { get; set; }
+
+    [JsonPropertyName("quotaUsed")]
+    [JsonPropertyOrder(16)]
+    public int QuotaUsed { get; set; }
+
+    [JsonPropertyName("quotaConsumedByOperation")]
+    [JsonPropertyOrder(17)]
+    public YouTubeQuotaConsumedByOperation QuotaConsumedByOperation { get; set; } = new();
+}

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Abstractions/ILookupRepository.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Abstractions/ILookupRepository.cs
@@ -11,4 +11,10 @@ public interface ILookupRepository
     Task<HomePageCache?> GetHomePageCache();
     Task SaveHomePageCache(HomePageCache homePageCache);
     Task IncrementHomePageActiveEpisodeCount(int delta);
+    Task SaveYouTubeQuotaDailyReport(YouTubeQuotaDailyReport report);
+    Task<YouTubeQuotaDailyReport?> GetYouTubeQuotaDailyReport(DateOnly reportDate, string sourceApplication);
+    Task<YouTubeIndexerKeyState?> GetYouTubeIndexerKeyState();
+    Task SaveYouTubeIndexerKeyState(YouTubeIndexerKeyState state);
+    Task<YouTubeQuotaUsageState?> GetYouTubeQuotaUsageState();
+    Task SaveYouTubeQuotaUsageState(YouTubeQuotaUsageState state);
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence/LookupRepository.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/LookupRepository.cs
@@ -41,6 +41,37 @@ public class LookupRepository(
         await lookupContainer.UpsertItemAsync(homePageCache, new PartitionKey(homePageCache.Id.ToString()));
     }
 
+    public async Task SaveYouTubeQuotaDailyReport(YouTubeQuotaDailyReport report)
+    {
+        await lookupContainer.UpsertItemAsync(report, new PartitionKey(report.Id.ToString()));
+    }
+
+    public Task<YouTubeQuotaDailyReport?> GetYouTubeQuotaDailyReport(DateOnly reportDate, string sourceApplication)
+    {
+        var id = YouTubeQuotaDailyReport.CreateId(reportDate, sourceApplication);
+        return GetById<YouTubeQuotaDailyReport>(id);
+    }
+
+    public Task<YouTubeIndexerKeyState?> GetYouTubeIndexerKeyState()
+    {
+        return GetById<YouTubeIndexerKeyState>(YouTubeIndexerKeyState._Id);
+    }
+
+    public async Task SaveYouTubeIndexerKeyState(YouTubeIndexerKeyState state)
+    {
+        await lookupContainer.UpsertItemAsync(state, new PartitionKey(state.Id.ToString()));
+    }
+
+    public Task<YouTubeQuotaUsageState?> GetYouTubeQuotaUsageState()
+    {
+        return GetById<YouTubeQuotaUsageState>(YouTubeQuotaUsageState._Id);
+    }
+
+    public async Task SaveYouTubeQuotaUsageState(YouTubeQuotaUsageState state)
+    {
+        await lookupContainer.UpsertItemAsync(state, new PartitionKey(state.Id.ToString()));
+    }
+
     public async Task IncrementHomePageActiveEpisodeCount(int delta)
     {
         if (delta == 0)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/IndexingContext.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/IndexingContext.cs
@@ -8,11 +8,13 @@ public record IndexingContext(
     bool SkipExpensiveYouTubeQueries = true,
     bool SkipPodcastDiscovery = true,
     bool SkipExpensiveSpotifyQueries = true,
-    bool SkipShortEpisodes = true)
+    bool SkipShortEpisodes = true,
+    bool YouTubeQuotaExhausted = false)
 {
     public bool SkipYouTubeUrlResolving { get; set; } = SkipYouTubeUrlResolving;
     public bool SkipSpotifyUrlResolving { get; set; } = SkipSpotifyUrlResolving;
     public bool IndexSpotify { get; set; } = IndexSpotify;
+    public bool YouTubeQuotaExhausted { get; set; } = YouTubeQuotaExhausted;
 
     public override string ToString()
     {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/IndexingContextExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/IndexingContextExtensions.cs
@@ -1,7 +1,19 @@
+using RedditPodcastPoster.Models;
+
 namespace RedditPodcastPoster.PodcastServices.Abstractions;
 
 public static class IndexingContextExtensions
 {
+    /// <summary>
+    /// Full playlist pagination is only allowed when the podcast is known-expensive and this pass
+    /// permits expensive YouTube queries (hour 0 UTC primary pass). Channel listing and single-page
+    /// playlist fetches are unaffected by <see cref="IndexingContext.SkipExpensiveYouTubeQueries"/>.
+    /// </summary>
+    public static bool RunExpensiveYouTubePlaylistPagination(this IndexingContext indexingContext, Podcast podcast)
+    {
+        return podcast.HasExpensiveYouTubePlaylistQuery() && !indexingContext.SkipExpensiveYouTubeQueries;
+    }
+
     public static List<string> GetIndexingContextChanges(this IndexingContext before, IndexingContext after)
     {
         var changes = new List<string>();
@@ -19,6 +31,11 @@ public static class IndexingContextExtensions
         if (before.SkipYouTubeUrlResolving != after.SkipYouTubeUrlResolving)
         {
             changes.Add($"{nameof(IndexingContext.SkipYouTubeUrlResolving)}: '{before.SkipYouTubeUrlResolving}' -> '{after.SkipYouTubeUrlResolving}'");
+        }
+
+        if (before.YouTubeQuotaExhausted != after.YouTubeQuotaExhausted)
+        {
+            changes.Add($"{nameof(IndexingContext.YouTubeQuotaExhausted)}: '{before.YouTubeQuotaExhausted}' -> '{after.YouTubeQuotaExhausted}'");
         }
 
         if (before.SkipSpotifyUrlResolving != after.SkipSpotifyUrlResolving)
@@ -47,5 +64,11 @@ public static class IndexingContextExtensions
         }
 
         return changes;
+    }
+
+    public static void MarkYouTubeQuotaExhausted(this IndexingContext indexingContext)
+    {
+        indexingContext.SkipYouTubeUrlResolving = true;
+        indexingContext.YouTubeQuotaExhausted = true;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/PodcastExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/PodcastExtensions.cs
@@ -4,35 +4,94 @@ namespace RedditPodcastPoster.PodcastServices.Abstractions;
 
 public static class PodcastExtensions
 {
-    public static bool IsDelayedYouTubePublishing(this Podcast podcast, Episode episode)
+    public static bool DependsOnYouTubeForEpisodeDiscovery(this Podcast podcast)
     {
-        if (string.IsNullOrWhiteSpace(podcast.SpotifyId) && podcast.AppleId == null)
+        return DependsOnYouTubeForEpisodeDiscovery(
+            podcast.ReleaseAuthority,
+            podcast.YouTubeChannelId,
+            podcast.SpotifyId,
+            podcast.AppleId);
+    }
+
+  public static bool IsScheduledYouTubeDiscoveryBypassed(this Podcast podcast, IndexingContext indexingContext)
+    {
+        return indexingContext.SkipYouTubeUrlResolving && podcast.DependsOnYouTubeForEpisodeDiscovery();
+    }
+
+    public static bool DependsOnYouTubeForEpisodeDiscovery(
+        Service? releaseAuthority,
+        string? youTubeChannelId,
+        string? spotifyId,
+        long? appleId)
+    {
+        if (string.IsNullOrWhiteSpace(youTubeChannelId))
         {
             return false;
         }
 
-        if (IsAudioPodcastAwaitingYouTubeRelease(podcast, episode) ||
-            IsYouTubePodcastWithDelayedPosting(podcast))
+        if (releaseAuthority == Service.YouTube)
         {
-            var youTubePublishingDelay = podcast.YouTubePublishingDelay();
-            if (youTubePublishingDelay > TimeSpan.Zero && episode.Length > TimeSpan.Zero)
-            {
-                youTubePublishingDelay = youTubePublishingDelay.Add(episode.Length);
-            }
-
-            var expiry = episode.Release.Add(youTubePublishingDelay);
-            if (expiry > DateTime.UtcNow)
-            {
-                return true;
-            }
+            return true;
         }
 
-        return false;
+        var hasSpotifyDiscovery = releaseAuthority is null or Service.Spotify &&
+                                  !string.IsNullOrWhiteSpace(spotifyId);
+        var hasAppleDiscovery = releaseAuthority != Service.YouTube && appleId != null;
+
+        return !hasSpotifyDiscovery && !hasAppleDiscovery;
+    }
+
+    public static bool IsDelayedYouTubePublishing(this Podcast podcast, Episode episode)
+    {
+        if (!HasAudioPlatformConfigured(podcast))
+        {
+            return false;
+        }
+
+        if (!IsAudioPodcastAwaitingYouTubeRelease(podcast, episode) &&
+            !IsYouTubeAuthorityAwaitingAudioRelease(podcast) &&
+            !IsYouTubePodcastWithDelayedPosting(podcast))
+        {
+            return false;
+        }
+
+        return GetYouTubePublishingDelayExpiry(podcast, episode.Release, episode.Length) > DateTime.UtcNow;
+    }
+
+    public static bool IsAwaitingDelayedAudioRelease(this Podcast podcast, DateTime release, TimeSpan length)
+    {
+        if (!HasAudioPlatformConfigured(podcast) || !IsYouTubeAuthorityAwaitingAudioRelease(podcast))
+        {
+            return false;
+        }
+
+        return GetYouTubePublishingDelayExpiry(podcast, release, length) > DateTime.UtcNow;
+    }
+
+    private static bool HasAudioPlatformConfigured(Podcast podcast)
+    {
+        return !string.IsNullOrWhiteSpace(podcast.SpotifyId) || podcast.AppleId != null;
+    }
+
+    private static DateTime GetYouTubePublishingDelayExpiry(Podcast podcast, DateTime release, TimeSpan length)
+    {
+        var youTubePublishingDelay = podcast.YouTubePublishingDelay();
+        if (youTubePublishingDelay > TimeSpan.Zero && length > TimeSpan.Zero)
+        {
+            youTubePublishingDelay = youTubePublishingDelay.Add(length);
+        }
+
+        return release.Add(youTubePublishingDelay);
     }
 
     private static bool IsAudioPodcastAwaitingYouTubeRelease(Podcast podcast, Episode episode)
     {
         return episode.Urls.YouTube == null && podcast.YouTubePublishingDelay() > TimeSpan.Zero;
+    }
+
+    private static bool IsYouTubeAuthorityAwaitingAudioRelease(Podcast podcast)
+    {
+        return podcast.ReleaseAuthority == Service.YouTube && podcast.YouTubePublishingDelay() > TimeSpan.Zero;
     }
 
     private static bool IsYouTubePodcastWithDelayedPosting(Podcast podcast)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerTests.cs
@@ -1,0 +1,132 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Handlers;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using EpisodeModel = RedditPodcastPoster.Models.Episode;
+using IYouTubeEpisodeProvider = RedditPodcastPoster.PodcastServices.YouTube.Episode.IYouTubeEpisodeProvider;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Handlers;
+
+public class YouTubeEpisodeRetrievalHandlerTests
+{
+    [Fact]
+    public async Task GetEpisodes_ChannelOnly_WhenSkipExpensiveYouTubeQueries_StillCallsChannelDiscovery()
+    {
+        var podcast = new Podcast
+        {
+            Id = Guid.NewGuid(),
+            YouTubeChannelId = "UC_test_channel",
+            YouTubePlaylistId = null
+        };
+        var indexingContext = new IndexingContext(
+            DateTime.UtcNow.AddDays(-2),
+            SkipExpensiveYouTubeQueries: true);
+        var expectedEpisodes = new List<EpisodeModel> { new() { Title = "episode-1" } };
+
+        var youTubeEpisodeProvider = new Mock<IYouTubeEpisodeProvider>();
+        youTubeEpisodeProvider
+            .Setup(x => x.GetEpisodes(podcast, indexingContext, It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(expectedEpisodes);
+
+        var sut = new YouTubeEpisodeRetrievalHandler(
+            youTubeEpisodeProvider.Object,
+            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
+
+        var result = await sut.GetEpisodes(podcast, [], indexingContext);
+
+        result.Handled.Should().BeTrue();
+        result.Episodes.Should().BeEquivalentTo(expectedEpisodes);
+        youTubeEpisodeProvider.Verify(
+            x => x.GetEpisodes(podcast, indexingContext, It.IsAny<IEnumerable<string>>()),
+            Times.Once);
+        youTubeEpisodeProvider.Verify(
+            x => x.GetPlaylistEpisodes(
+                It.IsAny<YouTubePlaylistId>(),
+                It.IsAny<YouTubeChannelId>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetEpisodes_ExpensivePlaylist_WhenSkipExpensiveYouTubeQueries_UsesSinglePageFetch()
+    {
+        var podcast = new Podcast
+        {
+            Id = Guid.NewGuid(),
+            YouTubeChannelId = "UC_test_channel",
+            YouTubePlaylistId = "PL_test_playlist",
+            YouTubePlaylistQueryIsExpensive = true
+        };
+        var indexingContext = new IndexingContext(
+            DateTime.UtcNow.AddDays(-2),
+            SkipExpensiveYouTubeQueries: true);
+        var expectedEpisodes = new List<EpisodeModel> { new() { Title = "playlist-episode" } };
+
+        var youTubeEpisodeProvider = new Mock<IYouTubeEpisodeProvider>();
+        youTubeEpisodeProvider
+            .Setup(x => x.GetPlaylistEpisodes(
+                new YouTubePlaylistId("PL_test_playlist"),
+                new YouTubeChannelId("UC_test_channel"),
+                indexingContext,
+                false))
+            .ReturnsAsync(new GetPlaylistEpisodesResponse(expectedEpisodes));
+
+        var sut = new YouTubeEpisodeRetrievalHandler(
+            youTubeEpisodeProvider.Object,
+            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
+
+        var result = await sut.GetEpisodes(podcast, [], indexingContext);
+
+        result.Handled.Should().BeTrue();
+        result.Episodes.Should().BeEquivalentTo(expectedEpisodes);
+        youTubeEpisodeProvider.Verify(
+            x => x.GetPlaylistEpisodes(
+                new YouTubePlaylistId("PL_test_playlist"),
+                new YouTubeChannelId("UC_test_channel"),
+                indexingContext,
+                false),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetEpisodes_ExpensivePlaylist_WhenExpensiveQueriesAllowed_UsesExpensivePagination()
+    {
+        var podcast = new Podcast
+        {
+            Id = Guid.NewGuid(),
+            YouTubeChannelId = "UC_test_channel",
+            YouTubePlaylistId = "PL_test_playlist",
+            YouTubePlaylistQueryIsExpensive = true
+        };
+        var indexingContext = new IndexingContext(
+            DateTime.UtcNow.AddDays(-2),
+            SkipExpensiveYouTubeQueries: false);
+
+        var youTubeEpisodeProvider = new Mock<IYouTubeEpisodeProvider>();
+        youTubeEpisodeProvider
+            .Setup(x => x.GetPlaylistEpisodes(
+                new YouTubePlaylistId("PL_test_playlist"),
+                new YouTubeChannelId("UC_test_channel"),
+                indexingContext,
+                true))
+            .ReturnsAsync(new GetPlaylistEpisodesResponse([]));
+
+        var sut = new YouTubeEpisodeRetrievalHandler(
+            youTubeEpisodeProvider.Object,
+            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
+
+        await sut.GetEpisodes(podcast, [], indexingContext);
+
+        youTubeEpisodeProvider.Verify(
+            x => x.GetPlaylistEpisodes(
+                new YouTubePlaylistId("PL_test_playlist"),
+                new YouTubeChannelId("UC_test_channel"),
+                indexingContext,
+                true),
+            Times.Once);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/IndexerKeyRingTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/IndexerKeyRingTests.cs
@@ -1,0 +1,153 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RedditPodcastPoster.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Strategies;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests;
+
+public class IndexerKeyRingTests
+{
+    private static YouTubeSettings CreateProductionLikeSettings() => new()
+    {
+        Applications =
+        [
+            App("key0", "CultPodcasts", ApplicationUsage.Cli, "ApiKey-0 - Cli", null),
+            App("key1", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-01-CultPodcasts", null),
+            App("key2", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-02-CultPodcasts", null),
+            App("key3", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-03-CultPodcasts", null),
+            App("key4", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-04-CultPodcasts", null),
+            App("key13discover", "cultpodcasts", ApplicationUsage.Discover, "ApiKey-13 - Discover", null),
+            App("key13discover2", "cultpodcasts", ApplicationUsage.Discover, "ApiKey-13 - Discover backup", null),
+            App("key7", "CultPodcasts", ApplicationUsage.Bluesky, "ApiKey-7 - Bluesky", null),
+            App("key8", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-05-CultPodcasts", null),
+            App("key9", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-06-CultPodcasts", null),
+            App("key10", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-07-CultPodcasts", null),
+            App("key11", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-08-CultPodcasts", null),
+            App("key12", "CultPodcasts", ApplicationUsage.Api, "ApiKey-12 - Api", null),
+            App("key15", "cultpodcasts", ApplicationUsage.Indexer, "Indexer-Key-09-CultPodcasts", null),
+            App("key14", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-10-CultPodcasts", null),
+            App("key16", "cultpodcasts", ApplicationUsage.Indexer, "Indexer-Key-11-CultPodcasts", null),
+            App("key14", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-12-CultPodcasts", null),
+        ]
+    };
+
+    private static Application App(
+        string apiKey,
+        string name,
+        ApplicationUsage usage,
+        string displayName,
+        int? reattempt) =>
+        new()
+        {
+            ApiKey = apiKey,
+            Name = name,
+            Usage = usage,
+            DisplayName = displayName,
+            Reattempt = reattempt
+        };
+
+    [Fact]
+    public void BuildIndexerKeyRing_ReturnsFlatConfigOrderWhenStartIndexZero()
+    {
+        var sut = CreateStrategy(CreateProductionLikeSettings(), hour: 0);
+
+        var ring = sut.BuildIndexerKeyRing(startRingIndex: 0);
+
+        ring.Select(x => x.Application.DisplayName).Should().Equal(
+            "Indexer-Key-01-CultPodcasts",
+            "Indexer-Key-02-CultPodcasts",
+            "Indexer-Key-03-CultPodcasts",
+            "Indexer-Key-04-CultPodcasts",
+            "Indexer-Key-05-CultPodcasts",
+            "Indexer-Key-06-CultPodcasts",
+            "Indexer-Key-07-CultPodcasts",
+            "Indexer-Key-08-CultPodcasts",
+            "Indexer-Key-09-CultPodcasts",
+            "Indexer-Key-10-CultPodcasts",
+            "Indexer-Key-11-CultPodcasts");
+    }
+
+    [Fact]
+    public void BuildIndexerKeyRing_DeduplicatesPhysicalApiKeys()
+    {
+        var sut = CreateStrategy(CreateProductionLikeSettings(), hour: 0);
+
+        var ring = sut.BuildIndexerKeyRing(startRingIndex: 0);
+
+        ring.Select(x => x.Application.ApiKey).Should().OnlyHaveUniqueItems();
+        ring.Should().HaveCount(11);
+        ring.Count(x => x.Application.ApiKey == "key15").Should().Be(1);
+        ring.Count(x => x.Application.ApiKey == "key16").Should().Be(1);
+        ring.Count(x => x.Application.ApiKey == "key14").Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildIndexerKeyRing_ExcludesDiscoverApiBlueskyAndCliKeys()
+    {
+        var sut = CreateStrategy(CreateProductionLikeSettings(), hour: 0);
+
+        var ring = sut.BuildIndexerKeyRing(startRingIndex: 0);
+
+        ring.Select(x => x.Application.ApiKey).Should().NotContain(["key0", "key7", "key12", "key13discover"]);
+        ring.Select(x => x.Application.Usage).Should().AllBeEquivalentTo(ApplicationUsage.Indexer);
+    }
+
+    [Fact]
+    public void GetApplication_ForIndexer_DoesNotReturnDiscoverOrApiKeys()
+    {
+        var sut = CreateStrategy(CreateProductionLikeSettings(), hour: 0);
+
+        var application = sut.GetApplication(ApplicationUsage.Indexer);
+
+        application.Application.Usage.Should().Be(ApplicationUsage.Indexer);
+        application.Application.ApiKey.Should().Be("key1");
+    }
+
+    [Fact]
+    public void BuildIndexerKeyRing_RotatesFromStartRingIndex()
+    {
+        var sut = CreateStrategy(CreateProductionLikeSettings(), hour: 12);
+
+        var ring = sut.BuildIndexerKeyRing(startRingIndex: 4);
+
+        ring.First().Application.DisplayName.Should().Be("Indexer-Key-05-CultPodcasts");
+    }
+
+    [Fact]
+    public void GetApplication_ForIndexer_UsesHourFallbackSpread()
+    {
+        var sut = CreateStrategy(CreateProductionLikeSettings(), hour: 18);
+
+        var application = sut.GetApplication(ApplicationUsage.Indexer);
+
+        application.Application.DisplayName.Should().Be("Indexer-Key-09-CultPodcasts");
+        application.Index.Should().Be(8);
+    }
+
+    [Fact]
+    public void GetHourFallbackRingIndex_CoversAllRingPositionsAcrossUtcDay()
+    {
+        const int ringCount = 11;
+        var seen = new HashSet<int>();
+
+        for (var hour = 0; hour < 24; hour++)
+        {
+            seen.Add(IndexerKeyRingBuilder.GetHourFallbackRingIndex(hour, ringCount));
+        }
+
+        seen.Should().HaveCount(ringCount);
+    }
+
+    private static YouTubeApiKeyStrategy CreateStrategy(YouTubeSettings settings, int hour)
+    {
+        var dateTimeService = new Mock<IDateTimeService>();
+        dateTimeService.Setup(x => x.GetHour()).Returns(hour);
+        return new YouTubeApiKeyStrategy(
+            Options.Create(settings),
+            dateTimeService.Object,
+            NullLogger<YouTubeApiKeyStrategy>.Instance);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/IndexingContextExtensionsTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/IndexingContextExtensionsTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests;
+
+public class IndexingContextExtensionsTests
+{
+    [Fact]
+    public void RunExpensiveYouTubePlaylistPagination_WhenSkipExpensive_ReturnsFalse()
+    {
+        var podcast = new Podcast { YouTubePlaylistQueryIsExpensive = true };
+        var indexingContext = new IndexingContext(DateTime.UtcNow.AddDays(-2), SkipExpensiveYouTubeQueries: true);
+
+        indexingContext.RunExpensiveYouTubePlaylistPagination(podcast).Should().BeFalse();
+    }
+
+    [Fact]
+    public void RunExpensiveYouTubePlaylistPagination_WhenExpensiveAllowed_ReturnsTrue()
+    {
+        var podcast = new Podcast { YouTubePlaylistQueryIsExpensive = true };
+        var indexingContext = new IndexingContext(DateTime.UtcNow.AddDays(-2), SkipExpensiveYouTubeQueries: false);
+
+        indexingContext.RunExpensiveYouTubePlaylistPagination(podcast).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RunExpensiveYouTubePlaylistPagination_WhenNotKnownExpensive_ReturnsFalse()
+    {
+        var podcast = new Podcast();
+        var indexingContext = new IndexingContext(DateTime.UtcNow.AddDays(-2), SkipExpensiveYouTubeQueries: false);
+
+        indexingContext.RunExpensiveYouTubePlaylistPagination(podcast).Should().BeFalse();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/RedditPodcastPoster.PodcastServices.YouTube.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/RedditPodcastPoster.PodcastServices.YouTube.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -27,6 +28,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.YouTube\RedditPodcastPoster.PodcastServices.YouTube.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.Persistence.Abstractions\RedditPodcastPoster.Persistence.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/TolerantYouTubeChannelServiceTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/TolerantYouTubeChannelServiceTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Channel;
+using RedditPodcastPoster.PodcastServices.YouTube.Clients;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests;
+
+public class TolerantYouTubeChannelServiceTests
+{
+    [Fact]
+    public async Task GetChannel_OnQuotaException_RotatesAndRetries()
+    {
+        var channelId = new YouTubeChannelId("channel-1");
+        var indexingContext = new IndexingContext();
+        var channel = new Google.Apis.YouTube.v3.Data.Channel { Id = channelId.ChannelId };
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Primary-1"
+        };
+
+        var wrapper = new Mock<IYouTubeServiceWrapper>();
+        wrapper.SetupGet(x => x.CanRotate).Returns(true);
+        wrapper.SetupGet(x => x.Usage).Returns(ApplicationUsage.Indexer);
+        wrapper.SetupGet(x => x.CurrentApplication).Returns(application);
+
+        var callCount = 0;
+        var channelService = new Mock<IYouTubeChannelService>();
+        channelService
+            .Setup(x => x.GetChannel(
+                channelId,
+                indexingContext,
+                true,
+                false,
+                false,
+                false))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    throw new YouTubeQuotaException();
+                }
+
+                return channel;
+            });
+
+        var quotaTracker = new Mock<IYouTubeQuotaUsageTracker>();
+        quotaTracker
+            .Setup(x => x.RecordCallAsync(It.IsAny<Application>(), ApplicationUsage.Indexer, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        quotaTracker
+            .Setup(x => x.RecordQuotaHitAsync(
+                It.IsAny<Application>(),
+                ApplicationUsage.Indexer,
+                It.IsAny<YouTubeQuotaOperation>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var sut = new TolerantYouTubeChannelService(
+            wrapper.Object,
+            channelService.Object,
+            quotaTracker.Object,
+            NullLogger<TolerantYouTubeChannelService>.Instance);
+
+        var result = await sut.GetChannel(channelId, indexingContext, withSnippets: true);
+
+        result.Should().Be(channel);
+        wrapper.Verify(x => x.Rotate(), Times.Once);
+        channelService.Verify(
+            x => x.GetChannel(channelId, indexingContext, true, false, false, false),
+            Times.Exactly(2));
+        quotaTracker.Verify(
+            x => x.RecordQuotaHitAsync(
+                application,
+                ApplicationUsage.Indexer,
+                YouTubeQuotaOperation.ChannelsList,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetChannel_WhenRotationExhausted_SetsSkipYouTubeUrlResolving()
+    {
+        var channelId = new YouTubeChannelId("channel-1");
+        var indexingContext = new IndexingContext();
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Primary-1"
+        };
+
+        var wrapper = new Mock<IYouTubeServiceWrapper>();
+        wrapper.SetupGet(x => x.CanRotate).Returns(true);
+        wrapper.SetupGet(x => x.Usage).Returns(ApplicationUsage.Indexer);
+        wrapper.SetupGet(x => x.CurrentApplication).Returns(application);
+        wrapper.Setup(x => x.Rotate()).Throws(new InvalidOperationException("Indexer key ring exhausted."));
+
+        var channelService = new Mock<IYouTubeChannelService>();
+        channelService
+            .Setup(x => x.GetChannel(
+                It.IsAny<YouTubeChannelId>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .ThrowsAsync(new YouTubeQuotaException());
+
+        var quotaTracker = new Mock<IYouTubeQuotaUsageTracker>();
+        quotaTracker
+            .Setup(x => x.RecordCallAsync(It.IsAny<Application>(), ApplicationUsage.Indexer, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        quotaTracker
+            .Setup(x => x.RecordQuotaHitAsync(
+                It.IsAny<Application>(),
+                ApplicationUsage.Indexer,
+                It.IsAny<YouTubeQuotaOperation>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var sut = new TolerantYouTubeChannelService(
+            wrapper.Object,
+            channelService.Object,
+            quotaTracker.Object,
+            NullLogger<TolerantYouTubeChannelService>.Instance);
+
+        var result = await sut.GetChannel(channelId, indexingContext);
+
+        result.Should().BeNull();
+        indexingContext.SkipYouTubeUrlResolving.Should().BeTrue();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeApiKeyStrategyTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeApiKeyStrategyTests.cs
@@ -25,29 +25,9 @@ public class YouTubeApiKeyStrategyTests
     [Theory]
     [InlineData(0, "1")]
     [InlineData(1, "1")]
-    [InlineData(2, "1")]
-    [InlineData(3, "1")]
-    [InlineData(4, "1")]
-    [InlineData(5, "1")]
-    [InlineData(6, "1")]
-    [InlineData(7, "1")]
-    [InlineData(8, "1")]
-    [InlineData(9, "1")]
-    [InlineData(10, "1")]
-    [InlineData(11, "1")]
     [InlineData(12, "2")]
-    [InlineData(13, "2")]
-    [InlineData(14, "2")]
-    [InlineData(15, "2")]
-    [InlineData(16, "2")]
-    [InlineData(17, "2")]
-    [InlineData(18, "2")]
-    [InlineData(19, "2")]
-    [InlineData(20, "2")]
-    [InlineData(21, "2")]
-    [InlineData(22, "2")]
     [InlineData(23, "2")]
-    public void GetApplication_WithTwoApplications_IsCorrect(int hour, string applicationName)
+    public void GetApplication_WithTwoIndexerApplications_UsesHourFallbackSpread(int hour, string applicationName)
     {
         // arrange
         _mocker.Use(Options.Create(new YouTubeSettings
@@ -98,7 +78,7 @@ public class YouTubeApiKeyStrategyTests
     [InlineData(21, "4")]
     [InlineData(22, "4")]
     [InlineData(23, "4")]
-    public void GetApplication_WithFourApplications_IsCorrect(int hour, string applicationName)
+    public void GetApplication_WithFourIndexerApplications_UsesHourFallbackSpread(int hour, string applicationName)
     {
         // arrange
         _mocker.Use(Options.Create(new YouTubeSettings
@@ -167,10 +147,10 @@ public class YouTubeApiKeyStrategyTests
     }
 
     [Fact]
-    public void GetApplication_WithCombinationUsageFlags_IsCorrect()
+    public void GetApplication_WithCombinationUsageFlags_UsesExactIndexerMatch()
     {
         // arrange
-        var applicationName = _fixture.Create<string>();
+        var indexerOnlyName = _fixture.Create<string>();
         _mocker.Use(Options.Create(new YouTubeSettings
         {
             Applications =
@@ -182,7 +162,12 @@ public class YouTubeApiKeyStrategyTests
                 },
                 new Application
                 {
-                    ApiKey = _fixture.Create<string>(), Name = applicationName,
+                    ApiKey = _fixture.Create<string>(), Name = indexerOnlyName,
+                    Usage = ApplicationUsage.Indexer, DisplayName = _fixture.Create<string>()
+                },
+                new Application
+                {
+                    ApiKey = _fixture.Create<string>(), Name = _fixture.Create<string>(),
                     Usage = ApplicationUsage.Indexer | ApplicationUsage.Api, DisplayName = _fixture.Create<string>()
                 }
             ]
@@ -190,6 +175,6 @@ public class YouTubeApiKeyStrategyTests
         // act
         var result = Sut.GetApplication(ApplicationUsage.Indexer);
         // assert
-        result.Application.Name.Should().Be(applicationName);
+        result.Application.Name.Should().Be(indexerOnlyName);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeIndexerKeyStateServiceTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeIndexerKeyStateServiceTests.cs
@@ -1,0 +1,183 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RedditPodcastPoster.Configuration;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Persistence.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
+using RedditPodcastPoster.PodcastServices.YouTube.Strategies;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests;
+
+public class YouTubeIndexerKeyStateServiceTests
+{
+    private static DateOnly CurrentPacificQuotaDate =>
+        YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow);
+
+    private static DateOnly PreviousPacificQuotaDate =>
+        YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow.AddDays(-1));
+
+    private static readonly DateOnly SamplePacificQuotaDate = new(2026, 6, 18);
+
+    private static YouTubeSettings CreateProductionLikeSettings() => new()
+    {
+        Applications =
+        [
+            App("key1", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-01-CultPodcasts", null),
+            App("key2", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-02-CultPodcasts", null),
+            App("key3", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-03-CultPodcasts", null),
+            App("key4", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-04-CultPodcasts", null),
+            App("key8", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-05-CultPodcasts", null),
+            App("key9", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-06-CultPodcasts", null),
+            App("key10", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-07-CultPodcasts", null),
+            App("key11", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-08-CultPodcasts", null),
+            App("key15", "cultpodcasts", ApplicationUsage.Indexer, "Indexer-Key-09-CultPodcasts", null),
+            App("key14", "CultPodcasts", ApplicationUsage.Indexer, "Indexer-Key-10-CultPodcasts", null),
+        ]
+    };
+
+    [Fact]
+    public async Task ResolveSessionStartAsync_WhenSavedStateMatchesQuotaDay_ResumesAtSavedKey()
+    {
+        var lookupRepository = new Mock<ILookupRepository>();
+        var strategy = CreateStrategy(CreateProductionLikeSettings(), hour: 0);
+        var sut = new YouTubeIndexerKeyStateService(
+            lookupRepository.Object,
+            strategy,
+            NullLogger<YouTubeIndexerKeyStateService>.Instance);
+        lookupRepository.Setup(x => x.GetYouTubeIndexerKeyState()).ReturnsAsync(new YouTubeIndexerKeyState
+        {
+            PacificQuotaDate = CurrentPacificQuotaDate,
+            LastRingIndex = 8,
+            LastApiKey = "key15",
+            UpdatedUtc = DateTime.UtcNow
+        });
+
+        var session = await sut.ResolveSessionStartAsync();
+
+        session.HourFallbackRingIndex.Should().Be(0);
+        session.InitialRingIndex.Should().Be(8);
+        session.Ring[session.InitialRingIndex].Application.ApiKey.Should().Be("key15");
+    }
+
+    [Fact]
+    public async Task ResolveSessionStartAsync_WhenQuotaDayChanged_ResetsToHourFallback()
+    {
+        var lookupRepository = new Mock<ILookupRepository>();
+        var strategy = CreateStrategy(CreateProductionLikeSettings(), hour: 0);
+        var sut = new YouTubeIndexerKeyStateService(
+            lookupRepository.Object,
+            strategy,
+            NullLogger<YouTubeIndexerKeyStateService>.Instance);
+
+        lookupRepository.Setup(x => x.GetYouTubeIndexerKeyState()).ReturnsAsync(new YouTubeIndexerKeyState
+        {
+            PacificQuotaDate = PreviousPacificQuotaDate,
+            LastRingIndex = 8,
+            LastApiKey = "key15",
+            UpdatedUtc = DateTime.UtcNow
+        });
+
+        var session = await sut.ResolveSessionStartAsync();
+
+        session.InitialRingIndex.Should().Be(0);
+        session.Ring[0].Application.ApiKey.Should().Be("key1");
+    }
+
+    [Fact]
+    public async Task ResolveSessionStartAsync_WhenSavedKeyMissingFromRing_FallsBackToHourFallback()
+    {
+        var lookupRepository = new Mock<ILookupRepository>();
+        var strategy = CreateStrategy(CreateProductionLikeSettings(), hour: 0);
+        var sut = new YouTubeIndexerKeyStateService(
+            lookupRepository.Object,
+            strategy,
+            NullLogger<YouTubeIndexerKeyStateService>.Instance);
+        lookupRepository.Setup(x => x.GetYouTubeIndexerKeyState()).ReturnsAsync(new YouTubeIndexerKeyState
+        {
+            PacificQuotaDate = CurrentPacificQuotaDate,
+            LastRingIndex = 8,
+            LastApiKey = "removed-key",
+            UpdatedUtc = DateTime.UtcNow
+        });
+
+        var session = await sut.ResolveSessionStartAsync();
+
+        session.InitialRingIndex.Should().Be(0);
+        session.Ring[0].Application.ApiKey.Should().Be("key1");
+    }
+
+    [Fact]
+    public async Task PersistSessionEndAsync_SavesCurrentRingPosition()
+    {
+        var lookupRepository = new Mock<ILookupRepository>();
+        var strategy = CreateStrategy(CreateProductionLikeSettings(), hour: 0);
+        var sut = new YouTubeIndexerKeyStateService(
+            lookupRepository.Object,
+            strategy,
+            NullLogger<YouTubeIndexerKeyStateService>.Instance);
+        YouTubeIndexerKeyState? savedState = null;
+        lookupRepository
+            .Setup(x => x.SaveYouTubeIndexerKeyState(It.IsAny<YouTubeIndexerKeyState>()))
+            .Callback<YouTubeIndexerKeyState>(state => savedState = state)
+            .Returns(Task.CompletedTask);
+
+        await sut.PersistSessionEndAsync(3, "key2");
+
+        savedState.Should().NotBeNull();
+        savedState!.LastRingIndex.Should().Be(3);
+        savedState.LastApiKey.Should().Be("key2");
+        savedState.PacificQuotaDate.Should().Be(CurrentPacificQuotaDate);
+    }
+
+    [Theory]
+    [InlineData("key15", 8, 8)]
+    [InlineData("missing-key", 8, 0)]
+    public void ResolveInitialRingIndex_UsesSavedKeyWhenPresent(string savedApiKey, int savedRingIndex, int expectedIndex)
+    {
+        var strategy = CreateStrategy(CreateProductionLikeSettings(), hour: 0);
+        var ring = strategy.BuildIndexerKeyRing(0);
+        var savedState = new YouTubeIndexerKeyState
+        {
+            PacificQuotaDate = SamplePacificQuotaDate,
+            LastRingIndex = savedRingIndex,
+            LastApiKey = savedApiKey
+        };
+
+        var initialRingIndex = IndexerKeyRingSessionResolver.ResolveInitialRingIndex(
+            ring,
+            savedState,
+            SamplePacificQuotaDate,
+            hourFallbackRingIndex: 0);
+
+        initialRingIndex.Should().Be(expectedIndex);
+    }
+
+    private static Application App(
+        string apiKey,
+        string name,
+        ApplicationUsage usage,
+        string displayName,
+        int? reattempt) =>
+        new()
+        {
+            ApiKey = apiKey,
+            Name = name,
+            Usage = usage,
+            DisplayName = displayName,
+            Reattempt = reattempt
+        };
+
+    private static YouTubeApiKeyStrategy CreateStrategy(YouTubeSettings settings, int hour)
+    {
+        var dateTimeService = new Mock<IDateTimeService>();
+        dateTimeService.Setup(x => x.GetHour()).Returns(hour);
+        return new YouTubeApiKeyStrategy(
+            Options.Create(settings),
+            dateTimeService.Object,
+            NullLogger<YouTubeApiKeyStrategy>.Instance);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeQuotaUsageTrackerTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeQuotaUsageTrackerTests.cs
@@ -1,0 +1,529 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Persistence.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests;
+
+public class YouTubeQuotaUsageTrackerTests
+{
+    private static readonly DateOnly SampleReportDate = new(2026, 6, 18);
+
+    [Fact]
+    public async Task CreateReport_IdentifiesSpareCapacityCandidates()
+    {
+        var sut = CreateTracker(
+            App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"),
+            App("key2", "CultPodcasts", "Indexer-Key-02-CultPodcasts"));
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Indexer-Key-01-CultPodcasts"
+        };
+
+        await sut.RecordCallAsync(application, ApplicationUsage.Indexer);
+        await sut.RecordQuotaHitAsync(application, ApplicationUsage.Indexer, YouTubeQuotaOperation.ChannelsList);
+
+        var spareApplication = new Application
+        {
+            ApiKey = "key2",
+            Name = application.Name,
+            Usage = application.Usage,
+            DisplayName = "Indexer-Key-02-CultPodcasts"
+        };
+        await sut.RecordCallAsync(spareApplication, ApplicationUsage.Indexer);
+
+        var report = await sut.CreateReportAsync(SampleReportDate, "Indexer");
+
+        report.Keys.Should().HaveCount(2);
+        var exhaustedKey = report.Keys.Single(x => x.DisplayName == "Indexer-Key-01-CultPodcasts");
+        exhaustedKey.CapacityHint.Should().Be("quota-exhausted");
+        exhaustedKey.DailyLimit.Should().Be(YouTubeQuotaCosts.DailyLimitPerKey);
+        exhaustedKey.EstimatedQuotaUsed.Should().Be(YouTubeQuotaCosts.DailyLimitPerKey);
+        exhaustedKey.QuotaConsumedByOperation.ChannelsList.Should().Be(YouTubeQuotaCosts.ChannelsList);
+
+        var spareKey = report.Keys.Single(x => x.DisplayName == "Indexer-Key-02-CultPodcasts");
+        spareKey.CapacityHint.Should().Be("spare-capacity-candidate");
+        spareKey.DailyLimit.Should().Be(YouTubeQuotaCosts.DailyLimitPerKey);
+        spareKey.EstimatedQuotaUsed.Should().Be(0);
+        report.Id.Should().Be(YouTubeQuotaDailyReport.CreateId(SampleReportDate, "Indexer"));
+    }
+
+    [Fact]
+    public async Task CreateReport_ComputesEstimatedQuotaUsedFromConsumedUnits()
+    {
+        var sut = CreateTracker(
+            App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"),
+            App("key2", "CultPodcasts", "Indexer-Key-02-CultPodcasts"));
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Indexer-Key-01-CultPodcasts"
+        };
+
+        await sut.RecordQuotaConsumedAsync(
+            application,
+            ApplicationUsage.Indexer,
+            YouTubeQuotaOperation.SearchList,
+            2_500);
+
+        var report = await sut.CreateReportAsync(SampleReportDate, "Indexer");
+
+        report.Keys.Single().QuotaUsed.Should().Be(2_500);
+        report.Keys.Single().EstimatedQuotaUsed.Should().Be(2_500);
+        report.Keys.Single().QuotaConsumedByOperation.SearchList.Should().Be(2_500);
+        report.UsedIndexerKeys.Single().QuotaUsed.Should().Be(2_500);
+        report.UsedIndexerKeys.Single().EstimatedQuotaUsed.Should().Be(2_500);
+        report.UnusedIndexerKeys.Single().QuotaUsed.Should().Be(0);
+        report.UnusedIndexerKeys.Single().EstimatedQuotaUsed.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateReport_InfersFullDailyLimitWhenQuotaHitRecorded()
+    {
+        var sut = CreateTracker(App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Indexer-Key-01-CultPodcasts"
+        };
+
+        await sut.RecordQuotaConsumedAsync(
+            application,
+            ApplicationUsage.Indexer,
+            YouTubeQuotaOperation.PlaylistItemsList,
+            12_000);
+        await sut.RecordQuotaHitAsync(application, ApplicationUsage.Indexer, YouTubeQuotaOperation.PlaylistItemsList);
+
+        var report = await sut.CreateReportAsync(SampleReportDate, "Indexer");
+
+        report.Keys.Single().QuotaUsed.Should().Be(12_001);
+        report.Keys.Single().EstimatedQuotaUsed.Should().Be(12_001);
+    }
+
+    [Fact]
+    public async Task CreateReport_SeparatesUsedAndUnusedConfiguredIndexerKeys()
+    {
+        var sut = CreateTracker(
+            App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"),
+            App("key2", "CultPodcasts", "Indexer-Key-02-CultPodcasts"),
+            App("key3", "CultPodcasts", "Indexer-Key-03-CultPodcasts"),
+            App("key4", "CultPodcasts", "Indexer-Key-04-CultPodcasts"),
+            App("key8", "CultPodcasts", "Indexer-Key-05-CultPodcasts"),
+            App("key12", "CultPodcasts", "ApiKey-12 - Api", usage: ApplicationUsage.Api));
+
+        await sut.RecordCallAsync(
+            new Application
+            {
+                ApiKey = "key1",
+                Name = "CultPodcasts",
+                Usage = ApplicationUsage.Indexer,
+                DisplayName = "Indexer-Key-01-CultPodcasts"
+            },
+            ApplicationUsage.Indexer);
+        await sut.RecordQuotaHitAsync(
+            new Application
+            {
+                ApiKey = "key8",
+                Name = "CultPodcasts",
+                Usage = ApplicationUsage.Indexer,
+                DisplayName = "Indexer-Key-05-CultPodcasts"
+            },
+            ApplicationUsage.Indexer,
+            YouTubeQuotaOperation.SearchList);
+
+        var report = await sut.CreateReportAsync(SampleReportDate, "Indexer");
+
+        report.Keys.Should().OnlyContain(x => x.Usage == nameof(ApplicationUsage.Indexer));
+        report.UsedIndexerKeys.Select(x => x.DisplayName).Should().Equal(
+            "Indexer-Key-01-CultPodcasts",
+            "Indexer-Key-05-CultPodcasts");
+        report.UnusedIndexerKeys.Select(x => x.DisplayName).Should().Equal(
+            "Indexer-Key-02-CultPodcasts",
+            "Indexer-Key-03-CultPodcasts",
+            "Indexer-Key-04-CultPodcasts");
+        report.UsedIndexerKeys.Should().AllSatisfy(x =>
+        {
+            x.Project.Should().Be("CultPodcasts");
+            x.ApiKeySuffix.Should().HaveLength(2);
+            (x.CallsAttempted > 0 || x.QuotaHits > 0).Should().BeTrue();
+        });
+        report.UnusedIndexerKeys.Should().AllSatisfy(x =>
+        {
+            x.CallsAttempted.Should().Be(0);
+            x.QuotaHits.Should().Be(0);
+            x.QuotaUsed.Should().Be(0);
+            x.EstimatedQuotaUsed.Should().Be(0);
+            x.DailyLimit.Should().Be(YouTubeQuotaCosts.DailyLimitPerKey);
+        });
+    }
+
+    [Fact]
+    public async Task CreateReport_IncludesOperationBreakdownRingExhaustionAndNonQuotaErrors()
+    {
+        var sut = CreateTracker(App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Indexer-Key-01-CultPodcasts"
+        };
+
+        await sut.RecordQuotaConsumedAsync(
+            application,
+            ApplicationUsage.Indexer,
+            YouTubeQuotaOperation.VideosList,
+            YouTubeQuotaCosts.VideosList);
+        await sut.RecordQuotaHitAsync(application, ApplicationUsage.Indexer, YouTubeQuotaOperation.SearchList);
+        await sut.RecordRingExhaustionAsync();
+        await sut.RecordNonQuotaErrorAsync();
+
+        var report = await sut.CreateReportAsync(SampleReportDate, "Indexer");
+
+        report.Keys.Single().QuotaConsumedByOperation.VideosList.Should().Be(YouTubeQuotaCosts.VideosList);
+        report.Keys.Single().QuotaConsumedByOperation.SearchList.Should().Be(YouTubeQuotaCosts.SearchList);
+        report.RingExhaustionCount.Should().Be(1);
+        report.NonQuotaErrorCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateReport_ListsAllConfiguredIndexerKeysEvenWhenNoneWereUsed()
+    {
+        var sut = CreateTracker(
+            App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"),
+            App("key2", "CultPodcasts", "Indexer-Key-02-CultPodcasts"),
+            App("key7", "CultPodcasts", "ApiKey-7 - Bluesky", usage: ApplicationUsage.Bluesky));
+
+        var report = await sut.CreateReportAsync(SampleReportDate, "Indexer");
+
+        report.UsedIndexerKeys.Should().BeEmpty();
+        report.UnusedIndexerKeys.Select(x => x.DisplayName).Should().Equal(
+            "Indexer-Key-01-CultPodcasts",
+            "Indexer-Key-02-CultPodcasts");
+        report.UnusedIndexerKeys.Should().AllSatisfy(x =>
+        {
+            x.EstimatedQuotaUsed.Should().Be(0);
+            x.QuotaUsed.Should().Be(0);
+        });
+        report.Keys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ResolveEstimatedQuotaUsed_ReturnsDailyLimitWhenQuotaHitRecorded()
+    {
+        YouTubeQuotaUsageTracker.ResolveEstimatedQuotaUsed(500, quotaHits: 1).Should().Be(YouTubeQuotaCosts.DailyLimitPerKey);
+    }
+
+    [Fact]
+    public void ResolveEstimatedQuotaUsed_ReturnsQuotaUsedWhenNoHits()
+    {
+        YouTubeQuotaUsageTracker.ResolveEstimatedQuotaUsed(500, quotaHits: 0).Should().Be(500);
+    }
+
+    [Fact]
+    public async Task RecordCallAsync_DoesNotPersistUntilFlush()
+    {
+        YouTubeQuotaUsageState? savedState = null;
+        var lookupRepository = new Mock<ILookupRepository>();
+        lookupRepository.Setup(x => x.GetYouTubeQuotaUsageState()).ReturnsAsync((YouTubeQuotaUsageState?)null);
+        lookupRepository
+            .Setup(x => x.SaveYouTubeQuotaUsageState(It.IsAny<YouTubeQuotaUsageState>()))
+            .Callback<YouTubeQuotaUsageState>(state => savedState = state)
+            .Returns(Task.CompletedTask);
+
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Indexer-Key-01-CultPodcasts"
+        };
+        var sut = CreateTracker(lookupRepository.Object, App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+
+        await sut.RecordCallAsync(application, ApplicationUsage.Indexer);
+
+        savedState.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FlushToCosmosAsync_PersistsUsageStateAfterRecord()
+    {
+        YouTubeQuotaUsageState? savedState = null;
+        var lookupRepository = new Mock<ILookupRepository>();
+        lookupRepository.Setup(x => x.GetYouTubeQuotaUsageState()).ReturnsAsync((YouTubeQuotaUsageState?)null);
+        lookupRepository
+            .Setup(x => x.SaveYouTubeQuotaUsageState(It.IsAny<YouTubeQuotaUsageState>()))
+            .Callback<YouTubeQuotaUsageState>(state => savedState = state)
+            .Returns(Task.CompletedTask);
+
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Indexer-Key-01-CultPodcasts"
+        };
+        var sut = CreateTracker(lookupRepository.Object, App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+
+        await sut.RecordCallAsync(application, ApplicationUsage.Indexer);
+        await sut.FlushToCosmosAsync();
+
+        savedState.Should().NotBeNull();
+        savedState!.Entries.Should().ContainSingle();
+        savedState.Entries.Single().CallsAttempted.Should().Be(1);
+        savedState.Entries.Single().StatsKey.Should().Be("Indexer:key1");
+    }
+
+    [Fact]
+    public async Task FlushToCosmosAsync_MergesSessionUsageWithExistingCosmosState()
+    {
+        var pacificQuotaDate = YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow);
+        YouTubeQuotaUsageState? savedState = null;
+        var lookupRepository = new Mock<ILookupRepository>();
+        lookupRepository.Setup(x => x.GetYouTubeQuotaUsageState()).ReturnsAsync(new YouTubeQuotaUsageState
+        {
+            PacificQuotaDate = pacificQuotaDate,
+            SourceApplication = "Indexer",
+            UpdatedUtc = DateTime.UtcNow,
+            Entries =
+            [
+                new YouTubeQuotaUsageEntry
+                {
+                    StatsKey = "Indexer:key1",
+                    DisplayName = "Indexer-Key-01-CultPodcasts",
+                    Project = "CultPodcasts",
+                    Usage = nameof(ApplicationUsage.Indexer),
+                    CallsAttempted = 3,
+                    QuotaHits = 0,
+                    QuotaUsed = 0
+                }
+            ]
+        });
+        lookupRepository
+            .Setup(x => x.SaveYouTubeQuotaUsageState(It.IsAny<YouTubeQuotaUsageState>()))
+            .Callback<YouTubeQuotaUsageState>(state => savedState = state)
+            .Returns(Task.CompletedTask);
+
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Indexer-Key-01-CultPodcasts"
+        };
+        var sut = CreateTracker(lookupRepository.Object, App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+
+        await sut.RecordCallAsync(application, ApplicationUsage.Indexer);
+        await sut.RecordCallAsync(application, ApplicationUsage.Indexer);
+        await sut.FlushToCosmosAsync();
+
+        savedState.Should().NotBeNull();
+        savedState!.Entries.Should().ContainSingle();
+        savedState.Entries.Single().CallsAttempted.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CreateReportAsync_HydratesPersistedUsageStateOnColdStart()
+    {
+        var pacificQuotaDate = YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow);
+        var lookupRepository = new Mock<ILookupRepository>();
+        lookupRepository.Setup(x => x.GetYouTubeQuotaUsageState()).ReturnsAsync(new YouTubeQuotaUsageState
+        {
+            PacificQuotaDate = pacificQuotaDate,
+            SourceApplication = "Indexer",
+            UpdatedUtc = DateTime.UtcNow,
+            Entries =
+            [
+                new YouTubeQuotaUsageEntry
+                {
+                    StatsKey = "Indexer:key1",
+                    DisplayName = "Indexer-Key-01-CultPodcasts",
+                    Project = "CultPodcasts",
+                    Usage = nameof(ApplicationUsage.Indexer),
+                    CallsAttempted = 3,
+                    QuotaHits = 1,
+                    QuotaUsed = 12
+                }
+            ]
+        });
+        lookupRepository
+            .Setup(x => x.SaveYouTubeQuotaUsageState(It.IsAny<YouTubeQuotaUsageState>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateTracker(
+            lookupRepository.Object,
+            App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"),
+            App("key2", "CultPodcasts", "Indexer-Key-02-CultPodcasts"));
+
+        var report = await sut.CreateReportAsync(pacificQuotaDate, "Indexer");
+
+        report.Keys.Should().ContainSingle();
+        report.Keys.Single().QuotaHits.Should().Be(1);
+        report.UsedIndexerKeys.Should().ContainSingle(x => x.DisplayName == "Indexer-Key-01-CultPodcasts");
+        report.UnusedIndexerKeys.Should().ContainSingle(x => x.DisplayName == "Indexer-Key-02-CultPodcasts");
+    }
+
+    [Fact]
+    public async Task CreateReportAsync_ReflectsInMemoryUsageBeforeFlush()
+    {
+        var sut = CreateTracker(App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+        var application = new Application
+        {
+            ApiKey = "key1",
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = "Indexer-Key-01-CultPodcasts"
+        };
+
+        await sut.RecordCallAsync(application, ApplicationUsage.Indexer);
+        await sut.RecordQuotaConsumedAsync(
+            application,
+            ApplicationUsage.Indexer,
+            YouTubeQuotaOperation.ChannelsList,
+            100);
+
+        var report = await sut.CreateReportAsync(SampleReportDate, "Indexer");
+
+        report.Keys.Single().CallsAttempted.Should().Be(1);
+        report.Keys.Single().QuotaUsed.Should().Be(100);
+        report.Keys.Single().QuotaConsumedByOperation.ChannelsList.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task CreateReport_IncludesPodcastQuotaSkipCounts()
+    {
+        var sut = CreateTracker(App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+
+        await sut.RecordPodcastNotIndexedDueToQuotaAsync();
+        await sut.RecordPodcastNotIndexedDueToQuotaAsync();
+        await sut.RecordPodcastNotEnrichedDueToQuotaAsync();
+
+        var report = await sut.CreateReportAsync(SampleReportDate, "Indexer");
+
+        report.PodcastsNotIndexedDueToQuota.Should().Be(2);
+        report.PodcastsNotEnrichedDueToQuota.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task FlushToCosmosAsync_PersistsPodcastQuotaSkipCounts()
+    {
+        YouTubeQuotaUsageState? savedState = null;
+        var lookupRepository = new Mock<ILookupRepository>();
+        lookupRepository.Setup(x => x.GetYouTubeQuotaUsageState()).ReturnsAsync((YouTubeQuotaUsageState?)null);
+        lookupRepository
+            .Setup(x => x.SaveYouTubeQuotaUsageState(It.IsAny<YouTubeQuotaUsageState>()))
+            .Callback<YouTubeQuotaUsageState>(state => savedState = state)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateTracker(lookupRepository.Object, App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+
+        await sut.RecordPodcastNotIndexedDueToQuotaAsync();
+        await sut.RecordPodcastNotEnrichedDueToQuotaAsync();
+        await sut.FlushToCosmosAsync();
+
+        savedState.Should().NotBeNull();
+        savedState!.PodcastsNotIndexedDueToQuota.Should().Be(1);
+        savedState.PodcastsNotEnrichedDueToQuota.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateReportAsync_HydratesPodcastQuotaSkipCountsOnColdStart()
+    {
+        var pacificQuotaDate = YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow);
+        var lookupRepository = new Mock<ILookupRepository>();
+        lookupRepository.Setup(x => x.GetYouTubeQuotaUsageState()).ReturnsAsync(new YouTubeQuotaUsageState
+        {
+            PacificQuotaDate = pacificQuotaDate,
+            SourceApplication = "Indexer",
+            UpdatedUtc = DateTime.UtcNow,
+            PodcastsNotIndexedDueToQuota = 4,
+            PodcastsNotEnrichedDueToQuota = 7,
+            Entries = []
+        });
+        lookupRepository
+            .Setup(x => x.SaveYouTubeQuotaUsageState(It.IsAny<YouTubeQuotaUsageState>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateTracker(
+            lookupRepository.Object,
+            App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+
+        await sut.RecordPodcastNotIndexedDueToQuotaAsync();
+        var report = await sut.CreateReportAsync(pacificQuotaDate, "Indexer");
+
+        report.PodcastsNotIndexedDueToQuota.Should().Be(5);
+        report.PodcastsNotEnrichedDueToQuota.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task ResetAsync_ClearsPodcastQuotaSkipCounts()
+    {
+        YouTubeQuotaUsageState? savedState = null;
+        var lookupRepository = new Mock<ILookupRepository>();
+        lookupRepository.Setup(x => x.GetYouTubeQuotaUsageState()).ReturnsAsync((YouTubeQuotaUsageState?)null);
+        lookupRepository
+            .Setup(x => x.SaveYouTubeQuotaUsageState(It.IsAny<YouTubeQuotaUsageState>()))
+            .Callback<YouTubeQuotaUsageState>(state => savedState = state)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateTracker(lookupRepository.Object, App("key1", "CultPodcasts", "Indexer-Key-01-CultPodcasts"));
+
+        await sut.RecordPodcastNotIndexedDueToQuotaAsync();
+        await sut.ResetAsync();
+
+        savedState.Should().NotBeNull();
+        savedState!.PodcastsNotIndexedDueToQuota.Should().Be(0);
+        savedState.PodcastsNotEnrichedDueToQuota.Should().Be(0);
+
+        var report = await sut.CreateReportAsync(SampleReportDate, "Indexer");
+        report.PodcastsNotIndexedDueToQuota.Should().Be(0);
+        report.PodcastsNotEnrichedDueToQuota.Should().Be(0);
+    }
+
+    private static YouTubeQuotaUsageTracker CreateTracker(params Application[] applications) =>
+        CreateTracker(CreateLookupRepository().Object, applications);
+
+    private static YouTubeQuotaUsageTracker CreateTracker(
+        ILookupRepository lookupRepository,
+        params Application[] applications) =>
+        new(
+            Options.Create(new YouTubeSettings { Applications = applications }),
+            lookupRepository,
+            NullLogger<YouTubeQuotaUsageTracker>.Instance);
+
+    private static Mock<ILookupRepository> CreateLookupRepository()
+    {
+        var lookupRepository = new Mock<ILookupRepository>();
+        lookupRepository.Setup(x => x.GetYouTubeQuotaUsageState()).ReturnsAsync((YouTubeQuotaUsageState?)null);
+        lookupRepository
+            .Setup(x => x.SaveYouTubeQuotaUsageState(It.IsAny<YouTubeQuotaUsageState>()))
+            .Returns(Task.CompletedTask);
+        return lookupRepository;
+    }
+
+    private static Application App(
+        string apiKey,
+        string name,
+        string displayName,
+        int? reattempt = null,
+        ApplicationUsage usage = ApplicationUsage.Indexer) =>
+        new()
+        {
+            ApiKey = apiKey,
+            Name = name,
+            Usage = usage,
+            DisplayName = displayName,
+            Reattempt = reattempt
+        };
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeServiceWrapperTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeServiceWrapperTests.cs
@@ -1,0 +1,129 @@
+using FluentAssertions;
+using Google.Apis.Services;
+using Google.Apis.YouTube.v3;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RedditPodcastPoster.PodcastServices.YouTube.Clients;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
+using RedditPodcastPoster.PodcastServices.YouTube.Strategies;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests;
+
+public class YouTubeServiceWrapperTests
+{
+    [Fact]
+    public void Rotate_WalksFullIndexerRingBeforeExhausting()
+    {
+        var strategy = new Mock<IYouTubeApiKeyStrategy>();
+        var ring = new List<ApplicationWrapper>
+        {
+            Wrap("key1", "Primary-1"),
+            Wrap("key8", "Reattempt-1"),
+            Wrap("key13", "Reattempt-2"),
+            Wrap("key2", "Primary-2")
+        };
+        strategy.Setup(x => x.BuildIndexerKeyRing(0)).Returns(ring);
+        strategy.Setup(x => x.GetApplication(ApplicationUsage.Indexer)).Returns(ring[0]);
+
+        var wrapper = new YouTubeServiceWrapper(
+            CreateService("key1"),
+            ring[0],
+            ApplicationUsage.Indexer,
+            strategy.Object,
+            ring,
+            initialRingIndex: 0,
+            indexerKeyStateService: null,
+            NullLogger<YouTubeServiceWrapper>.Instance);
+
+        wrapper.CurrentApplication.ApiKey.Should().Be("key1");
+        wrapper.CanRotate.Should().BeTrue();
+
+        wrapper.Rotate();
+        wrapper.CurrentApplication.ApiKey.Should().Be("key8");
+        wrapper.CanRotate.Should().BeTrue();
+
+        wrapper.Rotate();
+        wrapper.CurrentApplication.ApiKey.Should().Be("key13");
+        wrapper.CanRotate.Should().BeTrue();
+
+        wrapper.Rotate();
+        wrapper.CurrentApplication.ApiKey.Should().Be("key2");
+        wrapper.CanRotate.Should().BeTrue();
+
+        var act = () => wrapper.Rotate();
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_WithInitialRingIndex_StartsAtSavedPosition()
+    {
+        var strategy = new Mock<IYouTubeApiKeyStrategy>();
+        var ring = new List<ApplicationWrapper>
+        {
+            Wrap("key1", "Primary-1"),
+            Wrap("key8", "Reattempt-1"),
+            Wrap("key13", "Reattempt-2")
+        };
+
+        var wrapper = new YouTubeServiceWrapper(
+            CreateService("key13"),
+            ring[2],
+            ApplicationUsage.Indexer,
+            strategy.Object,
+            ring,
+            initialRingIndex: 2,
+            indexerKeyStateService: null,
+            NullLogger<YouTubeServiceWrapper>.Instance);
+
+        wrapper.CurrentApplication.ApiKey.Should().Be("key13");
+        wrapper.IndexerRingIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_PersistsIndexerRingState()
+    {
+        var strategy = new Mock<IYouTubeApiKeyStrategy>();
+        var ring = new List<ApplicationWrapper>
+        {
+            Wrap("key1", "Primary-1"),
+            Wrap("key8", "Reattempt-1")
+        };
+        var stateService = new Mock<IYouTubeIndexerKeyStateService>();
+
+        var wrapper = new YouTubeServiceWrapper(
+            CreateService("key1"),
+            ring[0],
+            ApplicationUsage.Indexer,
+            strategy.Object,
+            ring,
+            initialRingIndex: 0,
+            stateService.Object,
+            NullLogger<YouTubeServiceWrapper>.Instance);
+
+        wrapper.Rotate();
+
+        await wrapper.DisposeAsync();
+
+        stateService.Verify(
+            x => x.PersistSessionEndAsync(1, "key8", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static ApplicationWrapper Wrap(string apiKey, string displayName) =>
+        new(new Application
+        {
+            ApiKey = apiKey,
+            Name = "CultPodcasts",
+            Usage = ApplicationUsage.Indexer,
+            DisplayName = displayName
+        }, 0, 2);
+
+    private static YouTubeService CreateService(string apiKey) =>
+        new(new BaseClientService.Initializer
+        {
+            ApiKey = apiKey,
+            ApplicationName = "CultPodcasts"
+        });
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Channel/ITolerantYouTubeChannelService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Channel/ITolerantYouTubeChannelService.cs
@@ -1,0 +1,15 @@
+using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Channel;
+
+public interface ITolerantYouTubeChannelService
+{
+    Task<Google.Apis.YouTube.v3.Data.Channel?> GetChannel(
+        YouTubeChannelId channelId,
+        IndexingContext indexingContext,
+        bool withSnippets = false,
+        bool withContentOwnerDetails = false,
+        bool withStatistics = false,
+        bool withContentDetails = false);
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Channel/TolerantYouTubeChannelService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Channel/TolerantYouTubeChannelService.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Clients;
+using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Channel;
+
+public class TolerantYouTubeChannelService(
+    IYouTubeServiceWrapper youTubeService,
+    IYouTubeChannelService youTubeChannelService,
+    IYouTubeQuotaUsageTracker quotaUsageTracker,
+    ILogger<TolerantYouTubeChannelService> logger) : ITolerantYouTubeChannelService
+{
+    public async Task<Google.Apis.YouTube.v3.Data.Channel?> GetChannel(
+        YouTubeChannelId channelId,
+        IndexingContext indexingContext,
+        bool withSnippets = false,
+        bool withContentOwnerDetails = false,
+        bool withStatistics = false,
+        bool withContentDetails = false)
+    {
+        Google.Apis.YouTube.v3.Data.Channel? result = null;
+        var success = false;
+        var rotationExcepted = false;
+        while (youTubeService.CanRotate && !success && !rotationExcepted)
+        {
+            try
+            {
+                await quotaUsageTracker.RecordCallAsync(youTubeService.CurrentApplication, youTubeService.Usage);
+                result = await youTubeChannelService.GetChannel(
+                    channelId,
+                    indexingContext,
+                    withSnippets,
+                    withContentOwnerDetails,
+                    withStatistics,
+                    withContentDetails);
+                success = true;
+            }
+            catch (YouTubeQuotaException)
+            {
+                logger.LogInformation("Quota exceeded observed. Rotating api-key.");
+                await quotaUsageTracker.RecordQuotaHitAsync(
+                    youTubeService.CurrentApplication,
+                    youTubeService.Usage,
+                    YouTubeQuotaOperation.ChannelsList);
+                try
+                {
+                    youTubeService.Rotate();
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e, "Error rotating youtube-api.");
+                    await quotaUsageTracker.RecordRingExhaustionAsync();
+                    rotationExcepted = true;
+                }
+            }
+        }
+
+        if (!success)
+        {
+            indexingContext.MarkYouTubeQuotaExhausted();
+            logger.LogError("Unable to obtain channel for channel-id '{channelId}'.", channelId.ChannelId);
+        }
+
+        return result;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Channel/YouTubeChannelService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Channel/YouTubeChannelService.cs
@@ -1,14 +1,19 @@
 using System.Collections.Concurrent;
+using System.Net;
+using Google;
 using Google.Apis.YouTube.v3.Data;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
+using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Channel;
 
 public class YouTubeChannelService(
     IYouTubeServiceWrapper youTubeService,
+    IYouTubeQuotaUsageTracker quotaUsageTracker,
     ILogger<YouTubeChannelService> logger)
     : IYouTubeChannelService
 {
@@ -72,13 +77,38 @@ public class YouTubeChannelService(
         try
         {
             result = await listRequest.ExecuteAsync();
+            await quotaUsageTracker.RecordQuotaConsumedAsync(
+                youTubeService.CurrentApplication,
+                youTubeService.Usage,
+                YouTubeQuotaOperation.ChannelsList,
+                YouTubeQuotaCosts.ChannelsList);
+        }
+        catch (GoogleApiException ex)
+        {
+            if (ex.HttpStatusCode == HttpStatusCode.Forbidden && ex.Message.Contains("exceeded") &&
+                ex.Message.Contains("quota"))
+            {
+                logger.LogWarning(ex, "Exceeded Quota occurred.");
+                await quotaUsageTracker.RecordQuotaHitAsync(
+                    youTubeService.CurrentApplication,
+                    youTubeService.Usage,
+                    YouTubeQuotaOperation.ChannelsList);
+                throw new YouTubeQuotaException();
+            }
+
+            logger.LogError(ex,
+                "Failed to use {YouTubeService} obtaining channel with id '{ChannelId}' and request-scope '{requestScope}'.",
+                nameof(youTubeService.YouTubeService), channelId.ChannelId, requestScope);
+            await quotaUsageTracker.RecordNonQuotaErrorAsync();
+            indexingContext.SkipYouTubeUrlResolving = true;
+            return null;
         }
         catch (Exception ex)
         {
             logger.LogError(ex,
                 "Failed to use {YouTubeService} obtaining channel with id '{ChannelId}' and request-scope '{requestScope}'.",
                 nameof(youTubeService.YouTubeService), channelId.ChannelId, requestScope);
-            indexingContext.SkipYouTubeUrlResolving = true;
+            await quotaUsageTracker.RecordNonQuotaErrorAsync();
             return null;
         }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelSnippets/TolerantYouTubeChannelVideoSnippetsService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelSnippets/TolerantYouTubeChannelVideoSnippetsService.cs
@@ -4,12 +4,14 @@ using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.ChannelSnippets;
 
 public class TolerantYouTubeChannelVideoSnippetsService(
     IYouTubeServiceWrapper youTubeService,
     IYouTubeChannelVideoSnippetsService youTubeChannelVideoSnippets,
+    IYouTubeQuotaUsageTracker quotaUsageTracker,
     ILogger<TolerantYouTubeChannelVideoSnippetsService> logger) : ITolerantYouTubeChannelVideoSnippetsService
 {
     public async Task<IList<SearchResult>?> GetLatestChannelVideoSnippets(YouTubeChannelId channelId,
@@ -22,6 +24,7 @@ public class TolerantYouTubeChannelVideoSnippetsService(
         {
             try
             {
+                await quotaUsageTracker.RecordCallAsync(youTubeService.CurrentApplication, youTubeService.Usage);
                 result = await youTubeChannelVideoSnippets.GetLatestChannelVideoSnippets(youTubeService, channelId,
                     indexingContext);
                 success = true;
@@ -33,6 +36,10 @@ public class TolerantYouTubeChannelVideoSnippetsService(
             catch (YouTubeQuotaException)
             {
                 logger.LogInformation("Quota exceeded observed. Rotating api-key.");
+                await quotaUsageTracker.RecordQuotaHitAsync(
+                    youTubeService.CurrentApplication,
+                    youTubeService.Usage,
+                    YouTubeQuotaOperation.SearchList);
                 try
                 {
                     youTubeService.Rotate();
@@ -40,6 +47,7 @@ public class TolerantYouTubeChannelVideoSnippetsService(
                 catch (Exception e)
                 {
                     logger.LogError(e, "Error rotating youtube-api.");
+                    await quotaUsageTracker.RecordRingExhaustionAsync();
                     rotationExcepted = true;
                 }
             }
@@ -47,7 +55,7 @@ public class TolerantYouTubeChannelVideoSnippetsService(
 
         if (!success)
         {
-            indexingContext.SkipYouTubeUrlResolving = true;
+            indexingContext.MarkYouTubeQuotaExhausted();
             logger.LogError("Unable to obtain latest-channel-video-snippets for channel-id '{channelId}'.",
                 channelId.ChannelId);
         }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelSnippets/YouTubeChannelVideoSnippetsService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelSnippets/YouTubeChannelVideoSnippetsService.cs
@@ -7,10 +7,12 @@ using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.ChannelSnippets;
 
 public class YouTubeChannelVideoSnippetsService(
+    IYouTubeQuotaUsageTracker quotaUsageTracker,
     ILogger<YouTubeChannelVideoSnippetsService> logger)
     : IYouTubeChannelVideoSnippetsService
 {
@@ -43,6 +45,11 @@ public class YouTubeChannelVideoSnippetsService(
             try
             {
                 response = await searchListRequest.ExecuteAsync();
+                await quotaUsageTracker.RecordQuotaConsumedAsync(
+                    youTubeServiceWrapper.CurrentApplication,
+                    youTubeServiceWrapper.Usage,
+                    YouTubeQuotaOperation.SearchList,
+                    YouTubeQuotaCosts.SearchList);
             }
             catch (GoogleApiException ex)
             {
@@ -50,6 +57,10 @@ public class YouTubeChannelVideoSnippetsService(
                     ex.Message.Contains("quota"))
                 {
                     logger.LogWarning(ex, "Exceeded Quota occurred.");
+                    await quotaUsageTracker.RecordQuotaHitAsync(
+                        youTubeServiceWrapper.CurrentApplication,
+                        youTubeServiceWrapper.Usage,
+                        YouTubeQuotaOperation.SearchList);
                     throw new YouTubeQuotaException();
                 }
 
@@ -61,6 +72,7 @@ public class YouTubeChannelVideoSnippetsService(
                 logger.LogError(ex,
                     "Unrecognised google-api-exception. Failed to use {nameofYouTubeServiceWrapperYouTubeService} to obtain latest-channel-snippets for channel-id '{channelId}'.",
                     nameof(youTubeServiceWrapper.YouTubeService), channelId.ChannelId);
+                await quotaUsageTracker.RecordNonQuotaErrorAsync();
                 indexingContext.SkipYouTubeUrlResolving = true;
                 return result;
             }
@@ -69,6 +81,7 @@ public class YouTubeChannelVideoSnippetsService(
                 logger.LogError(ex,
                     "Failed to use {nameofYouTubeServiceWrapperYouTubeService)} to obtain latest-channel-snippets for channel-id '{channelId}'.",
                     nameof(youTubeServiceWrapper.YouTubeService), channelId.ChannelId);
+                await quotaUsageTracker.RecordNonQuotaErrorAsync();
                 indexingContext.SkipYouTubeUrlResolving = true;
                 return result;
             }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelVideos/YouTubeChannelVideosService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/ChannelVideos/YouTubeChannelVideosService.cs
@@ -10,7 +10,7 @@ using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 namespace RedditPodcastPoster.PodcastServices.YouTube.ChannelVideos;
 
 public class YouTubeChannelVideosService(
-    IYouTubeChannelService youTubeChannelService,
+    ITolerantYouTubeChannelService youTubeChannelService,
     ITolerantYouTubePlaylistService youTubePlaylistService,
     ILogger<YouTubeChannelVideosService> logger
 ) : IYouTubeChannelVideosService

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Clients/IYouTubeServiceWrapper.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Clients/IYouTubeServiceWrapper.cs
@@ -1,10 +1,13 @@
 ﻿using Google.Apis.YouTube.v3;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Clients;
 
 public interface IYouTubeServiceWrapper
 {
     YouTubeService YouTubeService { get; }
+    ApplicationUsage Usage { get; }
+    Application CurrentApplication { get; }
     bool CanRotate { get; }
     void Rotate();
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Clients/YouTubeServiceWrapper.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Clients/YouTubeServiceWrapper.cs
@@ -1,7 +1,9 @@
 ﻿using Google.Apis.Services;
 using Google.Apis.YouTube.v3;
 using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 using RedditPodcastPoster.PodcastServices.YouTube.Strategies;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Clients;
@@ -9,17 +11,41 @@ namespace RedditPodcastPoster.PodcastServices.YouTube.Clients;
 public class YouTubeServiceWrapper(
     YouTubeService youTubeService,
     ApplicationWrapper applicationWrapper,
+    ApplicationUsage usage,
     IYouTubeApiKeyStrategy youTubeApiKeyStrategy,
+    IReadOnlyList<ApplicationWrapper>? indexerKeyRing,
+    int initialRingIndex,
+    IYouTubeIndexerKeyStateService? indexerKeyStateService,
     ILogger<YouTubeServiceWrapper> logger
-) : IYouTubeServiceWrapper
+) : IYouTubeServiceWrapper, IAsyncDisposable
 {
     private ApplicationWrapper _applicationWrapper = applicationWrapper;
     private int _reattempt;
+    private int _ringIndex = initialRingIndex;
+    private bool _sessionPersisted;
+    private readonly IReadOnlyList<ApplicationWrapper> _indexerKeyRing =
+        usage == ApplicationUsage.Indexer
+            ? indexerKeyRing ?? youTubeApiKeyStrategy.BuildIndexerKeyRing(0)
+            : [];
+
     public YouTubeService YouTubeService { get; private set; } = youTubeService;
-    public bool CanRotate => _reattempt <= _applicationWrapper.Reattempts;
+    public ApplicationUsage Usage { get; } = usage;
+    public Application CurrentApplication => _applicationWrapper.Application;
+    internal int IndexerRingIndex => _ringIndex;
+
+    public bool CanRotate =>
+        Usage == ApplicationUsage.Indexer
+            ? _ringIndex < _indexerKeyRing.Count
+            : _reattempt <= _applicationWrapper.Reattempts;
 
     public void Rotate()
     {
+        if (Usage == ApplicationUsage.Indexer)
+        {
+            RotateIndexerKey();
+            return;
+        }
+
         logger.LogInformation("Rotate api-key from {apiKey}. usage: '{usage}', index: {index}, reattempt: {reattempt}",
             _applicationWrapper.Application.DisplayName,
             _applicationWrapper.Application.Usage,
@@ -29,6 +55,27 @@ public class YouTubeServiceWrapper(
             _applicationWrapper.Application.Usage,
             _applicationWrapper.Index,
             ++_reattempt);
+        ApplyApplication(application);
+    }
+
+    private void RotateIndexerKey()
+    {
+        if (_ringIndex >= _indexerKeyRing.Count - 1)
+        {
+            throw new InvalidOperationException("Indexer key ring exhausted.");
+        }
+
+        logger.LogInformation(
+            "Rotate indexer api-key from {apiKey} ({ringIndex}/{ringCount}).",
+            _applicationWrapper.Application.DisplayName,
+            _ringIndex + 1,
+            _indexerKeyRing.Count);
+        _ringIndex++;
+        ApplyApplication(_indexerKeyRing[_ringIndex]);
+    }
+
+    private void ApplyApplication(ApplicationWrapper application)
+    {
         logger.LogInformation("Obtained api-key '{apiKey}'.", application.Application.DisplayName);
         YouTubeService =
             new YouTubeService(new BaseClientService.Initializer
@@ -37,5 +84,16 @@ public class YouTubeServiceWrapper(
                 ApplicationName = application.Application.Name
             });
         _applicationWrapper = application;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Usage != ApplicationUsage.Indexer || indexerKeyStateService == null || _sessionPersisted)
+        {
+            return;
+        }
+
+        _sessionPersisted = true;
+        await indexerKeyStateService.PersistSessionEndAsync(_ringIndex, CurrentApplication.ApiKey);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using RedditPodcastPoster.PodcastServices.YouTube.ChannelSnippets;
 using RedditPodcastPoster.PodcastServices.YouTube.ChannelVideos;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 using RedditPodcastPoster.PodcastServices.YouTube.Enrichment;
 using RedditPodcastPoster.PodcastServices.YouTube.Episode;
 using RedditPodcastPoster.PodcastServices.YouTube.Factories;
@@ -22,7 +23,7 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddYouTubeServices(this IServiceCollection services, ApplicationUsage usage)
     {
-        return services
+        var serviceCollection = services
             .AddScoped<IYouTubeEpisodeProvider, YouTubeEpisodeProvider>()
             .AddScoped<IYouTubeEpisodeEnricher, YouTubeEpisodeEnricher>()
             .AddScoped<IYouTubeItemResolver, YouTubeItemResolver>()
@@ -30,6 +31,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IYouTubeVideoService, YouTubeVideoService>()
             .AddScoped<IYouTubeChannelVideoSnippetsService, YouTubeChannelVideoSnippetsService>()
             .AddScoped<IYouTubeChannelService, YouTubeChannelService>()
+            .AddScoped<ITolerantYouTubeChannelService, TolerantYouTubeChannelService>()
             .AddScoped<ISearchResultFinder, SearchResultFinder>()
             .AddScoped<IYouTubeChannelResolver, YouTubeChannelResolver>()
             .AddScoped<IYouTubeSearcher, YouTubeSearcher>()
@@ -38,6 +40,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IYouTubeChannelVideosService, YouTubeChannelVideosService>()
             .AddScoped<IYouTubeServiceFactory, YouTubeServiceFactory>()
             .AddScoped<IYouTubeApiKeyStrategy, YouTubeApiKeyStrategy>()
+            .AddSingleton<IYouTubeQuotaUsageTracker, YouTubeQuotaUsageTracker>()
             .AddDateTimeService()
             .AddScoped(s => s.GetService<IYouTubeServiceFactory>()!.Create(usage))
             .AddScoped<ITolerantYouTubeChannelVideoSnippetsService, TolerantYouTubeChannelVideoSnippetsService>()
@@ -48,5 +51,15 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IYouTubeChannelVideoRetrievalPolicy, YouTubeChannelVideoRetrievalPolicy>()
             .BindConfiguration<YouTubeSettings>("youtube")
             .BindConfiguration<YouTubeChannelOptions>("youtubeChannel");
+
+        if (usage == ApplicationUsage.Indexer)
+        {
+            serviceCollection
+                .AddScoped<YouTubeIndexerKeyRingSessionHolder>()
+                .AddScoped<IYouTubeIndexerKeyStateService, YouTubeIndexerKeyStateService>()
+                .AddScoped<YouTubeIndexerKeySessionBootstrapper>();
+        }
+
+        return serviceCollection;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Factories/YouTubeServiceFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Factories/YouTubeServiceFactory.cs
@@ -1,14 +1,18 @@
 ﻿using Google.Apis.Services;
 using Google.Apis.YouTube.v3;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 using RedditPodcastPoster.PodcastServices.YouTube.Strategies;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Factories;
 
 public class YouTubeServiceFactory(
     IYouTubeApiKeyStrategy youTubeApiKeyStrategy,
+    IServiceProvider serviceProvider,
     ILogger<YouTubeServiceFactory> logger,
     ILogger<YouTubeServiceWrapper> injectedLogger
 ) : IYouTubeServiceFactory
@@ -16,8 +20,32 @@ public class YouTubeServiceFactory(
     public IYouTubeServiceWrapper Create(ApplicationUsage usage)
     {
         logger.LogInformation("Create youtube-service for usage '{usage}'.", usage);
-        var application = youTubeApiKeyStrategy.GetApplication(usage);
-        logger.LogInformation("Obtained api-key: '{apiKey}'", application.Application.DisplayName);
+
+        IndexerKeyRingSessionStart? session = null;
+        IYouTubeIndexerKeyStateService? indexerKeyStateService = null;
+        if (usage == ApplicationUsage.Indexer)
+        {
+            var sessionBootstrapper = serviceProvider.GetService<YouTubeIndexerKeySessionBootstrapper>();
+            sessionBootstrapper?.EnsureLoadedAsync().GetAwaiter().GetResult();
+            session = serviceProvider.GetService<YouTubeIndexerKeyRingSessionHolder>()?.Value;
+            indexerKeyStateService = serviceProvider.GetService<IYouTubeIndexerKeyStateService>();
+        }
+
+        IReadOnlyList<ApplicationWrapper>? indexerKeyRing = usage == ApplicationUsage.Indexer
+            ? session?.Ring ?? youTubeApiKeyStrategy.BuildIndexerKeyRing(0)
+            : null;
+        var initialRingIndex = session?.InitialRingIndex
+            ?? (usage == ApplicationUsage.Indexer
+                ? youTubeApiKeyStrategy.GetApplication(usage).Index
+                : 0);
+        var application = session?.Ring[initialRingIndex]
+            ?? indexerKeyRing![initialRingIndex];
+
+        logger.LogInformation(
+            "Obtained api-key: '{apiKey}' at ring index {RingIndex}.",
+            application.Application.DisplayName,
+            initialRingIndex);
+
         return new YouTubeServiceWrapper(
             new YouTubeService(new BaseClientService.Initializer
             {
@@ -25,7 +53,11 @@ public class YouTubeServiceFactory(
                 ApplicationName = application.Application.Name
             }),
             application,
+            usage,
             youTubeApiKeyStrategy,
+            indexerKeyRing,
+            initialRingIndex,
+            indexerKeyStateService,
             injectedLogger);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Handlers/YouTubeEpisodeRetrievalHandler.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Handlers/YouTubeEpisodeRetrievalHandler.cs
@@ -15,56 +15,81 @@ public class YouTubeEpisodeRetrievalHandler(
     {
         var handled = false;
         IList<RedditPodcastPoster.Models.Episode> newEpisodes = new List<RedditPodcastPoster.Models.Episode>();
-        if (!string.IsNullOrWhiteSpace(podcast.YouTubeChannelId))
+        if (string.IsNullOrWhiteSpace(podcast.YouTubeChannelId))
         {
-            if (!string.IsNullOrWhiteSpace(podcast.YouTubePlaylistId))
+            LogDiscoveryPath(podcast, "skipped-no-channel", indexingContext, 0);
+            return new EpisodeRetrievalHandlerResponse(newEpisodes, handled);
+        }
+
+        if (!string.IsNullOrWhiteSpace(podcast.YouTubePlaylistId))
+        {
+            var runExpensivePagination = indexingContext.RunExpensiveYouTubePlaylistPagination(podcast);
+            var discoveryPath = runExpensivePagination ? "playlist-paginated" : "playlist-single-page";
+            if (podcast.HasExpensiveYouTubePlaylistQuery() && indexingContext.SkipExpensiveYouTubeQueries)
             {
-                if (podcast.HasExpensiveYouTubePlaylistQuery() && indexingContext.SkipExpensiveYouTubeQueries)
-                {
-                    logger.LogInformation(
-                        "Podcast '{PodcastId}' has known expensive query and will not run this time.", podcast.Id);
-                    {
-                        return new EpisodeRetrievalHandlerResponse(newEpisodes, handled);
-                    }
-                }
+                logger.LogInformation(
+                    "Podcast '{PodcastId}' has known expensive playlist query; using single-page playlist fetch this pass.",
+                    podcast.Id);
+            }
 
-                var getPlaylistEpisodesResult = await youTubeEpisodeProvider.GetPlaylistEpisodes(
-                    new YouTubePlaylistId(podcast.YouTubePlaylistId), new YouTubeChannelId(podcast.YouTubeChannelId),
-                    indexingContext);
-                if (getPlaylistEpisodesResult.Results != null)
-                {
-                    newEpisodes = getPlaylistEpisodesResult.Results;
-                }
+            var getPlaylistEpisodesResult = await youTubeEpisodeProvider.GetPlaylistEpisodes(
+                new YouTubePlaylistId(podcast.YouTubePlaylistId), new YouTubeChannelId(podcast.YouTubeChannelId),
+                indexingContext, runExpensivePagination);
+            if (getPlaylistEpisodesResult.Results != null)
+            {
+                newEpisodes = getPlaylistEpisodesResult.Results;
+            }
 
-                if (getPlaylistEpisodesResult.IsExpensiveQuery)
-                {
-                    podcast.YouTubePlaylistQueryIsExpensive = true;
-                }
+            if (getPlaylistEpisodesResult.IsExpensiveQuery)
+            {
+                podcast.YouTubePlaylistQueryIsExpensive = true;
+            }
+
+            LogDiscoveryPath(podcast, discoveryPath, indexingContext, newEpisodes.Count);
+        }
+        else
+        {
+            IEnumerable<string> knownIds;
+            if (indexingContext.ReleasedSince.HasValue)
+            {
+                knownIds = episodes.Where(x => x.Release >= indexingContext.ReleasedSince)
+                    .Select(x => x.YouTubeId);
             }
             else
             {
-                IEnumerable<string> knownIds;
-                if (indexingContext.ReleasedSince.HasValue)
-                {
-                    knownIds = episodes.Where(x => x.Release >= indexingContext.ReleasedSince)
-                        .Select(x => x.YouTubeId);
-                }
-                else
-                {
-                    knownIds = episodes.Select(x => x.YouTubeId);
-                }
-
-                var foundEpisodes = await youTubeEpisodeProvider.GetEpisodes(
-                    podcast, indexingContext, knownIds);
-                if (foundEpisodes != null)
-                {
-                    newEpisodes = foundEpisodes;
-                }
+                knownIds = episodes.Select(x => x.YouTubeId);
             }
 
-            handled = true;
+            var foundEpisodes = await youTubeEpisodeProvider.GetEpisodes(
+                podcast, indexingContext, knownIds);
+            if (foundEpisodes != null)
+            {
+                newEpisodes = foundEpisodes;
+            }
+
+            LogDiscoveryPath(podcast, "channel", indexingContext, newEpisodes.Count);
         }
 
+        handled = true;
+
         return new EpisodeRetrievalHandlerResponse(newEpisodes, handled);
+    }
+
+    private void LogDiscoveryPath(Podcast podcast, string discoveryPath, IndexingContext indexingContext, int episodesFound)
+    {
+        if (podcast.DependsOnYouTubeForEpisodeDiscovery())
+        {
+            logger.LogWarning(
+                "YouTubeDiscoveryPath podcast-id='{PodcastId}' path='{DiscoveryPath}' youtube-authority='{YouTubeAuthority}' skip-youtube='{SkipYouTube}' skip-expensive-youtube='{SkipExpensiveYouTube}' episodes-found='{EpisodesFound}'",
+                podcast.Id, discoveryPath, true,
+                indexingContext.SkipYouTubeUrlResolving, indexingContext.SkipExpensiveYouTubeQueries, episodesFound);
+        }
+        else
+        {
+            logger.LogInformation(
+                "YouTubeDiscoveryPath podcast-id='{PodcastId}' path='{DiscoveryPath}' youtube-authority='{YouTubeAuthority}' skip-youtube='{SkipYouTube}' skip-expensive-youtube='{SkipExpensiveYouTube}' episodes-found='{EpisodesFound}'",
+                podcast.Id, discoveryPath, false,
+                indexingContext.SkipYouTubeUrlResolving, indexingContext.SkipExpensiveYouTubeQueries, episodesFound);
+        }
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/TolerantYouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/TolerantYouTubePlaylistService.cs
@@ -3,12 +3,14 @@ using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 
 public class TolerantYouTubePlaylistService(
     IYouTubeServiceWrapper youTubeService,
     IYouTubePlaylistService youTubePlaylistService,
+    IYouTubeQuotaUsageTracker quotaUsageTracker,
     ILogger<TolerantYouTubePlaylistService> logger
 ) : ITolerantYouTubePlaylistService
 {
@@ -23,6 +25,7 @@ public class TolerantYouTubePlaylistService(
         {
             try
             {
+                await quotaUsageTracker.RecordCallAsync(youTubeService.CurrentApplication, youTubeService.Usage);
                 result = await youTubePlaylistService.GetPlaylistVideoSnippets(youTubeService, playlistId,
                     indexingContext, withContentDetails, expensivePlaylist);
                 success = true;
@@ -31,6 +34,10 @@ public class TolerantYouTubePlaylistService(
             {
                 logger.LogInformation(
                     "Quota exceeded observed. Rotating api-key .");
+                await quotaUsageTracker.RecordQuotaHitAsync(
+                    youTubeService.CurrentApplication,
+                    youTubeService.Usage,
+                    YouTubeQuotaOperation.PlaylistItemsList);
                 try
                 {
                     youTubeService.Rotate();
@@ -38,6 +45,7 @@ public class TolerantYouTubePlaylistService(
                 catch (Exception e)
                 {
                     logger.LogError(e, "Error rotating api.");
+                    await quotaUsageTracker.RecordRingExhaustionAsync();
                     rotationExcepted = true;
                 }
             }
@@ -45,7 +53,7 @@ public class TolerantYouTubePlaylistService(
 
         if (!success)
         {
-            indexingContext.SkipYouTubeUrlResolving = true;
+            indexingContext.MarkYouTubeQuotaExhausted();
             logger.LogError("Unable to obtain latest-playlist-video-snippets for channel-id '{playlistId}'.",
                 playlistId.PlaylistId);
         }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
@@ -7,10 +7,12 @@ using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 
 public class YouTubePlaylistService(
+    IYouTubeQuotaUsageTracker quotaUsageTracker,
     ILogger<YouTubePlaylistService> logger)
     : IYouTubePlaylistService
 {
@@ -63,6 +65,11 @@ public class YouTubePlaylistService(
             try
             {
                 playlistItemsListResponse = await playlistRequest.ExecuteAsync();
+                await quotaUsageTracker.RecordQuotaConsumedAsync(
+                    youTubeServiceWrapper.CurrentApplication,
+                    youTubeServiceWrapper.Usage,
+                    YouTubeQuotaOperation.PlaylistItemsList,
+                    YouTubeQuotaCosts.PlaylistItemsList);
             }
             catch (GoogleApiException ex)
             {
@@ -70,12 +77,17 @@ public class YouTubePlaylistService(
                     ex.Message.Contains("quota"))
                 {
                     logger.LogWarning(ex, "Exceeded Quota occurred.");
+                    await quotaUsageTracker.RecordQuotaHitAsync(
+                        youTubeServiceWrapper.CurrentApplication,
+                        youTubeServiceWrapper.Usage,
+                        YouTubeQuotaOperation.PlaylistItemsList);
                     throw new YouTubeQuotaException();
                 }
 
                 logger.LogError(ex,
                     "Unrecognised google-api-exception. Failed to use {nameofYouTubeServiceWrapperYouTubeService} to obtain playlist-snippets for playlist-id '{playlistId}'.",
                     nameof(youTubeServiceWrapper.YouTubeService), playlistId);
+                await quotaUsageTracker.RecordNonQuotaErrorAsync();
                 indexingContext.SkipYouTubeUrlResolving = true;
                 return new GetPlaylistVideoSnippetsResponse(null);
             }
@@ -84,6 +96,7 @@ public class YouTubePlaylistService(
                 logger.LogError(ex,
                     "Failed to use {nameofYouTubeServiceWrapperYouTubeService)} obtaining playlist-video-snippets for playlist-id '{playlistId}'.",
                     nameof(youTubeServiceWrapper.YouTubeService), playlistId);
+                await quotaUsageTracker.RecordNonQuotaErrorAsync();
                 indexingContext.SkipYouTubeUrlResolving = true;
                 return new GetPlaylistVideoSnippetsResponse(null);
             }
@@ -146,6 +159,11 @@ public class YouTubePlaylistService(
         playlistRequest.MaxResults = 1;
 
         var playlistResponse = await playlistRequest.ExecuteAsync();
+        await quotaUsageTracker.RecordQuotaConsumedAsync(
+            youTubeServiceWrapper.CurrentApplication,
+            youTubeServiceWrapper.Usage,
+            YouTubeQuotaOperation.PlaylistsList,
+            YouTubeQuotaCosts.PlaylistsList);
 
         if (playlistResponse == null || !playlistResponse.Items.Any())
         {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/IYouTubeQuotaUsageTracker.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/IYouTubeQuotaUsageTracker.cs
@@ -1,0 +1,42 @@
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public interface IYouTubeQuotaUsageTracker
+{
+    Task RecordCallAsync(Application application, ApplicationUsage usage, CancellationToken cancellationToken = default);
+
+    Task RecordQuotaHitAsync(
+        Application application,
+        ApplicationUsage usage,
+        YouTubeQuotaOperation operation,
+        CancellationToken cancellationToken = default);
+
+    Task RecordQuotaConsumedAsync(
+        Application application,
+        ApplicationUsage usage,
+        YouTubeQuotaOperation operation,
+        int quotaUnits,
+        CancellationToken cancellationToken = default);
+
+    Task RecordRingExhaustionAsync(CancellationToken cancellationToken = default);
+
+    Task RecordNonQuotaErrorAsync(CancellationToken cancellationToken = default);
+
+    Task RecordPodcastNotIndexedDueToQuotaAsync(CancellationToken cancellationToken = default);
+
+    Task RecordPodcastNotEnrichedDueToQuotaAsync(CancellationToken cancellationToken = default);
+
+    Task<YouTubeQuotaDailyReport> CreateReportAsync(
+        DateOnly reportDate,
+        string sourceApplication,
+        CancellationToken cancellationToken = default);
+
+    Task EnsureHydratedAsync(CancellationToken cancellationToken = default);
+
+    Task FlushToCosmosAsync(CancellationToken cancellationToken = default);
+
+    Task ResetAsync(CancellationToken cancellationToken = default);
+}
+

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/IndexerKeyRingSessionResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/IndexerKeyRingSessionResolver.cs
@@ -1,0 +1,56 @@
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public interface IYouTubeIndexerKeyStateService
+{
+    Task<IndexerKeyRingSessionStart> ResolveSessionStartAsync(CancellationToken cancellationToken = default);
+
+    Task PersistSessionEndAsync(int ringIndex, string apiKey, CancellationToken cancellationToken = default);
+}
+
+internal static class IndexerKeyRingSessionResolver
+{
+    internal static int ResolveInitialRingIndex(
+        IReadOnlyList<ApplicationWrapper> ring,
+        YouTubeIndexerKeyState? savedState,
+        DateOnly currentPacificQuotaDate,
+        int hourFallbackRingIndex)
+    {
+        if (savedState == null ||
+            savedState.PacificQuotaDate != currentPacificQuotaDate ||
+            string.IsNullOrWhiteSpace(savedState.LastApiKey))
+        {
+            return hourFallbackRingIndex;
+        }
+
+        var indexByKey = FindRingIndexByApiKey(ring, savedState.LastApiKey);
+        if (indexByKey.HasValue)
+        {
+            return indexByKey.Value;
+        }
+
+        if (savedState.LastRingIndex >= 0 &&
+            savedState.LastRingIndex < ring.Count &&
+            string.Equals(ring[savedState.LastRingIndex].Application.ApiKey, savedState.LastApiKey, StringComparison.Ordinal))
+        {
+            return savedState.LastRingIndex;
+        }
+
+        return hourFallbackRingIndex;
+    }
+
+    private static int? FindRingIndexByApiKey(IReadOnlyList<ApplicationWrapper> ring, string apiKey)
+    {
+        for (var index = 0; index < ring.Count; index++)
+        {
+            if (string.Equals(ring[index].Application.ApiKey, apiKey, StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/IndexerKeyRingSessionStart.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/IndexerKeyRingSessionStart.cs
@@ -1,0 +1,8 @@
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public sealed record IndexerKeyRingSessionStart(
+    int HourFallbackRingIndex,
+    int InitialRingIndex,
+    IReadOnlyList<ApplicationWrapper> Ring);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeIndexerKeyRingSessionHolder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeIndexerKeyRingSessionHolder.cs
@@ -1,0 +1,6 @@
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public sealed class YouTubeIndexerKeyRingSessionHolder
+{
+    public IndexerKeyRingSessionStart? Value { get; set; }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeIndexerKeySessionBootstrapper.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeIndexerKeySessionBootstrapper.cs
@@ -1,0 +1,19 @@
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public sealed class YouTubeIndexerKeySessionBootstrapper(
+    YouTubeIndexerKeyRingSessionHolder sessionHolder,
+    IYouTubeIndexerKeyStateService indexerKeyStateService)
+{
+    private Task? _loadTask;
+
+    public Task EnsureLoadedAsync()
+    {
+        _loadTask ??= LoadAsync();
+        return _loadTask;
+    }
+
+    private async Task LoadAsync()
+    {
+        sessionHolder.Value = await indexerKeyStateService.ResolveSessionStartAsync();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeIndexerKeyStateService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeIndexerKeyStateService.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Persistence.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Strategies;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public sealed class YouTubeIndexerKeyStateService(
+    ILookupRepository lookupRepository,
+    IYouTubeApiKeyStrategy youTubeApiKeyStrategy,
+    ILogger<YouTubeIndexerKeyStateService> logger) : IYouTubeIndexerKeyStateService
+{
+    public async Task<IndexerKeyRingSessionStart> ResolveSessionStartAsync(CancellationToken cancellationToken = default)
+    {
+        var hourFallback = youTubeApiKeyStrategy.GetApplication(ApplicationUsage.Indexer);
+        var hourFallbackRingIndex = hourFallback.Index;
+        var ring = youTubeApiKeyStrategy.BuildIndexerKeyRing(0);
+        var currentPacificQuotaDate = YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow);
+
+        var savedState = await lookupRepository.GetYouTubeIndexerKeyState();
+        var initialRingIndex = IndexerKeyRingSessionResolver.ResolveInitialRingIndex(
+            ring,
+            savedState,
+            currentPacificQuotaDate,
+            hourFallbackRingIndex);
+
+        if (savedState == null)
+        {
+            logger.LogInformation(
+                "No saved YouTube indexer key state found. Starting at hour fallback ring index {HourFallbackRingIndex}, ring index {InitialRingIndex}.",
+                hourFallbackRingIndex,
+                initialRingIndex);
+        }
+        else if (savedState.PacificQuotaDate != currentPacificQuotaDate)
+        {
+            logger.LogInformation(
+                "Saved YouTube indexer key state is from quota day {SavedPacificQuotaDate}; current is {CurrentPacificQuotaDate}. Resetting to hour fallback ring index {HourFallbackRingIndex}, ring index {InitialRingIndex}.",
+                savedState.PacificQuotaDate,
+                currentPacificQuotaDate,
+                hourFallbackRingIndex,
+                initialRingIndex);
+        }
+        else if (initialRingIndex == hourFallbackRingIndex &&
+                 !string.IsNullOrWhiteSpace(savedState.LastApiKey))
+        {
+            logger.LogWarning(
+                "Saved YouTube indexer key '{LastApiKeyEnding}' is no longer in the configured ring. Falling back to hour fallback ring index {HourFallbackRingIndex}.",
+                savedState.LastApiKey[^Math.Min(2, savedState.LastApiKey.Length)..],
+                hourFallbackRingIndex);
+        }
+        else
+        {
+            logger.LogInformation(
+                "Resuming YouTube indexer key ring at index {InitialRingIndex} (hour fallback ring index {HourFallbackRingIndex}) for quota day {PacificQuotaDate}.",
+                initialRingIndex,
+                hourFallbackRingIndex,
+                currentPacificQuotaDate);
+        }
+
+        return new IndexerKeyRingSessionStart(hourFallbackRingIndex, initialRingIndex, ring);
+    }
+
+    public async Task PersistSessionEndAsync(int ringIndex, string apiKey, CancellationToken cancellationToken = default)
+    {
+        var state = new YouTubeIndexerKeyState
+        {
+            PacificQuotaDate = YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow),
+            LastRingIndex = ringIndex,
+            LastApiKey = apiKey,
+            UpdatedUtc = DateTime.UtcNow
+        };
+
+        await lookupRepository.SaveYouTubeIndexerKeyState(state);
+
+        logger.LogInformation(
+            "Persisted YouTube indexer key state at ring index {RingIndex} for quota day {PacificQuotaDate}.",
+            ringIndex,
+            state.PacificQuotaDate);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubePacificQuotaDate.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubePacificQuotaDate.cs
@@ -1,0 +1,31 @@
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public static class YouTubePacificQuotaDate
+{
+    private static readonly TimeZoneInfo PacificTimeZone = ResolvePacificTimeZone();
+
+    public static DateOnly GetCurrent(DateTime utcNow)
+    {
+        var pacificNow = TimeZoneInfo.ConvertTimeFromUtc(utcNow, PacificTimeZone);
+        return DateOnly.FromDateTime(pacificNow);
+    }
+
+    private static TimeZoneInfo ResolvePacificTimeZone()
+    {
+        foreach (var timeZoneId in new[] { "America/Los_Angeles", "Pacific Standard Time" })
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+            catch (InvalidTimeZoneException)
+            {
+            }
+        }
+
+        throw new InvalidOperationException("Unable to resolve Pacific time zone.");
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeQuotaCosts.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeQuotaCosts.cs
@@ -1,0 +1,22 @@
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public static class YouTubeQuotaCosts
+{
+    public const int DailyLimitPerKey = 10_000;
+    public const int SearchList = 100;
+    public const int PlaylistItemsList = 1;
+    public const int PlaylistsList = 1;
+    public const int ChannelsList = 1;
+    public const int VideosList = 1;
+
+    public static int GetCost(YouTubeQuotaOperation operation) =>
+        operation switch
+        {
+            YouTubeQuotaOperation.SearchList => SearchList,
+            YouTubeQuotaOperation.ChannelsList => ChannelsList,
+            YouTubeQuotaOperation.PlaylistItemsList => PlaylistItemsList,
+            YouTubeQuotaOperation.PlaylistsList => PlaylistsList,
+            YouTubeQuotaOperation.VideosList => VideosList,
+            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null)
+        };
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeQuotaOperation.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeQuotaOperation.cs
@@ -1,0 +1,10 @@
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public enum YouTubeQuotaOperation
+{
+    SearchList,
+    ChannelsList,
+    PlaylistItemsList,
+    PlaylistsList,
+    VideosList
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeQuotaUsageTracker.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Quota/YouTubeQuotaUsageTracker.cs
@@ -1,0 +1,501 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Persistence.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Strategies;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+public sealed class YouTubeQuotaUsageTracker(
+    IOptions<YouTubeSettings> settings,
+    ILookupRepository lookupRepository,
+    ILogger<YouTubeQuotaUsageTracker> logger) : IYouTubeQuotaUsageTracker
+{
+    private const string SourceApplication = "Indexer";
+
+    private readonly YouTubeSettings _settings =
+        settings.Value ?? throw new ArgumentNullException($"Missing {nameof(YouTubeSettings)}.");
+
+    private readonly ConcurrentDictionary<string, MutableKeyStats> _stats = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _sync = new(1, 1);
+    private bool _hydrated;
+    private DateOnly? _pacificQuotaDate;
+    private int _podcastsNotIndexedDueToQuota;
+    private int _podcastsNotEnrichedDueToQuota;
+    private int _ringExhaustionCount;
+    private int _nonQuotaErrorCount;
+
+    public Task RecordCallAsync(
+        Application application,
+        ApplicationUsage usage,
+        CancellationToken cancellationToken = default) =>
+        MutateAsync(
+            application,
+            usage,
+            stats => stats.CallsAttempted++,
+            cancellationToken);
+
+    public Task RecordQuotaHitAsync(
+        Application application,
+        ApplicationUsage usage,
+        YouTubeQuotaOperation operation,
+        CancellationToken cancellationToken = default)
+    {
+        var quotaUnits = YouTubeQuotaCosts.GetCost(operation);
+        return MutateAsync(
+            application,
+            usage,
+            stats =>
+            {
+                stats.QuotaHits++;
+                stats.QuotaUsed += quotaUnits;
+                AddOperationUsage(stats.QuotaConsumedByOperation, operation, quotaUnits);
+            },
+            cancellationToken);
+    }
+
+    public Task RecordQuotaConsumedAsync(
+        Application application,
+        ApplicationUsage usage,
+        YouTubeQuotaOperation operation,
+        int quotaUnits,
+        CancellationToken cancellationToken = default)
+    {
+        if (quotaUnits <= 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        return MutateAsync(
+            application,
+            usage,
+            stats =>
+            {
+                stats.QuotaUsed += quotaUnits;
+                AddOperationUsage(stats.QuotaConsumedByOperation, operation, quotaUnits);
+            },
+            cancellationToken);
+    }
+
+    public Task RecordRingExhaustionAsync(CancellationToken cancellationToken = default) =>
+        MutateReportCounterAsync(() => _ringExhaustionCount++, cancellationToken);
+
+    public Task RecordNonQuotaErrorAsync(CancellationToken cancellationToken = default) =>
+        MutateReportCounterAsync(() => _nonQuotaErrorCount++, cancellationToken);
+
+    public Task RecordPodcastNotIndexedDueToQuotaAsync(CancellationToken cancellationToken = default) =>
+        MutateReportCounterAsync(() => _podcastsNotIndexedDueToQuota++, cancellationToken);
+
+    public Task RecordPodcastNotEnrichedDueToQuotaAsync(CancellationToken cancellationToken = default) =>
+        MutateReportCounterAsync(() => _podcastsNotEnrichedDueToQuota++, cancellationToken);
+
+    public async Task<YouTubeQuotaDailyReport> CreateReportAsync(
+        DateOnly reportDate,
+        string sourceApplication,
+        CancellationToken cancellationToken = default)
+    {
+        await _sync.WaitAsync(cancellationToken);
+        try
+        {
+            await EnsureHydratedLockedAsync(cancellationToken);
+            return BuildReport(reportDate, sourceApplication);
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    public async Task EnsureHydratedAsync(CancellationToken cancellationToken = default)
+    {
+        await _sync.WaitAsync(cancellationToken);
+        try
+        {
+            await EnsureHydratedLockedAsync(cancellationToken);
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    public async Task FlushToCosmosAsync(CancellationToken cancellationToken = default)
+    {
+        await _sync.WaitAsync(cancellationToken);
+        try
+        {
+            await EnsureHydratedLockedAsync(cancellationToken);
+            await PersistLockedAsync(cancellationToken);
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    public async Task ResetAsync(CancellationToken cancellationToken = default)
+    {
+        await _sync.WaitAsync(cancellationToken);
+        try
+        {
+            _stats.Clear();
+            _hydrated = false;
+            _pacificQuotaDate = null;
+            _podcastsNotIndexedDueToQuota = 0;
+            _podcastsNotEnrichedDueToQuota = 0;
+            _ringExhaustionCount = 0;
+            _nonQuotaErrorCount = 0;
+
+            var emptyState = new YouTubeQuotaUsageState
+            {
+                PacificQuotaDate = YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow),
+                SourceApplication = SourceApplication,
+                UpdatedUtc = DateTime.UtcNow,
+                Entries = [],
+                PodcastsNotIndexedDueToQuota = 0,
+                PodcastsNotEnrichedDueToQuota = 0,
+                RingExhaustionCount = 0,
+                NonQuotaErrorCount = 0
+            };
+            await lookupRepository.SaveYouTubeQuotaUsageState(emptyState);
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    private async Task MutateAsync(
+        Application application,
+        ApplicationUsage usage,
+        Action<MutableKeyStats> mutate,
+        CancellationToken cancellationToken)
+    {
+        await _sync.WaitAsync(cancellationToken);
+        try
+        {
+            await EnsureHydratedLockedAsync(cancellationToken);
+            mutate(GetOrAdd(application, usage));
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    private async Task MutateReportCounterAsync(Action mutate, CancellationToken cancellationToken)
+    {
+        await _sync.WaitAsync(cancellationToken);
+        try
+        {
+            await EnsureHydratedLockedAsync(cancellationToken);
+            mutate();
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    private async Task EnsureHydratedLockedAsync(CancellationToken cancellationToken)
+    {
+        var currentPacificQuotaDate = YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow);
+        if (_hydrated && _pacificQuotaDate == currentPacificQuotaDate)
+        {
+            return;
+        }
+
+        _stats.Clear();
+        var savedState = await lookupRepository.GetYouTubeQuotaUsageState();
+        if (savedState != null && savedState.PacificQuotaDate == currentPacificQuotaDate)
+        {
+            foreach (var entry in savedState.Entries)
+            {
+                var operationUsage = new MutableOperationUsage();
+                CopyOperationUsage(operationUsage, entry.QuotaConsumedByOperation);
+                _stats[entry.StatsKey] = new MutableKeyStats
+                {
+                    StatsKey = entry.StatsKey,
+                    DisplayName = entry.DisplayName,
+                    Project = entry.Project,
+                    Usage = entry.Usage,
+                    CallsAttempted = entry.CallsAttempted,
+                    QuotaHits = entry.QuotaHits,
+                    QuotaUsed = entry.QuotaUsed,
+                    QuotaConsumedByOperation = operationUsage
+                };
+            }
+
+            _podcastsNotIndexedDueToQuota = savedState.PodcastsNotIndexedDueToQuota;
+            _podcastsNotEnrichedDueToQuota = savedState.PodcastsNotEnrichedDueToQuota;
+            _ringExhaustionCount = savedState.RingExhaustionCount;
+            _nonQuotaErrorCount = savedState.NonQuotaErrorCount;
+
+            logger.LogDebug(
+                "Hydrated YouTube quota usage tracker with {EntryCount} keys for Pacific quota day {PacificQuotaDate}.",
+                savedState.Entries.Count,
+                currentPacificQuotaDate);
+        }
+        else
+        {
+            if (savedState != null)
+            {
+                logger.LogInformation(
+                    "Skipping stale YouTube quota usage state from Pacific quota day {SavedPacificQuotaDate}; current is {CurrentPacificQuotaDate}.",
+                    savedState.PacificQuotaDate,
+                    currentPacificQuotaDate);
+            }
+
+            _podcastsNotIndexedDueToQuota = 0;
+            _podcastsNotEnrichedDueToQuota = 0;
+            _ringExhaustionCount = 0;
+            _nonQuotaErrorCount = 0;
+        }
+
+        _pacificQuotaDate = currentPacificQuotaDate;
+        _hydrated = true;
+    }
+
+    private async Task PersistLockedAsync(CancellationToken cancellationToken)
+    {
+        var pacificQuotaDate = _pacificQuotaDate ?? YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow);
+        var state = new YouTubeQuotaUsageState
+        {
+            PacificQuotaDate = pacificQuotaDate,
+            SourceApplication = SourceApplication,
+            UpdatedUtc = DateTime.UtcNow,
+            Entries = _stats.Values
+                .Select(CreateUsageEntry)
+                .OrderBy(x => x.Usage, StringComparer.Ordinal)
+                .ThenBy(x => x.Project, StringComparer.Ordinal)
+                .ThenBy(x => x.DisplayName, StringComparer.Ordinal)
+                .ToList(),
+            PodcastsNotIndexedDueToQuota = _podcastsNotIndexedDueToQuota,
+            PodcastsNotEnrichedDueToQuota = _podcastsNotEnrichedDueToQuota,
+            RingExhaustionCount = _ringExhaustionCount,
+            NonQuotaErrorCount = _nonQuotaErrorCount
+        };
+
+        await lookupRepository.SaveYouTubeQuotaUsageState(state);
+    }
+
+    private YouTubeQuotaDailyReport BuildReport(DateOnly reportDate, string sourceApplication)
+    {
+        var (usedIndexerKeys, unusedIndexerKeys) = BuildIndexerKeyUsage();
+
+        return new YouTubeQuotaDailyReport
+        {
+            Id = YouTubeQuotaDailyReport.CreateId(reportDate, sourceApplication),
+            ReportDate = reportDate,
+            SourceApplication = sourceApplication,
+            Keys = _stats.Values
+                .OrderBy(x => x.Usage)
+                .ThenBy(x => x.Project)
+                .ThenBy(x => x.DisplayName)
+                .Select(CreateKeyStats)
+                .ToList(),
+            UsedIndexerKeys = usedIndexerKeys,
+            UnusedIndexerKeys = unusedIndexerKeys,
+            PodcastsNotIndexedDueToQuota = _podcastsNotIndexedDueToQuota,
+            PodcastsNotEnrichedDueToQuota = _podcastsNotEnrichedDueToQuota,
+            RingExhaustionCount = _ringExhaustionCount,
+            NonQuotaErrorCount = _nonQuotaErrorCount
+        };
+    }
+
+    private (List<YouTubeIndexerKeySummary> Used, List<YouTubeIndexerKeySummary> Unused) BuildIndexerKeyUsage()
+    {
+        var used = new List<YouTubeIndexerKeySummary>();
+        var unused = new List<YouTubeIndexerKeySummary>();
+
+        foreach (var application in GetConfiguredIndexerApplications())
+        {
+            var summary = CreateIndexerKeySummary(application);
+
+            if (summary.CallsAttempted > 0 || summary.QuotaHits > 0 || summary.QuotaUsed > 0)
+            {
+                used.Add(summary);
+            }
+            else
+            {
+                unused.Add(summary);
+            }
+        }
+
+        return (used, unused);
+    }
+
+    private IEnumerable<Application> GetConfiguredIndexerApplications() =>
+        IndexerKeyRingBuilder.GetFlatIndexerApplications(_settings.Applications);
+
+    private YouTubeIndexerKeySummary CreateIndexerKeySummary(Application application)
+    {
+        var statsKey = CreateStatsKey(application.ApiKey, ApplicationUsage.Indexer);
+        _stats.TryGetValue(statsKey, out var stats);
+        var callsAttempted = stats?.CallsAttempted ?? 0;
+        var quotaHits = stats?.QuotaHits ?? 0;
+        var quotaUsed = stats?.QuotaUsed ?? 0;
+        var operationUsage = stats?.QuotaConsumedByOperation ?? new MutableOperationUsage();
+
+        return new YouTubeIndexerKeySummary
+        {
+            DisplayName = application.DisplayName,
+            Project = application.Name,
+            HourPrimary = ResolveRingOrder(application),
+            Reattempt = null,
+            ApiKeySuffix = ResolveApiKeySuffix(application.ApiKey),
+            CallsAttempted = callsAttempted,
+            QuotaHits = quotaHits,
+            QuotaUsed = quotaUsed,
+            EstimatedQuotaUsed = ResolveEstimatedQuotaUsed(quotaUsed, quotaHits),
+            DailyLimit = YouTubeQuotaCosts.DailyLimitPerKey,
+            QuotaConsumedByOperation = CreateOperationUsageReport(operationUsage)
+        };
+    }
+
+    private static YouTubeQuotaKeyStats CreateKeyStats(MutableKeyStats stats) =>
+        new()
+        {
+            DisplayName = stats.DisplayName,
+            Project = stats.Project,
+            Usage = stats.Usage,
+            CallsAttempted = stats.CallsAttempted,
+            QuotaHits = stats.QuotaHits,
+            QuotaUsed = stats.QuotaUsed,
+            EstimatedQuotaUsed = ResolveEstimatedQuotaUsed(stats.QuotaUsed, stats.QuotaHits),
+            DailyLimit = YouTubeQuotaCosts.DailyLimitPerKey,
+            QuotaConsumedByOperation = CreateOperationUsageReport(stats.QuotaConsumedByOperation),
+            CapacityHint = ResolveCapacityHint(stats.CallsAttempted, stats.QuotaHits)
+        };
+
+    private static YouTubeQuotaUsageEntry CreateUsageEntry(MutableKeyStats stats) =>
+        new()
+        {
+            StatsKey = stats.StatsKey,
+            DisplayName = stats.DisplayName,
+            Project = stats.Project,
+            Usage = stats.Usage,
+            CallsAttempted = stats.CallsAttempted,
+            QuotaHits = stats.QuotaHits,
+            QuotaUsed = stats.QuotaUsed,
+            QuotaConsumedByOperation = CreateOperationUsageReport(stats.QuotaConsumedByOperation)
+        };
+
+    private MutableKeyStats GetOrAdd(Application application, ApplicationUsage usage)
+    {
+        var key = CreateStatsKey(application.ApiKey, usage);
+        return _stats.GetOrAdd(key, _ => new MutableKeyStats
+        {
+            DisplayName = application.DisplayName,
+            Project = application.Name,
+            Usage = usage.ToString(),
+            StatsKey = key
+        });
+    }
+
+    internal static string CreateStatsKey(string apiKey, ApplicationUsage usage) => $"{usage}:{apiKey}";
+
+    internal static int ResolveRingOrder(Application application)
+    {
+        var parts = application.DisplayName.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 3
+            && parts[0] == "Indexer"
+            && parts[1] == "Key"
+            && int.TryParse(parts[2], out var ringOrder))
+        {
+            return ringOrder;
+        }
+
+        throw new InvalidOperationException(
+            $"Unable to resolve ring order from indexer display name '{application.DisplayName}'.");
+    }
+
+    internal static string ResolveApiKeySuffix(string apiKey) =>
+        apiKey.Length <= 2 ? apiKey : apiKey[^2..];
+
+    internal static int ResolveEstimatedQuotaUsed(int quotaUsed, int quotaHits) =>
+        quotaHits > 0 ? Math.Max(quotaUsed, YouTubeQuotaCosts.DailyLimitPerKey) : quotaUsed;
+
+    private static string? ResolveCapacityHint(int callsAttempted, int quotaHits)
+    {
+        if (callsAttempted == 0)
+        {
+            return "unused";
+        }
+
+        return quotaHits == 0 ? "spare-capacity-candidate" : "quota-exhausted";
+    }
+
+    private static void AddOperationUsage(MutableOperationUsage usage, YouTubeQuotaOperation operation, int quotaUnits)
+    {
+        switch (operation)
+        {
+            case YouTubeQuotaOperation.SearchList:
+                usage.SearchList += quotaUnits;
+                break;
+            case YouTubeQuotaOperation.ChannelsList:
+                usage.ChannelsList += quotaUnits;
+                break;
+            case YouTubeQuotaOperation.PlaylistItemsList:
+                usage.PlaylistItemsList += quotaUnits;
+                break;
+            case YouTubeQuotaOperation.PlaylistsList:
+                usage.PlaylistsList += quotaUnits;
+                break;
+            case YouTubeQuotaOperation.VideosList:
+                usage.VideosList += quotaUnits;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(operation), operation, null);
+        }
+    }
+
+    private static YouTubeQuotaConsumedByOperation CreateOperationUsageReport(MutableOperationUsage usage) =>
+        new()
+        {
+            SearchList = usage.SearchList,
+            ChannelsList = usage.ChannelsList,
+            PlaylistItemsList = usage.PlaylistItemsList,
+            PlaylistsList = usage.PlaylistsList,
+            VideosList = usage.VideosList
+        };
+
+    private static void CopyOperationUsage(MutableOperationUsage target, YouTubeQuotaConsumedByOperation source)
+    {
+        target.SearchList = source.SearchList;
+        target.ChannelsList = source.ChannelsList;
+        target.PlaylistItemsList = source.PlaylistItemsList;
+        target.PlaylistsList = source.PlaylistsList;
+        target.VideosList = source.VideosList;
+    }
+
+    private static MutableOperationUsage CloneOperationUsage(YouTubeQuotaConsumedByOperation usage)
+    {
+        var clone = new MutableOperationUsage();
+        CopyOperationUsage(clone, usage);
+        return clone;
+    }
+
+    private sealed class MutableKeyStats
+    {
+        public required string StatsKey { get; init; }
+        public required string DisplayName { get; init; }
+        public required string Project { get; init; }
+        public required string Usage { get; init; }
+        public int CallsAttempted;
+        public int QuotaHits;
+        public int QuotaUsed;
+        public MutableOperationUsage QuotaConsumedByOperation { get; init; } = new();
+    }
+
+    private sealed class MutableOperationUsage
+    {
+        public int SearchList;
+        public int ChannelsList;
+        public int PlaylistItemsList;
+        public int PlaylistsList;
+        public int VideosList;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/RedditPodcastPoster.PodcastServices.YouTube.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/RedditPodcastPoster.PodcastServices.YouTube.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="RedditPodcastPoster.PodcastServices.YouTube.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Google.Apis.YouTube.v3" Version="1.75.0.4172" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
@@ -16,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\RedditPodcastPoster.Configuration\RedditPodcastPoster.Configuration.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.Persistence.Abstractions\RedditPodcastPoster.Persistence.Abstractions.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.Abstractions\RedditPodcastPoster.PodcastServices.Abstractions.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Text\RedditPodcastPoster.Text.csproj" />
   </ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
@@ -52,7 +52,7 @@ public class YouTubeItemResolver(
     {
         var latestPlaylistItems = await youTubePlaylistService.GetPlaylistVideoSnippets(
             new YouTubePlaylistId(request.Podcast.YouTubePlaylistId), indexingContext, true,
-            request.Podcast.HasExpensiveYouTubePlaylistQuery());
+            indexingContext.RunExpensiveYouTubePlaylistPagination(request.Podcast));
         if (latestPlaylistItems?.Result == null)
         {
             return null;

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeSearcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeSearcher.cs
@@ -17,7 +17,7 @@ public class YouTubeSearcher(
     IYouTubeServiceWrapper youTubeService,
     INoRedirectHttpClientFactory httpClientFactory,
     IYouTubeVideoService youTubeVideoService,
-    IYouTubeChannelService youTubeChannelService,
+    ITolerantYouTubeChannelService youTubeChannelService,
     ILogger<YouTubeSearcher> logger) : IYouTubeSearcher
 {
     private const long MaxSearchResults = 25;

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeUrlCategoriser.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeUrlCategoriser.cs
@@ -17,7 +17,7 @@ namespace RedditPodcastPoster.PodcastServices.YouTube.Services;
 
 public class YouTubeUrlCategoriser(
     IYouTubeServiceWrapper youTubeService,
-    IYouTubeChannelService youTubeChannelService,
+    ITolerantYouTubeChannelService youTubeChannelService,
     IYouTubeVideoService youTubeVideoService,
     IYouTubeChannelVideosService youTubeChannelVideosService,
     IYouTubePlaylistService youTubePlaylistService,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Strategies/IYouTubeApiKeyStrategy.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Strategies/IYouTubeApiKeyStrategy.cs
@@ -7,4 +7,5 @@ public interface IYouTubeApiKeyStrategy
 {
     ApplicationWrapper GetApplication(ApplicationUsage usage);
     ApplicationWrapper GetApplication(ApplicationUsage usage, int index, int reattempt);
+    IReadOnlyList<ApplicationWrapper> BuildIndexerKeyRing(int startRingIndex);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Strategies/IndexerKeyRingBuilder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Strategies/IndexerKeyRingBuilder.cs
@@ -1,0 +1,58 @@
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Strategies;
+
+internal static class IndexerKeyRingBuilder
+{
+    internal static IReadOnlyList<Application> GetFlatIndexerApplications(IEnumerable<Application> applications)
+    {
+        var seenApiKeys = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<Application>();
+        foreach (var application in applications)
+        {
+            if (application.Usage != ApplicationUsage.Indexer)
+            {
+                continue;
+            }
+
+            if (!seenApiKeys.Add(application.ApiKey))
+            {
+                continue;
+            }
+
+            result.Add(application);
+        }
+
+        if (result.Count == 0)
+        {
+            throw new InvalidOperationException("No Indexer youtube-applications registered.");
+        }
+
+        return result;
+    }
+
+    internal static int GetHourFallbackRingIndex(int hour, int ringCount) =>
+        ringCount == 0 ? 0 : hour * ringCount / 24 % ringCount;
+
+    internal static IReadOnlyList<ApplicationWrapper> Build(
+        IEnumerable<Application> applications,
+        int startRingIndex)
+    {
+        var flatApplications = GetFlatIndexerApplications(applications);
+        if (startRingIndex < 0 || startRingIndex >= flatApplications.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(startRingIndex),
+                $"Indexer ring start index must be between 0 and {flatApplications.Count - 1}.");
+        }
+
+        var ring = new List<ApplicationWrapper>(flatApplications.Count);
+        for (var offset = 0; offset < flatApplications.Count; offset++)
+        {
+            var canonicalIndex = (startRingIndex + offset) % flatApplications.Count;
+            ring.Add(new ApplicationWrapper(flatApplications[canonicalIndex], canonicalIndex, 0));
+        }
+
+        return ring;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Strategies/YouTubeApiKeyStrategy.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Strategies/YouTubeApiKeyStrategy.cs
@@ -17,9 +17,14 @@ public class YouTubeApiKeyStrategy(
 
     public ApplicationWrapper GetApplication(ApplicationUsage usage)
     {
+        if (usage == ApplicationUsage.Indexer)
+        {
+            return GetIndexerApplication();
+        }
+
         var usageApplications =
-            _settings.Applications.Where(x => x.Usage.HasFlag(usage) && x.Reattempt == null).ToArray();
-        var settingsCount = usageApplications.Count();
+            _settings.Applications.Where(x => MatchesUsage(x, usage) && x.Reattempt == null).ToArray();
+        var settingsCount = usageApplications.Length;
         if (settingsCount == 0)
         {
             throw new InvalidOperationException($"No youtube-applications registered or usage '{usage.ToString()}'");
@@ -34,8 +39,25 @@ public class YouTubeApiKeyStrategy(
         return new ApplicationWrapper(
             application,
             applicationIndex,
-            _settings.Applications.Where(x => x.Usage.HasFlag(usage)).Max(x => x.Reattempt) ?? 0
+            _settings.Applications.Where(x => MatchesUsage(x, usage)).Max(x => x.Reattempt) ?? 0
         );
+    }
+
+    private ApplicationWrapper GetIndexerApplication()
+    {
+        var flatApplications = IndexerKeyRingBuilder.GetFlatIndexerApplications(_settings.Applications);
+        var applicationIndex = IndexerKeyRingBuilder.GetHourFallbackRingIndex(
+            dateTimeService.GetHour(),
+            flatApplications.Count);
+        var application = flatApplications[applicationIndex];
+        logger.LogInformation(
+            "{methodName}: Using indexer ring key '{displayName}' ({position}/{settingsCount}) ending '{keyEnding}'.",
+            nameof(GetApplication),
+            application.DisplayName,
+            applicationIndex + 1,
+            flatApplications.Count,
+            application.ApiKey.Substring(application.ApiKey.Length - 2));
+        return new ApplicationWrapper(application, applicationIndex, 0);
     }
 
     public ApplicationWrapper GetApplication(ApplicationUsage usage, int index, int reattempt)
@@ -43,15 +65,15 @@ public class YouTubeApiKeyStrategy(
         logger.LogInformation("{method}: usage= '{usage}', index= {index}, reattempt= {reattempt}",
             nameof(GetApplication), usage, index, reattempt);
         var usageApplications =
-            _settings.Applications.Where(x => x.Usage.HasFlag(usage) && x.Reattempt == reattempt).ToArray();
-        var settingsCount = usageApplications.Count();
+            _settings.Applications.Where(x => MatchesUsage(x, usage) && x.Reattempt == reattempt).ToArray();
+        var settingsCount = usageApplications.Length;
         if (settingsCount == 0)
         {
             throw new InvalidOperationException(
                 $"No youtube-applications registered for usage '{usage.ToString()}' with reattempt '{reattempt}' (Index-requested: '{index}').");
         }
 
-        if (settingsCount < index)
+        if (settingsCount <= index)
         {
             throw new InvalidOperationException(
                 $"Inadequate number of youtube-applications registered for usage '{usage.ToString()}'. Applications: '{settingsCount}', Index-requested: '{index}'.");
@@ -65,6 +87,29 @@ public class YouTubeApiKeyStrategy(
         return new ApplicationWrapper(
             application,
             index,
-            _settings.Applications.Where(x => x.Usage.HasFlag(usage)).Max(x => x.Reattempt) ?? 0);
+            _settings.Applications.Where(x => MatchesUsage(x, usage)).Max(x => x.Reattempt) ?? 0);
     }
+
+    public IReadOnlyList<ApplicationWrapper> BuildIndexerKeyRing(int startRingIndex)
+    {
+        var ring = IndexerKeyRingBuilder.Build(_settings.Applications, startRingIndex);
+        logger.LogInformation(
+            "{methodName}: Built indexer key ring with {count} unique keys starting at ring index {startRingIndex}. Order: {order}.",
+            nameof(BuildIndexerKeyRing),
+            ring.Count,
+            startRingIndex,
+            string.Join(" -> ", ring.Select(x => x.Application.DisplayName)));
+        return ring;
+    }
+
+    private static bool MatchesUsage(Application application, ApplicationUsage usage) =>
+        usage switch
+        {
+            ApplicationUsage.Indexer => application.Usage == ApplicationUsage.Indexer,
+            ApplicationUsage.Discover => application.Usage == ApplicationUsage.Discover,
+            ApplicationUsage.Api => application.Usage == ApplicationUsage.Api,
+            ApplicationUsage.Bluesky => application.Usage == ApplicationUsage.Bluesky,
+            ApplicationUsage.Cli => application.Usage == ApplicationUsage.Cli,
+            _ => application.Usage.HasFlag(usage)
+        };
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Video/YouTubeVideoService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Video/YouTubeVideoService.cs
@@ -1,11 +1,16 @@
+using System.Net;
+using Google;
 using Google.Apis.YouTube.v3.Data;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
+using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Video;
 
 public class YouTubeVideoService(
+    IYouTubeQuotaUsageTracker quotaUsageTracker,
     ILogger<YouTubeVideoService> logger)
     : IYouTubeVideoService
 {
@@ -53,12 +58,32 @@ public class YouTubeVideoService(
                 try
                 {
                     response = await request.ExecuteAsync();
+                    await quotaUsageTracker.RecordQuotaConsumedAsync(
+                        youTubeService.CurrentApplication,
+                        youTubeService.Usage,
+                        YouTubeQuotaOperation.VideosList,
+                        YouTubeQuotaCosts.VideosList);
+                }
+                catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.Forbidden &&
+                                                    ex.Message.Contains("exceeded") &&
+                                                    ex.Message.Contains("quota"))
+                {
+                    logger.LogWarning(ex,
+                        "Exceeded quota obtaining videos matching video-ids '{videoIds}'.",
+                        string.Join(",", videoIds));
+                    await quotaUsageTracker.RecordQuotaHitAsync(
+                        youTubeService.CurrentApplication,
+                        youTubeService.Usage,
+                        YouTubeQuotaOperation.VideosList);
+                    indexingContext?.MarkYouTubeQuotaExhausted();
+                    return null;
                 }
                 catch (Exception ex)
                 {
                     logger.LogError(ex,
                         "Failed to use {youTubeServiceName} obtaining videos matching video-ids '{videoIds}'.",
                         nameof(youTubeService.YouTubeService), string.Join(",", videoIds));
+                    await quotaUsageTracker.RecordNonQuotaErrorAsync();
                     if (indexingContext != null)
                     {
                         indexingContext.SkipYouTubeUrlResolving = true;

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
@@ -7,6 +7,7 @@ using RedditPodcastPoster.DependencyInjection;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions;
 using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 using RedditPodcastPoster.Text.EliminationTerms;
 
 namespace RedditPodcastPoster.PodcastServices;
@@ -20,6 +21,7 @@ public class PodcastUpdater(
     IPodcastFilter podcastFilter,
     IAsyncInstance<IEliminationTermsProvider> eliminationTermsProviderInstance,
     IOptions<PostingCriteria> postingCriteria,
+    IYouTubeQuotaUsageTracker youTubeQuotaUsageTracker,
     ILogger<PodcastUpdater> logger)
     : IPodcastUpdater
 {
@@ -113,7 +115,17 @@ public class PodcastUpdater(
             }
         }
 
-        var enrichmentResult = await podcastServicesEpisodeEnricher.EnrichEpisodes(podcast, episodes, episodes, indexingContext);
+        var episodesWithAssignedPlatformIds = await episodeRepository
+            .GetByPodcastId(
+                podcast.Id,
+                x => (x.AppleId != null && x.AppleId > 0) ||
+                     (x.SpotifyId != null && x.SpotifyId != string.Empty))
+            .ToListAsync();
+        var enrichmentEpisodeContext =
+            BuildEnrichmentEpisodeContext(episodes, episodesWithAssignedPlatformIds);
+
+        var enrichmentResult = await podcastServicesEpisodeEnricher.EnrichEpisodes(
+            podcast, enrichmentEpisodeContext, episodes, indexingContext);
         var eliminationTermsProvider = await eliminationTermsProviderInstance.GetAsync();
         var eliminationTerms = eliminationTermsProvider.GetEliminationTerms();
         var filterResult = podcastFilter.Filter(podcast, episodes, eliminationTerms.Terms);
@@ -168,10 +180,31 @@ public class PodcastUpdater(
                 podcast.Name, podcast.Id, podcast.SpotifyId);
         }
 
-        if (mergeResult.MergedEpisodes.Any() || mergeResult.AddedEpisodes.Any() ||
-            filterResult.FilteredEpisodes.Any() || enrichmentResult.UpdatedEpisodes.Any() ||
-            discoveredYouTubeExpensiveQuery || discoveredYouTubeChannelSearchForbidden ||
-            discoveredSpotifyExpensiveQuery)
+        var spotifyBypassed = initialSkipSpotify != indexingContext.SkipSpotifyUrlResolving;
+        var youTubeBypassed = initialSkipYouTube != indexingContext.SkipYouTubeUrlResolving;
+        var youTubeDiscoveryBypassed = podcast.IsScheduledYouTubeDiscoveryBypassed(indexingContext);
+        if (youTubeDiscoveryBypassed)
+        {
+            logger.LogInformation(
+                "YouTube episode discovery bypassed for podcast '{podcastName}' with id '{podcastId}'; LastIndexed will not be updated.",
+                podcast.Name, podcast.Id);
+        }
+
+        var indexSucceeded = !spotifyBypassed && !youTubeBypassed && !youTubeDiscoveryBypassed &&
+                             !mergeResult.FailedEpisodes.Any();
+
+        var podcastChanged = mergeResult.MergedEpisodes.Any() || mergeResult.AddedEpisodes.Any() ||
+                             filterResult.FilteredEpisodes.Any() || enrichmentResult.UpdatedEpisodes.Any() ||
+                             discoveredYouTubeExpensiveQuery || discoveredYouTubeChannelSearchForbidden ||
+                             discoveredSpotifyExpensiveQuery;
+
+        if (indexSucceeded)
+        {
+            podcast.LastIndexed = DateTime.UtcNow;
+            podcastChanged = true;
+        }
+
+        if (podcastChanged)
         {
             // Update LatestReleased if new episodes were added or merged
             if (mergeResult.AddedEpisodes.Any())
@@ -195,13 +228,71 @@ public class PodcastUpdater(
             await podcastRepository.Save(podcast);
         }
 
+        await RecordPodcastQuotaImpactIfNeeded(
+            podcast,
+            enrichOnly,
+            indexingContext,
+            initialSkipYouTube);
+
         return new IndexPodcastResult(
             podcast,
             mergeResult,
             filterResult,
             enrichmentResult,
-            initialSkipSpotify != indexingContext.SkipSpotifyUrlResolving,
-            initialSkipYouTube != indexingContext.SkipYouTubeUrlResolving);
+            spotifyBypassed,
+            youTubeBypassed);
+    }
+
+    private async Task RecordPodcastQuotaImpactIfNeeded(
+        Podcast podcast,
+        bool enrichOnly,
+        IndexingContext indexingContext,
+        bool initialSkipYouTube)
+    {
+        if (initialSkipYouTube || !indexingContext.YouTubeQuotaExhausted)
+        {
+            return;
+        }
+
+        if (podcast.SkipEnrichingFromYouTube == true)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(podcast.YouTubeChannelId) &&
+            string.IsNullOrWhiteSpace(podcast.YouTubePlaylistId))
+        {
+            return;
+        }
+
+        if (enrichOnly || !podcast.IsScheduledYouTubeDiscoveryBypassed(indexingContext))
+        {
+            await youTubeQuotaUsageTracker.RecordPodcastNotEnrichedDueToQuotaAsync();
+            return;
+        }
+
+        await youTubeQuotaUsageTracker.RecordPodcastNotIndexedDueToQuotaAsync();
+    }
+
+    private static IList<Episode> BuildEnrichmentEpisodeContext(
+        IList<Episode> episodesToEnrich,
+        IList<Episode> episodesWithAssignedPlatformIds)
+    {
+        var assignedById = episodesWithAssignedPlatformIds.ToDictionary(x => x.Id);
+        var context = episodesToEnrich
+            .Select(episode => assignedById.TryGetValue(episode.Id, out var assigned) ? assigned : episode)
+            .ToList();
+
+        var indexedIds = episodesToEnrich.Select(x => x.Id).ToHashSet();
+        foreach (var assignedEpisode in episodesWithAssignedPlatformIds)
+        {
+            if (!indexedIds.Contains(assignedEpisode.Id))
+            {
+                context.Add(assignedEpisode);
+            }
+        }
+
+        return context;
     }
 
     private bool ReduceToSinceIncorporatingPublishDelay(

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastsUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastsUpdater.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 
@@ -15,10 +16,32 @@ public class PodcastsUpdater(
     public async Task<bool> UpdatePodcasts(Guid[] podcastIds, IndexingContext indexingContext)
     {
         var success = true;
+        var initialSkipYouTube = indexingContext.SkipYouTubeUrlResolving;
+        var initialSkipSpotify = indexingContext.SkipSpotifyUrlResolving;
+        var youtubeEnabled = !indexingContext.SkipYouTubeUrlResolving;
+        var youtubeAuthorityInBatch = 0;
+        var youtubeAuthorityIndexedWithYouTubePass = 0;
+        var youtubeAuthorityBypassed = 0;
+        var anyYouTubeBypassed = false;
+        var anyYouTubeQuotaExhausted = false;
+        var anySpotifyBypassed = false;
+
+        var podcasts = await Task.WhenAll(podcastIds.Select(async podcastId =>
+            (Id: podcastId, Podcast: await podcastRepository.GetPodcast(podcastId))));
+        var orderedPodcasts = podcasts
+            .OrderByDescending(x => x.Podcast?.DependsOnYouTubeForEpisodeDiscovery() == true)
+            .ThenBy(x => x.Id)
+            .ToArray();
+
         logger.LogInformation("{nameofUpdatePodcasts} Indexing Starting.", nameof(UpdatePodcasts));
-        foreach (var podcastId in podcastIds)
+        foreach (var (podcastId, podcast) in orderedPodcasts)
         {
-            var podcast = await podcastRepository.GetPodcast(podcastId);
+            var dependsOnYouTubeForDiscovery = podcast?.DependsOnYouTubeForEpisodeDiscovery() == true;
+            if (dependsOnYouTubeForDiscovery)
+            {
+                youtubeAuthorityInBatch++;
+            }
+
             var performAutoIndex = podcast != null &&
                                    (podcast.IndexAllEpisodes ||
                                     !string.IsNullOrWhiteSpace(podcast.EpisodeIncludeTitleRegex));
@@ -26,7 +49,11 @@ public class PodcastsUpdater(
             {
                 try
                 {
-                    var result = await podcastUpdater.Update(podcast!, false, indexingContext);
+                    var podcastIndexingContext = indexingContext with { };
+                    var result = await podcastUpdater.Update(podcast!, false, podcastIndexingContext);
+                    anyYouTubeBypassed |= !initialSkipYouTube && podcastIndexingContext.SkipYouTubeUrlResolving;
+                    anyYouTubeQuotaExhausted |= !initialSkipYouTube && podcastIndexingContext.YouTubeQuotaExhausted;
+                    anySpotifyBypassed |= !initialSkipSpotify && podcastIndexingContext.SkipSpotifyUrlResolving;
                     var resultReport = result.ToString();
                     if (!result.Success)
                     {
@@ -37,6 +64,27 @@ public class PodcastsUpdater(
                         if (!string.IsNullOrWhiteSpace(resultReport))
                         {
                             logger.LogInformation("{result}",result.ToString());
+                        }
+                    }
+
+                    if (dependsOnYouTubeForDiscovery)
+                    {
+                        var youtubeEnriched = result.EnrichmentResult.UpdatedEpisodes
+                            .Count(e => e.EnrichmentContext.YouTubeUrlUpdated ||
+                                        e.EnrichmentContext.YouTubeIdUpdated);
+
+                        logger.LogWarning(
+                            "YouTubeAuthorityPodcastAudit podcast-id='{PodcastId}' podcast-name='{PodcastName}' youtube-enabled='{YouTubeEnabled}' youtube-bypassed='{YouTubeBypassed}' episodes-added='{EpisodesAdded}' youtube-enriched='{YouTubeEnriched}'",
+                            podcast!.Id, podcast.Name, youtubeEnabled, result.YouTubeBypassed,
+                            result.MergeResult.AddedEpisodes.Count, youtubeEnriched);
+
+                        if (youtubeEnabled)
+                        {
+                            youtubeAuthorityIndexedWithYouTubePass++;
+                            if (result.YouTubeBypassed)
+                            {
+                                youtubeAuthorityBypassed++;
+                            }
                         }
                     }
 
@@ -53,6 +101,35 @@ public class PodcastsUpdater(
                     flushableCaches.Flush();
                 }
             }
+            else if (dependsOnYouTubeForDiscovery)
+            {
+                logger.LogWarning(
+                    "YouTubeAuthorityPodcastAudit podcast-id='{PodcastId}' podcast-name='{PodcastName}' youtube-enabled='{YouTubeEnabled}' indexed='False'",
+                    podcast!.Id, podcast.Name, youtubeEnabled);
+            }
+        }
+
+        if (youtubeAuthorityInBatch > 0)
+        {
+            logger.LogWarning(
+                "YouTubeAuthorityIndexingAudit youtube-enabled='{YouTubeEnabled}' in-batch='{InBatch}' indexed-with-youtube-pass='{IndexedWithYouTubePass}' youtube-bypassed='{YouTubeBypassed}'",
+                youtubeEnabled, youtubeAuthorityInBatch, youtubeAuthorityIndexedWithYouTubePass,
+                youtubeAuthorityBypassed);
+        }
+
+        if (anyYouTubeBypassed)
+        {
+            indexingContext.SkipYouTubeUrlResolving = true;
+        }
+
+        if (anyYouTubeQuotaExhausted)
+        {
+            indexingContext.YouTubeQuotaExhausted = true;
+        }
+
+        if (anySpotifyBypassed)
+        {
+            indexingContext.SkipSpotifyUrlResolving = true;
         }
 
         logger.LogInformation("{nameofUpdatePodcasts} Indexing complete.", nameof(UpdatePodcasts));

--- a/Cloud/Indexer/HalfHourlyOrchestration.cs
+++ b/Cloud/Indexer/HalfHourlyOrchestration.cs
@@ -22,6 +22,9 @@ public class HalfHourlyOrchestration : TaskOrchestrator<object, IndexerContext>
             SpotifyError = true
         };
 
+        indexerContext = await context.CallLoadRecentCandidatesAsync(indexerContext);
+        logger.LogInformation("{nameofLoadRecentCandidates} complete.", nameof(LoadRecentCandidates));
+
         indexerContext = await context.CallPosterAsync(indexerContext with {PosterOperationId = context.NewGuid()});
         logger.LogInformation("{nameofPoster} complete.", nameof(Poster));
 

--- a/Cloud/Indexer/HourlyOrchestration.cs
+++ b/Cloud/Indexer/HourlyOrchestration.cs
@@ -21,16 +21,38 @@ public class HourlyOrchestration : TaskOrchestrator<object, IndexerContext>
 
         var hourUtc = context.CurrentUtcDateTime.Hour;
         var (firstPass, lastPass) = HourlyIndexingPassSelector.SelectPasses(hourUtc, indexPasses);
-        logger.LogInformation(
-            "Selected indexer passes {firstPass}-{lastPass} for UTC hour {hourUtc}.",
-            firstPass, lastPass, hourUtc);
+        var youtubeEnabledHour = hourUtc % 6 == 0;
+        logger.LogWarning(
+            "HourlyOrchestration pass-selection hour-utc='{HourUtc}' first-pass='{FirstPass}' last-pass='{LastPass}' youtube-enabled-hour='{YouTubeEnabledHour}' orchestration-instance-id='{OrchestrationInstanceId}'",
+            hourUtc, firstPass, lastPass, youtubeEnabledHour, context.InstanceId);
+        logger.LogWarning(
+            "HourlyOrchestration indexer-operation-ids pass-1='{Pass1OperationId}' pass-2='{Pass2OperationId}' pass-3='{Pass3OperationId}' pass-4='{Pass4OperationId}'",
+            indexPassOperationIs[0], indexPassOperationIs[1], indexPassOperationIs[2], indexPassOperationIs[3]);
 
         var indexerContext = new IndexerContext(indexPassOperationIs, indexIds.PodcastIdBatches);
         for (var pass = firstPass; pass <= lastPass; pass++)
         {
             indexerContext = await context.CallIndexerAsync(new IndexerContextWrapper(indexerContext, pass));
+            var batchPodcastCount = indexerContext.IndexIds?[pass - 1]?.Length ?? 0;
+            var operationId = indexerContext.IndexerPassOperationIds?[pass - 1];
+            logger.LogWarning(
+                "HourlyOrchestration indexer-pass-complete pass='{Pass}' hour-utc='{HourUtc}' operation-id='{OperationId}' podcast-count='{PodcastCount}' success='{Success}' skip-youtube='{SkipYouTube}' youtube-error='{YouTubeError}'",
+                pass, hourUtc, operationId, batchPodcastCount, indexerContext.Success,
+                indexerContext.SkipYouTubeUrlResolving, indexerContext.YouTubeError);
+
+            if (pass == 4)
+            {
+                logger.LogWarning(
+                    "HourlyOrchestration batch-4-rollup hour-utc='{HourUtc}' operation-id='{OperationId}' podcast-count='{PodcastCount}' success='{Success}' skip-youtube='{SkipYouTube}' youtube-error='{YouTubeError}'",
+                    hourUtc, operationId, batchPodcastCount, indexerContext.Success,
+                    indexerContext.SkipYouTubeUrlResolving, indexerContext.YouTubeError);
+            }
+
             logger.LogInformation("{nameofIndexer} complete - Pass {pass}.", nameof(Indexer), pass);
         }
+
+        indexerContext = await context.CallLoadRecentCandidatesAsync(indexerContext);
+        logger.LogInformation("{nameofLoadRecentCandidates} complete.", nameof(LoadRecentCandidates));
 
         indexerContext =
             await context.CallCategoriserAsync(indexerContext with {CategoriserOperationId = context.NewGuid()});

--- a/Cloud/Indexer/HourlyOrchestrationCatchUpEvaluator.cs
+++ b/Cloud/Indexer/HourlyOrchestrationCatchUpEvaluator.cs
@@ -1,0 +1,34 @@
+using Microsoft.DurableTask.Client;
+
+namespace Indexer;
+
+public readonly record struct HourlyOrchestrationInstance(DateTimeOffset CreatedAt, OrchestrationRuntimeStatus Status);
+
+public static class HourlyOrchestrationCatchUpEvaluator
+{
+    private static readonly OrchestrationRuntimeStatus[] ActiveStatuses =
+    [
+        OrchestrationRuntimeStatus.Pending,
+        OrchestrationRuntimeStatus.Running,
+        OrchestrationRuntimeStatus.ContinuedAsNew
+    ];
+
+    public static bool HasHourlyOrchestrationForUtcHour(
+        DateTime utcNow,
+        IEnumerable<HourlyOrchestrationInstance> instances)
+    {
+        var hourStart = new DateTimeOffset(utcNow.Year, utcNow.Month, utcNow.Day, utcNow.Hour, 0, 0, TimeSpan.Zero);
+        var hourEnd = hourStart.AddHours(1);
+
+        return instances.Any(instance =>
+            instance.CreatedAt >= hourStart && instance.CreatedAt < hourEnd);
+    }
+
+    public static bool HasActiveHourlyOrchestration(IEnumerable<HourlyOrchestrationInstance> instances) =>
+        instances.Any(instance => ActiveStatuses.Contains(instance.Status));
+
+    public static bool ShouldScheduleCatchUp(
+        DateTime utcNow,
+        IEnumerable<HourlyOrchestrationInstance> instances) =>
+        !HasActiveHourlyOrchestration(instances) && !HasHourlyOrchestrationForUtcHour(utcNow, instances);
+}

--- a/Cloud/Indexer/IndexIdProvider.cs
+++ b/Cloud/Indexer/IndexIdProvider.cs
@@ -1,15 +1,18 @@
 using Azure.Diagnostics;
+using Microsoft.Azure.Cosmos.Linq;
 using Microsoft.DurableTask;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RedditPodcastPoster.Configuration;
-using RedditPodcastPoster.PodcastServices;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Persistence.Abstractions;
+using RedditPodcastPoster.PodcastServices.Abstractions;
 
 namespace Indexer;
 
 [DurableTask(nameof(IndexIdProvider))]
 public class IndexIdProvider(
-    IIndexablePodcastIdProvider indexablePodcastIdProvider,
+    IPodcastRepository podcastRepository,
     IOptions<IndexerOptions> indexerOptions,
     IMemoryProbeOrchestrator memoryProbeOrchestrator,
     ILogger<IndexIdProvider> logger
@@ -28,7 +31,25 @@ public class IndexIdProvider(
             throw new ArgumentException("IndexPasses must be greater than 0.");
         }
 
-        var allIndexablePodcastIds = await indexablePodcastIdProvider.GetIndexablePodcastIds().ToArrayAsync();
+        var indexablePodcasts = await podcastRepository
+            .GetAllBy(
+                podcast => ((!podcast.Removed.IsDefined() || podcast.Removed == false) &&
+                            podcast.IndexAllEpisodes) ||
+                           podcast.EpisodeIncludeTitleRegex != "")
+            .ToArrayAsync();
+
+        var allIndexablePodcastIds = indexablePodcasts.Select(p => p.Id).ToArray();
+        var youtubeDiscoveryIds = indexablePodcasts
+            .Where(p => p.DependsOnYouTubeForEpisodeDiscovery())
+            .Select(p => p.Id)
+            .ToArray();
+
+        if (youtubeDiscoveryIds.Length > 0)
+        {
+            logger.LogInformation(
+                "YouTubeAuthorityIndexPool audit-utc='{AuditUtc:O}' podcast-count='{PodcastCount}' podcast-ids='{PodcastIds}'",
+                DateTime.UtcNow, youtubeDiscoveryIds.Length, string.Join(",", youtubeDiscoveryIds));
+        }
 
         var batchSizes = allIndexablePodcastIds.Length / req.IndexPasses;
         var batches = new List<Guid[]>();
@@ -42,6 +63,12 @@ public class IndexIdProvider(
 
             var batchArray = batch.ToArray();
             logger.LogInformation("Batch {i}: {batch}", i + 1, batchArray);
+            if (i == 3)
+            {
+                logger.LogWarning(
+                    "IndexIdProvider batch-4-summary podcast-count='{PodcastCount}'",
+                    batchArray.Length);
+            }
             batches.Add(batchArray);
         }
 

--- a/Cloud/Indexer/Indexer.cs
+++ b/Cloud/Indexer/Indexer.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RedditPodcastPoster.Configuration;
 using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 
 namespace Indexer;
 
@@ -17,6 +18,7 @@ public class Indexer(
     IActivityOptionsProvider activityOptionsProvider,
     IOptions<IndexerOptions> indexerOptions,
     IMemoryProbeOrchestrator memoryProbeOrchestrator,
+    IYouTubeQuotaUsageTracker youTubeQuotaUsageTracker,
     ILogger<Indexer> logger)
     : TaskActivity<IndexerContextWrapper, IndexerContext>
 {
@@ -56,17 +58,20 @@ public class Indexer(
         logger.LogInformation("Pre: {indexerContext} {indexerOptions}", indexerContext.ToString(),
             _indexerOptions.ToString());
         var isPrimaryPass = indexingStrategy.IsPrimaryPass(indexerContextWrapper.Pass, passes);
+        var youTubeEnabledThisPass = indexingStrategy.ResolveYouTube();
         var indexingContext = _indexerOptions.ToIndexingContext() with
         {
             IndexSpotify = indexingStrategy.IndexSpotify(),
             SkipSpotifyUrlResolving = false,
-            SkipYouTubeUrlResolving = !indexingStrategy.ResolveYouTube(),
+            SkipYouTubeUrlResolving = !youTubeEnabledThisPass,
             SkipExpensiveYouTubeQueries = !isPrimaryPass || !indexingStrategy.ExpensiveYouTubeQueries(),
             SkipExpensiveSpotifyQueries = !isPrimaryPass || !indexingStrategy.ExpensiveSpotifyQueries(),
             SkipPodcastDiscovery = true
         };
 
-        var originalIndexingContext = indexerContext with { };
+        logger.LogInformation(
+            "Indexer pass {Pass} indexing-context: {IndexingContext}",
+            indexerContextWrapper.Pass, indexingContext.ToString());
 
         logger.LogInformation("Post: {indexerContext}", indexerContext.ToString());
 
@@ -88,6 +93,32 @@ public class Indexer(
         }
 
         var indexerOperationId = indexerContext.IndexerPassOperationIds[indexerContextWrapper.Pass - 1];
+        var idsToIndex = indexerContext.IndexIds[indexerContextWrapper.Pass - 1];
+        idsToIndexCount = idsToIndex.Length;
+
+        logger.LogWarning(
+            "IndexerPassStart instance-id='{InstanceId}' pass='{Pass}' operation-id='{OperationId}' podcast-count='{PodcastCount}' youtube-enabled-pass='{YouTubeEnabledPass}' skip-youtube='{SkipYouTube}' skip-expensive-youtube='{SkipExpensiveYouTube}' skip-expensive-spotify='{SkipExpensiveSpotify}'",
+            context.InstanceId,
+            indexerContextWrapper.Pass,
+            indexerOperationId,
+            idsToIndexCount,
+            youTubeEnabledThisPass,
+            indexingContext.SkipYouTubeUrlResolving,
+            indexingContext.SkipExpensiveYouTubeQueries,
+            indexingContext.SkipExpensiveSpotifyQueries);
+
+        if (youTubeEnabledThisPass)
+        {
+            try
+            {
+                await youTubeQuotaUsageTracker.EnsureHydratedAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to hydrate YouTube quota usage tracker at indexer pass start.");
+            }
+        }
+
         initiatedStatus = await activityMarshaller.Initiate(indexerOperationId, nameof(Indexer));
 
         if (initiatedStatus != ActivityStatus.Initiated)
@@ -113,9 +144,6 @@ public class Indexer(
         bool results;
         try
         {
-            var idsToIndex = indexerContext.IndexIds[indexerContextWrapper.Pass - 1];
-            idsToIndexCount = idsToIndex.Length;
-
             var updateStopwatch = Stopwatch.StartNew();
             results = await podcastsUpdater.UpdatePodcasts(idsToIndex, indexingContext);
             updateStopwatch.Stop();
@@ -137,6 +165,18 @@ public class Indexer(
         }
         finally
         {
+            if (youTubeEnabledThisPass)
+            {
+                try
+                {
+                    await youTubeQuotaUsageTracker.FlushToCosmosAsync();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failure to flush YouTube quota usage to Cosmos.");
+                }
+            }
+
             try
             {
                 completedStatus = await activityMarshaller.Complete(indexerOperationId, nameof(Indexer));
@@ -161,12 +201,25 @@ public class Indexer(
         {
             Success = results,
             SkipYouTubeUrlResolving = indexingContext.SkipYouTubeUrlResolving,
-            YouTubeError = indexingContext.SkipYouTubeUrlResolving != originalIndexingContext.SkipYouTubeUrlResolving,
+            YouTubeError = youTubeEnabledThisPass && indexingContext.SkipYouTubeUrlResolving,
             SkipSpotifyUrlResolving = indexingContext.SkipSpotifyUrlResolving,
-            SpotifyError = indexingContext.SkipSpotifyUrlResolving != originalIndexingContext.SkipSpotifyUrlResolving
+            SpotifyError = indexingContext.SkipSpotifyUrlResolving
         };
 
         memoryProbe.End();
+
+        logger.LogWarning(
+            "IndexerPassComplete instance-id='{InstanceId}' pass='{Pass}' operation-id='{OperationId}' podcast-count='{PodcastCount}' success='{Success}' skip-youtube='{SkipYouTube}' youtube-error='{YouTubeError}' skip-spotify='{SkipSpotify}' spotify-error='{SpotifyError}' update-ms='{UpdateMs}'",
+            context.InstanceId,
+            indexerContextWrapper.Pass,
+            indexerOperationId,
+            idsToIndexCount,
+            result.Success,
+            result.SkipYouTubeUrlResolving,
+            result.YouTubeError,
+            result.SkipSpotifyUrlResolving,
+            result.SpotifyError,
+            updateMs);
 
         logger.LogInformation("{nameofRunAsync} Completed. Pass: {indexerContextWrapperPass}. Result: {result}",
             nameof(RunAsync), indexerContextWrapper.Pass, result);

--- a/Cloud/Indexer/IndexerContext.cs
+++ b/Cloud/Indexer/IndexerContext.cs
@@ -1,3 +1,5 @@
+using RedditPodcastPoster.Models;
+
 namespace Indexer;
 
 public record IndexerContext(
@@ -18,7 +20,8 @@ public record IndexerContext(
     bool? DuplicatePosterOperation = null,
     bool? DuplicatePublisherOperation = null,
     bool? DuplicateTweetOperation = null,
-    bool? DuplicateBlueskyOperation = null)
+    bool? DuplicateBlueskyOperation = null,
+    PodcastEpisode[]? RecentEpisodeCandidates = null)
 {
     public override string ToString()
     {
@@ -77,13 +80,17 @@ public record IndexerContext(
         var duplicateBlueskyOperation = DuplicateBlueskyOperation.HasValue
             ? $"duplicate-bluesky-operation: '{DuplicateBlueskyOperation}'"
             : string.Empty;
+        var recentEpisodeCandidates = RecentEpisodeCandidates != null
+            ? $"recent-episode-candidates: '{RecentEpisodeCandidates.Length}'"
+            : string.Empty;
 
         var strings = new List<string>
         {
             categoriserOperationId, posterOperationId, publisherOperationId, tweetOperationId,
             blueskyOperationId, success, skipYouTubeUrlResolving, youTubeError, skipSpotifyUrlResolving, spotifyError,
             duplicateIndexerOperation, duplicateCategoriserOperation, duplicatePosterOperation,
-            duplicatePublisherOperation, duplicateTweetOperation, duplicateBlueskyOperation
+            duplicatePublisherOperation, duplicateTweetOperation, duplicateBlueskyOperation,
+            recentEpisodeCandidates
         };
         if (indexerPassOperationIds != null)
         {

--- a/Cloud/Indexer/LoadRecentCandidates.cs
+++ b/Cloud/Indexer/LoadRecentCandidates.cs
@@ -1,0 +1,50 @@
+using Azure.Diagnostics;
+using Microsoft.DurableTask;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RedditPodcastPoster.Common.Episodes;
+using RedditPodcastPoster.Configuration;
+using RedditPodcastPoster.Configuration.Extensions;
+
+namespace Indexer;
+
+[DurableTask(nameof(LoadRecentCandidates))]
+public class LoadRecentCandidates(
+    IRecentEpisodeCandidatesProvider recentEpisodeCandidatesProvider,
+    IOptions<PostingCriteria> postingCriteria,
+    IMemoryProbeOrchestrator memoryProbeOrchestrator,
+    ILogger<LoadRecentCandidates> logger)
+    : TaskActivity<IndexerContext, IndexerContext>
+{
+    private readonly IMemoryProbeOrchestrator _memoryProbeOrchestrator = memoryProbeOrchestrator;
+
+    public override async Task<IndexerContext> RunAsync(TaskActivityContext context, IndexerContext indexerContext)
+    {
+        var memoryProbe = _memoryProbeOrchestrator.Start(nameof(LoadRecentCandidates));
+
+        logger.LogInformation(
+            "{LoadRecentCandidatesName} initiated. task-activity-context-instance-id: '{ContextInstanceId}'.",
+            nameof(LoadRecentCandidates), context.InstanceId);
+        logger.LogInformation(indexerContext.ToString());
+
+        if (indexerContext.RecentEpisodeCandidates != null)
+        {
+            logger.LogInformation(
+                "Recent episode candidates already preloaded. Count: {Count}.",
+                indexerContext.RecentEpisodeCandidates.Length);
+            memoryProbe.End();
+            return indexerContext;
+        }
+
+        var releasedSince = DateTimeExtensions.DaysAgo(postingCriteria.Value.MaxDays);
+        var candidates = await recentEpisodeCandidatesProvider.GetRecentActiveEpisodes(releasedSince);
+
+        logger.LogInformation(
+            "Loaded {Count} recent active episode candidates since '{ReleasedSince:O}'.",
+            candidates.Count,
+            releasedSince);
+
+        memoryProbe.End();
+        return indexerContext with { RecentEpisodeCandidates = candidates.ToArray() };
+    }
+}

--- a/Cloud/Indexer/OrchestrationTrigger.cs
+++ b/Cloud/Indexer/OrchestrationTrigger.cs
@@ -21,7 +21,10 @@ public class OrchestrationTrigger(ILogger<OrchestrationTrigger> logger)
         [DurableClient] DurableTaskClient client,
         CancellationToken cancellationToken)
     {
-        logger.LogInformation($"{nameof(OrchestrationTrigger)} {nameof(RunHourly)} initiated.");
+        var hourUtc = DateTime.UtcNow.Hour;
+        logger.LogWarning(
+            "OrchestrationTrigger RunHourly initiated hour-utc='{HourUtc}'.",
+            hourUtc);
 
         if (await HasActiveOrchestrationInstanceAsync(client, nameof(HourlyOrchestration), cancellationToken))
         {
@@ -31,26 +34,39 @@ public class OrchestrationTrigger(ILogger<OrchestrationTrigger> logger)
             return;
         }
 
-        string instanceId;
-        try
+        await ScheduleHourlyOrchestrationAsync(client, nameof(RunHourly), hourUtc, cancellationToken);
+    }
+
+    [Function("HourlyCatchUp")]
+    public async Task RunHourlyCatchUp(
+        [TimerTrigger("0 5 * * * *"
+#if DEBUG
+            , RunOnStartup = false
+#endif
+        )]
+        TimerInfo info,
+        [DurableClient] DurableTaskClient client,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("{OrchestrationTriggerName} {RunHourlyCatchUpName} initiated.",
+            nameof(OrchestrationTrigger), nameof(RunHourlyCatchUp));
+
+        var utcNow = DateTime.UtcNow;
+        var hourlyInstances = await GetHourlyOrchestrationInstancesAsync(client, cancellationToken);
+
+        if (!HourlyOrchestrationCatchUpEvaluator.ShouldScheduleCatchUp(utcNow, hourlyInstances))
         {
-            instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(HourlyOrchestration));
-        }
-        catch (RpcException ex)
-        {
-            logger.LogCritical(ex,
-                "Failure to execute '{ScheduleNewOrchestrationInstanceAsyncName}' for '{HourlyOrchestrationName}'. Status-Code: '{ExStatusCode}', Status: '{ExStatus}'.", nameof(client.ScheduleNewOrchestrationInstanceAsync), nameof(HourlyOrchestration), ex.StatusCode, ex.Status);
-            throw;
-        }
-        catch (Exception ex)
-        {
-            logger.LogCritical(ex,
-                $"Failure to execute '{nameof(client.ScheduleNewOrchestrationInstanceAsync)}' for '{nameof(HourlyOrchestration)}'.");
-            throw;
+            logger.LogInformation(
+                "{OrchestrationTriggerName} {RunHourlyCatchUpName} skipped. Hourly orchestration already ran or is active for UTC hour {HourUtc}.",
+                nameof(OrchestrationTrigger), nameof(RunHourlyCatchUp), utcNow.Hour);
+            return;
         }
 
-        logger.LogInformation(
-            "{OrchestrationTriggerName} {RunHourlyName} complete. Instance-id= '{InstanceId}'.", nameof(OrchestrationTrigger), nameof(RunHourly), instanceId);
+        logger.LogWarning(
+            "{OrchestrationTriggerName} {RunHourlyCatchUpName} scheduling missed hourly orchestration for UTC hour {HourUtc}.",
+            nameof(OrchestrationTrigger), nameof(RunHourlyCatchUp), utcNow.Hour);
+
+        await ScheduleHourlyOrchestrationAsync(client, nameof(RunHourlyCatchUp), utcNow.Hour, cancellationToken);
     }
 
 
@@ -97,6 +113,37 @@ public class OrchestrationTrigger(ILogger<OrchestrationTrigger> logger)
             "{OrchestrationTriggerName} {RunHalfHourlyName} complete. Instance-id= '{InstanceId}'.", nameof(OrchestrationTrigger), nameof(RunHalfHourly), instanceId);
     }
 
+    private async Task ScheduleHourlyOrchestrationAsync(
+        DurableTaskClient client,
+        string triggerName,
+        int hourUtc,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string instanceId;
+        try
+        {
+            instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(HourlyOrchestration));
+        }
+        catch (RpcException ex)
+        {
+            logger.LogCritical(ex,
+                "Failure to execute '{ScheduleNewOrchestrationInstanceAsyncName}' for '{HourlyOrchestrationName}'. Status-Code: '{ExStatusCode}', Status: '{ExStatus}'.", nameof(client.ScheduleNewOrchestrationInstanceAsync), nameof(HourlyOrchestration), ex.StatusCode, ex.Status);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex,
+                $"Failure to execute '{nameof(client.ScheduleNewOrchestrationInstanceAsync)}' for '{nameof(HourlyOrchestration)}'.");
+            throw;
+        }
+
+        logger.LogWarning(
+            "OrchestrationTrigger hourly-scheduled trigger='{TriggerName}' hour-utc='{HourUtc}' instance-id='{InstanceId}'.",
+            triggerName, hourUtc, instanceId);
+    }
+
     private static async Task<bool> HasActiveOrchestrationInstanceAsync(
         DurableTaskClient client,
         string orchestrationName,
@@ -124,5 +171,30 @@ public class OrchestrationTrigger(ILogger<OrchestrationTrigger> logger)
         }
 
         return false;
+    }
+
+    private static async Task<IReadOnlyList<HourlyOrchestrationInstance>> GetHourlyOrchestrationInstancesAsync(
+        DurableTaskClient client,
+        CancellationToken cancellationToken)
+    {
+        var query = new OrchestrationQuery
+        {
+            CreatedFrom = DateTime.UtcNow.Subtract(TimeSpan.FromHours(2))
+        };
+
+        var instances = new List<HourlyOrchestrationInstance>();
+        await foreach (var metadata in client.GetAllInstancesAsync(query))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (metadata.Name != new TaskName(nameof(HourlyOrchestration)))
+            {
+                continue;
+            }
+
+            instances.Add(new HourlyOrchestrationInstance(metadata.CreatedAt, metadata.RuntimeStatus));
+        }
+
+        return instances;
     }
 }

--- a/Cloud/Indexer/YouTubeQuotaReportTrigger.cs
+++ b/Cloud/Indexer/YouTubeQuotaReportTrigger.cs
@@ -1,0 +1,46 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Persistence.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Quota;
+
+namespace Indexer;
+
+public class YouTubeQuotaReportTrigger(
+    IYouTubeQuotaUsageTracker quotaUsageTracker,
+    ILookupRepository lookupRepository,
+    ILogger<YouTubeQuotaReportTrigger> logger)
+{
+    private const string SourceApplication = "Indexer";
+
+    [Function("YouTubeQuotaReport")]
+    public async Task Run(
+        [TimerTrigger("0 55 6 * * *"
+#if DEBUG
+            , RunOnStartup = false
+#endif
+        )]
+        TimerInfo timerInfo,
+        CancellationToken cancellationToken)
+    {
+        var reportDate = YouTubePacificQuotaDate.GetCurrent(DateTime.UtcNow);
+        logger.LogInformation(
+            "Flushing YouTube quota usage report for Pacific quota day {ReportDate} from {SourceApplication}.",
+            reportDate,
+            SourceApplication);
+
+        var report = await quotaUsageTracker.CreateReportAsync(reportDate, SourceApplication, cancellationToken);
+        await lookupRepository.SaveYouTubeQuotaDailyReport(report);
+        await quotaUsageTracker.ResetAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Saved YouTube quota report {ReportId} with {KeyCount} keys, {UsedIndexerKeyCount} used indexer keys, {UnusedIndexerKeyCount} unused indexer keys, {PodcastsNotIndexedDueToQuota} podcasts not indexed due to quota, {PodcastsNotEnrichedDueToQuota} podcasts not enriched due to quota, {RingExhaustionCount} ring exhaustions, {NonQuotaErrorCount} non-quota errors.",
+            report.Id,
+            report.Keys.Count,
+            report.UsedIndexerKeys.Count,
+            report.UnusedIndexerKeys.Count,
+            report.PodcastsNotIndexedDueToQuota,
+            report.PodcastsNotEnrichedDueToQuota,
+            report.RingExhaustionCount,
+            report.NonQuotaErrorCount);
+    }
+}

--- a/Cloud/Indexer/host.json
+++ b/Cloud/Indexer/host.json
@@ -20,7 +20,9 @@
       "Host.Startup": "Information",
       "Host.Results": "Warning",
       "Function": "Warning",
-      "RedditPodcastPoster": "Information",
+      "Azure": "Warning",
+      "RedditPodcastPoster": "Warning",
+      "RedditPodcastPoster.PodcastServices.YouTube": "Information",
       "Indexer": "Information"
     }
   },

--- a/Cloud/Unit-Tests/Indexer.Tests/HourlyOrchestrationCatchUpEvaluatorTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/HourlyOrchestrationCatchUpEvaluatorTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Microsoft.DurableTask.Client;
+using Xunit;
+
+namespace Indexer.Tests;
+
+public class HourlyOrchestrationCatchUpEvaluatorTests
+{
+    private static readonly DateTimeOffset HourStart = new(2026, 6, 19, 18, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void ShouldScheduleCatchUp_when_no_instance_exists_for_current_hour()
+    {
+        HourlyOrchestrationCatchUpEvaluator.ShouldScheduleCatchUp(
+                HourStart.UtcDateTime.AddMinutes(5),
+                [])
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldScheduleCatchUp_when_only_prior_hour_instances_exist()
+    {
+        var instances = new[]
+        {
+            new HourlyOrchestrationInstance(HourStart.AddHours(-1), OrchestrationRuntimeStatus.Completed)
+        };
+
+        HourlyOrchestrationCatchUpEvaluator.ShouldScheduleCatchUp(
+                HourStart.UtcDateTime.AddMinutes(5),
+                instances)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldNotScheduleCatchUp_when_instance_already_started_this_hour()
+    {
+        var instances = new[]
+        {
+            new HourlyOrchestrationInstance(HourStart.AddSeconds(14), OrchestrationRuntimeStatus.Completed)
+        };
+
+        HourlyOrchestrationCatchUpEvaluator.ShouldScheduleCatchUp(
+                HourStart.UtcDateTime.AddMinutes(5),
+                instances)
+            .Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(OrchestrationRuntimeStatus.Pending)]
+    [InlineData(OrchestrationRuntimeStatus.Running)]
+    [InlineData(OrchestrationRuntimeStatus.ContinuedAsNew)]
+    public void ShouldNotScheduleCatchUp_when_hourly_orchestration_is_still_active(OrchestrationRuntimeStatus status)
+    {
+        var instances = new[]
+        {
+            new HourlyOrchestrationInstance(HourStart.AddHours(-2), status)
+        };
+
+        HourlyOrchestrationCatchUpEvaluator.ShouldScheduleCatchUp(
+                HourStart.UtcDateTime.AddMinutes(5),
+                instances)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasHourlyOrchestrationForUtcHour_matches_instance_created_within_hour_boundary()
+    {
+        HourlyOrchestrationCatchUpEvaluator.HasHourlyOrchestrationForUtcHour(
+                HourStart.UtcDateTime.AddMinutes(5),
+                [new HourlyOrchestrationInstance(HourStart.AddHours(1).AddTicks(-1), OrchestrationRuntimeStatus.Completed)])
+            .Should().BeTrue();
+
+        HourlyOrchestrationCatchUpEvaluator.HasHourlyOrchestrationForUtcHour(
+                HourStart.UtcDateTime.AddMinutes(5),
+                [new HourlyOrchestrationInstance(HourStart.AddHours(1), OrchestrationRuntimeStatus.Completed)])
+            .Should().BeFalse();
+    }
+}

--- a/docs/indexer-youtube-go-live.md
+++ b/docs/indexer-youtube-go-live.md
@@ -1,0 +1,129 @@
+# Indexer YouTube go-live checklist
+
+Production checklist for deploying the **indexer** (`indexer-infra`) with the flat YouTube key ring, quota reporting, and cultpodcasts keys on slots 13/15.
+
+**Related docs:**
+
+- [youtube-keys.md](youtube-keys.md) — key vault naming, slot map, literal app settings
+- [indexing-app-insights-queries.md](indexing-app-insights-queries.md) — KQL validation at 06:00 / 18:00 UTC
+- [interim-deployment.md](interim-deployment.md) — local deploy when GitHub Actions is offline
+
+---
+
+## Architecture (reminder)
+
+```
+Pacific quota day
+    │
+    ▼
+Single flat indexer key ring (slots 1–4, 8–11, 13–16 — config order, deduped)
+    │  persisted ring position; hour spread fallback when no state
+    ▼
+YouTube enabled when hour % 6 == 0  →  00, 06, 12, 18 UTC
+    │
+    ├─ Passes 1–2 at 00 / 12 UTC
+    └─ Passes 3–4 at 06 / 18 UTC
+```
+
+- **Ring exhaustion:** if all keys are exhausted, later passes may run with `skip-youtube='True'`.
+- **Runtime config:** app reads **literal** `youtube__Applications__*` strings from app settings only — never Key Vault.
+
+---
+
+## 1. Prerequisites
+
+- [ ] `az login` and subscription **Cultpodcasts**
+- [ ] Google Cloud API keys for indexer ring slots **13** and **15** (DisplayNames `Indexer-Key-09`, `Indexer-Key-11`)
+- [ ] Key Vault `cultpodcasts-deployment` has `Youtube-ApiKey-15` and `Youtube-ApiKey-16` (deploy-time source)
+- [ ] Literal key strings ready for app settings
+- [ ] Target: **`indexer-infra`** (RG `AutomatedInfra`)
+
+**Do not** set `@Microsoft.KeyVault(...)` reference URIs on YouTube app settings.
+
+---
+
+## 2. App settings
+
+### Sync DisplayNames on all three function apps
+
+```powershell
+.\scripts\apply-youtube-keys.ps1 -DisplayNamesOnly
+```
+
+Indexer DisplayNames are `Indexer-Key-01-CultPodcasts` through `Indexer-Key-12-CultPodcasts` (flat ring — no Reattempt field).
+
+### Apply keys (if needed)
+
+```powershell
+.\scripts\apply-youtube-keys.ps1 -FromKeyVault
+```
+
+Or manual slot 13/15 update — see [youtube-keys.md § Step 2](youtube-keys.md#step-2--apply-to-live-function-apps-bicep-deploy-offline).
+
+Checklist:
+
+- [ ] Slots 13 and 15 `ApiKey` are **literal** `AIza...` strings
+- [ ] Slots 13 and 15 `Name` = `cultpodcasts` (lowercase)
+- [ ] All indexer slots use `Indexer-Key-NN-CultPodcasts` DisplayNames
+- [ ] App restarted after settings change
+
+---
+
+## 3. Deploy indexer code
+
+```powershell
+.\scripts\deploy-indexer.ps1
+```
+
+Deploy scripts do **not** change app settings.
+
+---
+
+## 4. Verify — 06:00 or 18:00 UTC window
+
+See [indexing-app-insights-queries.md](indexing-app-insights-queries.md) for full KQL.
+
+| Step | What to confirm |
+|------|-----------------|
+| Timer fired | `RunHourly initiated hour-utc='6'` or `'18'` |
+| Pass selection | `youtube-enabled-hour='True'` on YouTube hours |
+| Key ring | No sustained `ring exhausted`; rotation only if quota hit |
+| Batch 4 | `skip-youtube='False'`, `success='True'` |
+
+---
+
+## 5. Quota report — 06:55 UTC
+
+Daily `YouTubeQuotaReport` timer flushes prior Pacific quota day to Cosmos `LookUps`.
+
+```powershell
+$yesterday = (Get-Date).ToUniversalTime().AddDays(-1).ToString("yyyy-MM-dd")
+.\scripts\query-cosmos-lookups.ps1 -Query QuotaReport -ReportDate $yesterday
+```
+
+---
+
+## 6. Order of operations
+
+1. Prerequisites — login, keys in hand
+2. **App settings** — DisplayNames (`-DisplayNamesOnly`) and keys if needed
+3. **Deploy indexer code**
+4. Wait for YouTube window (06:00 or 18:00 UTC)
+5. Validate indexing (§4)
+6. Next 06:55 UTC — confirm quota report in Cosmos
+
+---
+
+## 7. Rollback
+
+| Layer | Rollback |
+|-------|----------|
+| **Code** | Redeploy previous package via `deploy-indexer.ps1` |
+| **App settings** | Restore prior ApiKey / DisplayName values via Portal or `az` |
+| **Cosmos state** | `YouTubeIndexerKeyState` is forward-compatible; delete only for intentional ring reset |
+
+---
+
+## Future — when bicep provision works
+
+Ensure KV has all secrets; run `functions.bicep` provision. Bicep writes literal keys and flat `Indexer-Key-NN` DisplayNames automatically.

--- a/docs/indexing-app-insights-queries.md
+++ b/docs/indexing-app-insights-queries.md
@@ -1,0 +1,850 @@
+# Indexing diagnostics — App Insights / Log Analytics KQL
+
+Operational query reference for diagnosing scheduled indexing failures on **`indexer-infra`**, especially **06:00 / 18:00 UTC** YouTube windows (batches 3–4) and the **Jakub Jahl** case study.
+
+**Related:** [indexing-investigation-jun2026.md](../indexing-investigation-jun2026.md) — full decision tree, Cosmos checks, deploy notes.
+
+| Field | Value |
+|-------|-------|
+| Log Analytics workspace | `loganalytics-infra` |
+| Workspace ID | `2b1c62ee-689f-422a-816b-be1605ae88fa` |
+| Function app / role | `indexer-infra` (`AppRoleName` / `cloud_RoleName`) |
+| App Insights resource | `ai-infra` (RG `AutomatedInfra`) |
+| App Insights application ID | `9005e913-7271-45e9-8358-4b3177d0b56d` |
+| Example indexer pass `operation_Id` | `5289449922f7727fbc0d998274a780a9` (batch 4, 2026-06-19 ~18:00 UTC) |
+| Jakub Jahl podcast ID | `8a0c0f4e-79e0-4d87-bcd5-2156fc0d2f9e` |
+
+---
+
+## Prerequisites
+
+```powershell
+az login
+az account set --subscription "Cultpodcasts"   # a6b8f1a2-6163-41bc-aa6d-e33928939a6e
+```
+
+### az CLI — Log Analytics workspace (preferred for this repo)
+
+```powershell
+$workspaceId = "2b1c62ee-689f-422a-816b-be1605ae88fa"
+
+$query = @'
+AppTraces
+| where TimeGenerated > ago(24h)
+| where AppRoleName == "indexer-infra"
+| where Message has "RunHourly"
+| project TimeGenerated, Message
+| order by TimeGenerated desc
+| take 20
+'@
+
+az monitor log-analytics query `
+  -w $workspaceId `
+  --analytics-query $query `
+  -o json
+```
+
+Single-line variant:
+
+```powershell
+az monitor log-analytics query -w 2b1c62ee-689f-422a-816b-be1605ae88fa --analytics-query "AppTraces | where TimeGenerated > ago(24h) | where AppRoleName == 'indexer-infra' | where Message has 'RunHourly' | project TimeGenerated, Message | take 10"
+```
+
+### az CLI — Application Insights (classic table names)
+
+```powershell
+$appId = "9005e913-7271-45e9-8358-4b3177d0b56d"
+
+az monitor app-insights query `
+  --app $appId `
+  --analytics-query "traces | where timestamp > ago(24h) | where cloud_RoleName == 'indexer-infra' | take 10" `
+  --offset 24h `
+  -o json
+```
+
+### Table / column cheat sheet
+
+| Log Analytics workspace | Application Insights (classic) |
+|-------------------------|--------------------------------|
+| `AppTraces` | `traces` |
+| `TimeGenerated` | `timestamp` |
+| `Message` | `message` |
+| `AppRoleName` | `cloud_RoleName` |
+| `OperationId` | `operation_Id` |
+| `SeverityLevel` (3 = Warning) | `severityLevel` (2 = Warning) |
+
+**Production note:** `RedditPodcastPoster` namespaces log at **Warning** in production for cost control. Diagnostic logs added for indexing investigation are **Warning-level** and queryable without lowering filters. Older Information-level strings (`BuildIndexerKeyRing`, `Indexer pass N indexing-context`) may be absent in live telemetry.
+
+---
+
+## Warning-level diagnostic log catalog
+
+Deployed or pending (diagnostic logging work — `HourlyOrchestration`, `OrchestrationTrigger`, `Indexer`, `IndexIdProvider`, `PodcastsUpdater`, `YouTubeEpisodeRetrievalHandler`):
+
+| Message prefix | Emitted by | Use |
+|----------------|------------|-----|
+| `OrchestrationTrigger RunHourly initiated` | `OrchestrationTrigger` | Timer fired at top of hour |
+| `OrchestrationTrigger hourly-scheduled` | `OrchestrationTrigger` | Durable instance scheduled (`trigger`, `hour-utc`, `instance-id`) |
+| `RunHourly skipped. Existing 'HourlyOrchestration' instance` | `OrchestrationTrigger` | Overlap — hourly skipped |
+| `HourlyOrchestration pass-selection` | `HourlyOrchestration` | `first-pass`, `last-pass`, `youtube-enabled-hour` |
+| `HourlyOrchestration indexer-operation-ids` | `HourlyOrchestration` | Maps pass 1–4 → `operation_Id` for deep-dive |
+| `HourlyOrchestration indexer-pass-complete` | `HourlyOrchestration` | Per-pass rollup: `success`, `skip-youtube`, `youtube-error` |
+| `HourlyOrchestration batch-4-rollup` | `HourlyOrchestration` | Batch 4 only — same fields as pass-complete |
+| `IndexerPassStart` / `IndexerPassComplete` | `Indexer` activity | Pass start/end with `operation-id`, YouTube flags |
+| `IndexerCostProbe.Update` | `Indexer` activity | `update-ms` for batch duration |
+| `IndexIdProvider batch-4-summary` | `IndexIdProvider` | Podcast count in batch 4 |
+| `YouTubeDiscoveryPath` | `YouTubeEpisodeRetrievalHandler` | Warning when YouTube-authority; Info otherwise |
+| `YouTubeAuthorityPodcastAudit` | `PodcastsUpdater` | Per YouTube-authority podcast |
+| `YouTubeAuthorityIndexingAudit` | `PodcastsUpdater` | Batch-level YouTube-authority summary |
+
+Jakub Jahl is **usually not** YouTube-authority (Spotify/Apple discovery). For Jakub, prefer `Batch 4:` membership, podcast name logs, and `YouTubeDiscoveryPath` at Info level.
+
+---
+
+## 1. Quick start — verify 06:00 / 18:00 run fired
+
+YouTube-enabled scheduled indexing for **batch 4** runs only when **passes 3–4** execute at **06:00 or 18:00 UTC** (`hour % 6 == 0`).
+
+### A. Timer + orchestration scheduled (last 24h)
+
+**Log Analytics:**
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(24h)
+| where AppRoleName == "indexer-infra"
+| where Message has "OrchestrationTrigger RunHourly initiated"
+    or Message has "OrchestrationTrigger hourly-scheduled"
+    or Message has "HourlyOrchestration.RunAsync initiated"
+| extend hourUtc = hourofday(TimeGenerated)
+| project TimeGenerated, hourUtc, Message
+| order by TimeGenerated desc
+```
+
+**Application Insights:**
+
+```kusto
+traces
+| where timestamp > ago(24h)
+| where cloud_RoleName == "indexer-infra"
+| where message has "RunHourly initiated"
+    or message has "hourly-scheduled"
+    or message has "HourlyOrchestration.RunAsync initiated"
+| extend hourUtc = hourofday(timestamp)
+| project timestamp, hourUtc, message
+| order by timestamp desc
+```
+
+### B. Pass selection at 06 / 18 (new Warning logs)
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(48h)
+| where AppRoleName == "indexer-infra"
+| where Message has "HourlyOrchestration pass-selection"
+| extend hourUtc = toint(extract(@"hour-utc='(\d+)'", 1, Message))
+| extend firstPass = extract(@"first-pass='(\d+)'", 1, Message)
+| extend lastPass = extract(@"last-pass='(\d+)'", 1, Message)
+| extend youtubeEnabled = extract(@"youtube-enabled-hour='(True|False)'", 1, Message)
+| where hourUtc in (6, 18)
+| project TimeGenerated, hourUtc, firstPass, lastPass, youtubeEnabled, Message
+| order by TimeGenerated desc
+```
+
+**Expect at 06/18:** `first-pass='3'`, `last-pass='4'`, `youtube-enabled-hour='True'`.
+
+Legacy fallback (if Warning logs not yet deployed):
+
+```kusto
+traces
+| where timestamp > ago(48h)
+| where cloud_RoleName == "indexer-infra"
+| where message has "Selected indexer passes 3-4"
+| where hourofday(timestamp) in (6, 18)
+| project timestamp, message
+| order by timestamp desc
+```
+
+### C. Daily count — orchestrations per hour (miss detection)
+
+```kusto
+traces
+| where timestamp > ago(7d)
+| where cloud_RoleName == "indexer-infra"
+| where message has "HourlyOrchestration.RunAsync initiated"
+| extend hour = hourofday(timestamp)
+| summarize count() by bin(timestamp, 1d), hour
+| order by timestamp desc, hour asc
+```
+
+Expect **one** `HourlyOrchestration` per UTC hour (24/day). Gaps at 06 or 18 → check section 5 (timer / catch-up / cold start).
+
+### D. Narrow time window (example: 2026-06-19 18:00 UTC)
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-19T17:58:00Z) .. datetime(2026-06-19T18:05:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "RunHourly"
+    or Message has "pass-selection"
+    or Message has "Selected indexer passes 3-4"
+    or Message has "batch-4-rollup"
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+---
+
+## 2. Single operation deep-dive (`operation_Id`)
+
+Each indexer pass gets a durable `operation_Id`. Example **batch 4 pass** from 2026-06-19 ~18:00 UTC:
+
+`5289449922f7727fbc0d998274a780a9`
+
+### A. Resolve pass operation IDs from orchestration (new Warning logs)
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-19T17:58:00Z) .. datetime(2026-06-19T18:30:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "HourlyOrchestration indexer-operation-ids"
+| project TimeGenerated, Message
+```
+
+Parse: `pass-4='{operation_Id}'`.
+
+### B. All telemetry for one `operation_Id`
+
+**Log Analytics:**
+
+```kusto
+let op = "5289449922f7727fbc0d998274a780a9";
+union AppTraces, AppRequests, AppDependencies, AppExceptions
+| where OperationId == op
+| project TimeGenerated, ItemType, SeverityLevel, Message = coalesce(Message, Name), ResultCode, DurationMs
+| order by TimeGenerated asc
+```
+
+**Application Insights:**
+
+```kusto
+let op = "5289449922f7727fbc0d998274a780a9";
+union traces, requests, dependencies, exceptions
+| where operation_Id == op
+| project timestamp, itemType, severityLevel, message = coalesce(message, name), resultCode, duration
+| order by timestamp asc
+```
+
+### C. Warning diagnostics only (indexer pass timeline)
+
+```kusto
+let op = "5289449922f7727fbc0d998274a780a9";
+AppTraces
+| where OperationId == op
+| where SeverityLevel >= 3
+    or Message has "IndexerPass"
+    or Message has "IndexerCostProbe"
+    or Message has "YouTubeDiscoveryPath"
+    or Message has "YouTubeAuthority"
+    or Message has "BuildIndexerKeyRing"
+    or Message has "Rotate indexer"
+    or Message has "quota"
+    or Message has "Jakub"
+    or Message has "8a0c0f4e"
+| project TimeGenerated, SeverityLevel, Message
+| order by TimeGenerated asc
+```
+
+### D. Pass 4 rollup vs activity logs
+
+```kusto
+let op = "5289449922f7727fbc0d998274a780a9";
+AppTraces
+| where TimeGenerated between (datetime(2026-06-19T17:58:00Z) .. datetime(2026-06-19T18:30:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has op
+    or Message has "batch-4-rollup"
+    or Message has "IndexerPassComplete"
+| where Message has "pass='4'" or Message has "pass-4" or Message has op
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+**Healthy pass 4 at 18:00 UTC:** `IndexerPassStart` with `skip-youtube='False'`, `IndexerPassComplete` with `success='True'`, `batch-4-rollup` with `skip-youtube='False'`, `youtube-error='False'`.
+
+---
+
+## 3. Batch 4 / Jakub
+
+### A. Batch 4 membership (podcast in pool)
+
+```kusto
+let podcastId = "8a0c0f4e-79e0-4d87-bcd5-2156fc0d2f9e";
+AppTraces
+| where TimeGenerated > ago(7d)
+| where AppRoleName == "indexer-infra"
+| where Message has "Batch 4:" and Message has podcastId
+| project TimeGenerated, Message
+| order by TimeGenerated desc
+| take 5
+```
+
+### B. Batch 4 rollup (new Warning log)
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(48h)
+| where AppRoleName == "indexer-infra"
+| where Message has "HourlyOrchestration batch-4-rollup"
+| extend hourUtc = toint(extract(@"hour-utc='(\d+)'", 1, Message))
+| extend success = extract(@"success='(True|False)'", 1, Message)
+| extend skipYouTube = extract(@"skip-youtube='(True|False)'", 1, Message)
+| extend youtubeError = extract(@"youtube-error='(True|False)'", 1, Message)
+| extend operationId = extract(@"operation-id='([^']+)'", 1, Message)
+| project TimeGenerated, hourUtc, success, skipYouTube, youtubeError, operationId, Message
+| order by TimeGenerated desc
+```
+
+### C. Jakub — broad pass-4 window search
+
+Czech characters can break `has` filters; use podcast ID and partial name:
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-19T18:00:00Z) .. datetime(2026-06-19T18:02:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "8a0c0f4e"
+    or Message has "Jakub"
+    or Message has "Batch 4"
+    or Message has "pass 4"
+    or Message has "youTubeRefreshed"
+    or Message has "skip-youtube"
+    or Message has "BuildIndexerKeyRing"
+    or Message has "Rotate indexer"
+    or Message has "RunAsync Completed. Pass: 4"
+| project TimeGenerated, OperationId, Message
+| order by TimeGenerated asc
+```
+
+### D. `YouTubeDiscoveryPath` (YouTube-authority podcasts)
+
+Warning level when `DependsOnYouTubeForEpisodeDiscovery()` is true:
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(48h)
+| where AppRoleName == "indexer-infra"
+| where Message has "YouTubeDiscoveryPath"
+| extend podcastId = extract(@"podcast-id='([^']+)'", 1, Message)
+| extend path = extract(@"path='([^']+)'", 1, Message)
+| extend skipYouTube = extract(@"skip-youtube='(True|False)'", 1, Message)
+| project TimeGenerated, podcastId, path, skipYouTube, Message
+| order by TimeGenerated desc
+```
+
+For Jakub (non-authority), same string may appear at **Info** — query without `SeverityLevel` filter or use podcast ID:
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(48h)
+| where Message has "YouTubeDiscoveryPath"
+| where Message has "8a0c0f4e"
+| project TimeGenerated, Message
+| order by TimeGenerated desc
+```
+
+### E. `YouTubeAuthorityPodcastAudit` (authority pool only)
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(7d)
+| where Message has "YouTubeAuthorityPodcastAudit"
+| where Message has "8a0c0f4e-79e0-4d87-bcd5-2156fc0d2f9e"
+| project TimeGenerated, Message
+| order by TimeGenerated desc
+```
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(24h)
+| where Message has "YouTubeAuthorityIndexingAudit"
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+### F. Indexer pass 4 context (legacy Information log)
+
+```kusto
+traces
+| where timestamp > ago(48h)
+| where cloud_RoleName == "indexer-infra"
+| where message has "Indexer pass 4 indexing-context"
+| extend bypassYouTube = extract(@"bypass-youtube: '(True|False)'", 1, message)
+| where hourofday(timestamp) in (6, 18)
+| project timestamp, bypassYouTube, message
+| order by timestamp desc
+```
+
+---
+
+## 4. Key rotation — `BuildIndexerKeyRing`, `Rotate indexer api-key`
+
+Indexer YouTube calls use a **key ring** persisted in Cosmos (`YouTubeIndexerKeyState`). Rotation happens on quota exhaustion.
+
+### A. Key ring build + rotation in a time window
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-19T17:50:00Z) .. datetime(2026-06-19T18:30:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "BuildIndexerKeyRing"
+    or Message has "Rotate indexer api-key"
+    or Message has "Obtained api-key"
+    or Message has "Persisted YouTube indexer key state"
+    or Message has "Resuming YouTube indexer key ring"
+    or Message has "quota exhausted"
+    or Message has "Exceeded Quota"
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+### B. Scoped to indexer pass `operation_Id`
+
+```kusto
+let op = "5289449922f7727fbc0d998274a780a9";
+AppTraces
+| where OperationId == op
+| where Message has "BuildIndexerKeyRing"
+    or Message has "Rotate indexer"
+    or Message has "SkipYouTubeUrlResolving"
+    or Message has "quota"
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+### C. YouTube flags during 18:00 window
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-19T17:58:00Z) .. datetime(2026-06-19T18:15:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "BuildIndexerKeyRing"
+    or Message has "Rotate indexer api-key"
+    or Message has "TolerantYouTube"
+    or Message has "skip-youtube"
+    or Message has "bypass-youtube"
+    or Message has "youTubeRefreshed"
+    or Message has "SkipYouTubeUrlResolving"
+    or Message has "quota exhausted"
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+**Red flag:** `Rotate indexer api-key` repeated until ring exhausted, then `SkipYouTubeUrlResolving` / `youtube-error='True'` on batch rollup.
+
+---
+
+## 5. Timer reliability — `RunHourly`, `HourlyCatchUp`, cold starts
+
+| Function | Schedule | Role |
+|----------|----------|------|
+| `Hourly` (`RunHourly`) | `0 */1 * * *` (top of each UTC hour) | Start `HourlyOrchestration` if none active |
+| `HourlyCatchUp` (`RunHourlyCatchUp`) | `0 5 * * * *` (minute 5 each hour) | Schedule missed hour if no instance for current hour |
+| `HalfHourly` | `30 */1 * * *` | Separate half-hourly orchestration |
+
+### A. RunHourly timeline (today)
+
+```kusto
+traces
+| where timestamp > datetime(2026-06-19T00:00:00Z)
+| where cloud_RoleName == "indexer-infra"
+| where message has "RunHourly"
+| project timestamp, message
+| order by timestamp asc
+```
+
+### B. Skipped / catch-up / schedule failures
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(48h)
+| where AppRoleName == "indexer-infra"
+| where Message has "RunHourly skipped"
+    or Message has "RunHourlyCatchUp scheduling missed"
+    or Message has "RunHourlyCatchUp skipped"
+    or Message has "Failure to execute" and Message has "HourlyOrchestration"
+| project TimeGenerated, Message
+| order by TimeGenerated desc
+```
+
+### C. Cold start / host lock (18:00 miss pattern)
+
+Long gap between `RunHourly initiated` and `HourlyOrchestration.RunAsync initiated` often indicates **cold start** or **host lock lease** delay:
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-19T17:58:00Z) .. datetime(2026-06-19T18:05:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "Host started"
+    or Message has "Initializing"
+    or Message has "Loading functions metadata"
+    or Message has "Host lock lease acquired"
+    or Message has "RunHourly"
+    or Message has "HourlyOrchestration"
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+### D. Full 18:00 timeline (host + orchestration + batch 4)
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-19T17:50:00Z) .. datetime(2026-06-19T18:30:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "RunHourly"
+    or Message has "HourlyOrchestration"
+    or Message has "Selected indexer passes"
+    or Message has "Host started"
+    or Message has "Host lock lease"
+    or Message has "BuildIndexerKeyRing"
+    or Message has "Rotate indexer"
+    or Message has "Indexer pass"
+    or Message has "Batch 4:"
+    or Message has "8a0c0f4e"
+    or Message has "Jakub Jahl"
+    or Message has "SkipYouTube"
+    or Message has "quota"
+    or Message has "bypass-youtube"
+    or Message has "batch-4-rollup"
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+---
+
+## 6. Quota report — Cosmos + flush logs at 06:55 UTC
+
+`YouTubeQuotaReport` timer runs **06:55 UTC daily** (`0 55 6 * * *`). Flushes prior Pacific quota day to Cosmos **`LookUps`** container (`type = 'YouTubeQuotaReport'`).
+
+### A. Flush confirmation in logs
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(7d)
+| where AppRoleName == "indexer-infra"
+| where Message has "Flushing YouTube quota usage report"
+    or Message has "Saved YouTube quota report"
+| project TimeGenerated, Message
+| order by TimeGenerated desc
+```
+
+The `Saved YouTube quota report` line includes report-level counters: `podcastsNotIndexedDueToQuota`, `podcastsNotEnrichedDueToQuota`, `ringExhaustionCount`, `nonQuotaErrorCount` (see section 6D for Cosmos field definitions).
+
+### B. Quota / bypass signals near YouTube hours
+
+```kusto
+traces
+| where timestamp > ago(72h)
+| where cloud_RoleName == "indexer-infra"
+| where message has "SkipYouTubeUrlResolving"
+    or message has "YouTubeQuota"
+    or message has "quota exhausted"
+    or message has "Exceeded Quota"
+| project timestamp, message
+| order by timestamp desc
+| take 50
+```
+
+### C. 06:00 UTC pass quota context
+
+```kusto
+traces
+| where timestamp between (datetime(2026-06-19T06:00:00Z) .. datetime(2026-06-19T06:30:00Z))
+| where cloud_RoleName == "indexer-infra"
+| where message has "SkipYouTubeUrlResolving"
+    or message has "quota"
+    or message has "YouTubeQuota"
+    or message has "bypass-youtube: 'False'"
+| project timestamp, message
+| order by timestamp asc
+```
+
+### D. Cosmos — daily quota report document
+
+**Cosmos targets:** account `cultpodcasts-db`, RG `AutomatedData`, database `cultpodcasts-db`, container **`LookUps`**, document `type = 'YouTubeQuotaReport'`.
+
+Azure CLI has **no** `az cosmosdb sql query` (control plane only). Use **Cosmos DB Shell** or [`scripts/query-cosmos-lookups.ps1`](../scripts/query-cosmos-lookups.ps1).
+
+**Cosmos DB Shell** (after `dotnet tool install --global CosmosDBShell --prerelease` and `az login`):
+
+```powershell
+$yesterday = (Get-Date).ToUniversalTime().AddDays(-1).ToString("yyyy-MM-dd")
+
+cosmosdbshell --connect https://cultpodcasts-db.documents.azure.com:443/ `
+  --connect-subscription a6b8f1a2-6163-41bc-aa6d-e33928939a6e `
+  --connect-resource-group AutomatedData `
+  -c "cd cultpodcasts-db/LookUps; query `"SELECT TOP 1 c.id, c.reportDate, c.sourceApplication, c.podcastsNotIndexedDueToQuota, c.podcastsNotEnrichedDueToQuota, c.ringExhaustionCount, c.nonQuotaErrorCount, c.keys FROM c WHERE c.type = 'YouTubeQuotaReport' AND c.reportDate = '$yesterday' AND c.sourceApplication = 'Indexer' ORDER BY c._ts DESC`""
+```
+
+**Script:**
+
+```powershell
+.\scripts\query-cosmos-lookups.ps1 -Query QuotaReport -ReportDate $yesterday
+```
+
+**Report-level counters** (Pacific quota day rollup):
+
+| Field | Meaning |
+|-------|---------|
+| `podcastsNotIndexedDueToQuota` | Podcasts skipped for indexing when the key ring was exhausted |
+| `podcastsNotEnrichedDueToQuota` | Podcasts indexed but YouTube enrichment skipped due to quota |
+| `ringExhaustionCount` | Times the indexer key ring was fully exhausted |
+| `nonQuotaErrorCount` | YouTube API failures not attributed to quota (auth, 5xx, etc.) |
+
+**Per-key stats** (`keys[]`, `usedIndexerKeys[]`, `unusedIndexerKeys[]`):
+
+| Field | Meaning |
+|-------|---------|
+| `quotaHits` | API responses indicating quota exhaustion |
+| `quotaUsed` | Quota units charged by Google (when reported) |
+| `estimatedQuotaUsed` | Estimated units consumed from operation counts × per-call costs |
+| `quotaConsumedByOperation` | Breakdown: `searchList`, `channelsList`, `playlistItemsList`, `playlistsList`, `videosList` |
+| `dailyLimit` | Configured daily limit for the key (typically 10,000) |
+| `capacityHint` | `quota-exhausted` vs `spare-capacity-candidate` |
+
+Compare `estimatedQuotaUsed` to `dailyLimit` for headroom. High `ringExhaustionCount` or `podcastsNotIndexedDueToQuota` on a report day correlates with batch 3–4 `skip-youtube='True'` / `youtube-error='True'` rollups (sections 4, 8).
+
+### E. Cosmos — indexer key ring state
+
+**Cosmos DB Shell:**
+
+```powershell
+cosmosdbshell --connect https://cultpodcasts-db.documents.azure.com:443/ `
+  --connect-subscription a6b8f1a2-6163-41bc-aa6d-e33928939a6e `
+  --connect-resource-group AutomatedData `
+  -c "cd cultpodcasts-db/LookUps; query `"SELECT TOP 1 * FROM c WHERE c.type = 'YouTubeIndexerKeyState' ORDER BY c._ts DESC`""
+```
+
+**Script:**
+
+```powershell
+.\scripts\query-cosmos-lookups.ps1 -Query IndexerKeyState
+```
+
+---
+
+## 7. Tomorrow morning checklist — 06:00 UTC validation (Jun 20, 2026)
+
+Run after **~06:10 UTC** (allow orchestration + batch 4 to finish). Replace date literals with the validation day if needed.
+
+### Step 1 — Timer fired
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-20T05:58:00Z) .. datetime(2026-06-20T06:10:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "RunHourly initiated" or Message has "hourly-scheduled"
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+- [ ] `RunHourly initiated hour-utc='6'`
+- [ ] `hourly-scheduled trigger='RunHourly' hour-utc='6'`
+- [ ] No `RunHourly skipped` (unless prior hour still running — then check `HourlyCatchUp` at :05)
+
+### Step 2 — Passes 3–4 + YouTube enabled
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-20T05:58:00Z) .. datetime(2026-06-20T06:45:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "pass-selection" or Message has "batch-4-rollup"
+| project TimeGenerated, Message
+| order by TimeGenerated asc
+```
+
+- [ ] `first-pass='3'`, `last-pass='4'`, `youtube-enabled-hour='True'`
+- [ ] `batch-4-rollup` with `skip-youtube='False'`, `success='True'`, `youtube-error='False'`
+- [ ] Note `operation-id` from `batch-4-rollup` for deep-dive if failed
+
+### Step 3 — Jakub indexed
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-20T05:58:00Z) .. datetime(2026-06-20T06:45:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "8a0c0f4e" or Message has "Jakub Jahl"
+| project TimeGenerated, OperationId, Message
+| order by TimeGenerated asc
+```
+
+- [ ] `Podcast: 'Jakub Jahl` / `IndexPodcastResult` with added or enriched episodes
+- [ ] `YouTubeDiscoveryPath` for podcast-id (Info or Warning)
+
+### Step 4 — Cosmos ground truth
+
+Use Cosmos DB Shell or the repo script (not `az cosmosdb sql query` — see section 6D).
+
+```powershell
+.\scripts\query-cosmos-lookups.ps1 -Query Podcast
+.\scripts\query-cosmos-lookups.ps1 -Query Episodes
+```
+
+Or **Cosmos DB Shell** interactively:
+
+```
+CS> cd cultpodcasts-db/Podcasts
+CS cultpodcasts-db/Podcasts> query "SELECT c.id, c.name, c.lastIndexed, c.latestReleased FROM c WHERE c.id = '8a0c0f4e-79e0-4d87-bcd5-2156fc0d2f9e'"
+
+CS> cd cultpodcasts-db/Episodes
+CS cultpodcasts-db/Episodes> query "SELECT c.id, c.title, c.release, c.urls FROM c WHERE c.podcastId = '8a0c0f4e-79e0-4d87-bcd5-2156fc0d2f9e' AND (CONTAINS(c.urls.youTube, 'hh4MIFHUzRM') OR CONTAINS(c.urls.youTube, 'wuSWvcS2Yfo')) ORDER BY c.release DESC"
+```
+
+- [ ] `lastIndexed` within ~15 min of 06:00 UTC run
+- [ ] Target episodes have `urls.youTube` populated
+
+### Step 5 — If failed, branch quickly
+
+| Symptom | Next query / action |
+|---------|---------------------|
+| No `RunHourly` at 06:00 | Section 5C cold start; check Function App health / deployment |
+| `RunHourly skipped` | Prior orchestration still running — find stuck instance |
+| `skip-youtube='True'` at 06:00 | Section 4 key rotation / quota exhaustion |
+| Batch 4 ran, no Jakub logs | Section 3A batch membership |
+| Jakub logs, no YouTube URLs | Section 2 on pass-4 `operation_Id`; verify Fix 2 deployed |
+| `youtube-error='True'` on rollup | Section 4 + 6 quota report |
+
+### Step 6 — 06:55 quota flush (same morning)
+
+After 06:55 UTC, confirm prior day report saved (Section 6A) before concluding quota exhaustion.
+
+---
+
+## 8. Key ring exhaustion — day-by-day comparison
+
+Indexer YouTube uses a **Cosmos-persisted key ring** (`YouTubeIndexerKeyState`) that **resumes within the same Pacific quota day**. Exhaustion at **12:00 UTC** (passes 1–2) leaves **18:00 UTC** (passes 3–4) with no keys. `Rotate indexer api-key` is **Information-level** and usually absent in production; use **`AppExceptions`** with `ring exhausted` and **`YouTubeAuthorityIndexingAudit`** instead.
+
+**YouTube windows:** hours **0 / 6 / 12 / 18 UTC** (`hour % 6 == 0`). Passes **1–2** at 0/12; passes **3–4** at 6/18.
+
+### A. Ring exhaustion heatmap (14d)
+
+```kusto
+AppExceptions
+| where TimeGenerated > ago(14d)
+| where AppRoleName == "indexer-infra"
+| where OuterMessage has "ring exhausted"
+| extend day = startofday(TimeGenerated)
+| extend hourUtc = hourofday(TimeGenerated)
+| summarize exceptions = count() by day, hourUtc
+| order by day desc, hourUtc asc
+```
+
+**Observed Jun 2026:** exhaustion only at **Jun 20 18:00** (135) and **Jun 24 12:00** (147) + **18:00** (136). All other days/hours in 14d: **zero** `ring exhausted` exceptions.
+
+### B. YouTube-window pass outcomes (Warning rollups)
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(14d)
+| where AppRoleName == "indexer-infra"
+| where Message has "HourlyOrchestration indexer-pass-complete"
+| extend hourUtc = toint(extract(@"hour-utc='(\d+)'", 1, Message))
+| extend pass = toint(extract(@"pass='(\d+)'", 1, Message))
+| extend skipYouTube = extract(@"skip-youtube='(True|False)'", 1, Message)
+| extend youtubeError = extract(@"youtube-error='(True|False)'", 1, Message)
+| extend podcastCount = extract(@"podcast-count='(\d+)'", 1, Message)
+| where hourUtc in (0, 6, 12, 18)
+| extend day = startofday(TimeGenerated)
+| project day, hourUtc, pass, skipYouTube, youtubeError, podcastCount, TimeGenerated
+| order by day desc, hourUtc asc, pass asc
+```
+
+### C. Authority bypass vs ring exhaustion (same window)
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(14d)
+| where AppRoleName == "indexer-infra"
+| where Message has "YouTubeAuthorityIndexingAudit"
+| extend hourUtc = hourofday(TimeGenerated)
+| extend day = startofday(TimeGenerated)
+| extend inBatch = toint(extract(@"in-batch='(\d+)'", 1, Message))
+| extend bypassed = toint(extract(@"youtube-bypassed='(\d+)'", 1, Message))
+| where hourUtc in (0, 6, 12, 18)
+| summarize totalInBatch = sum(inBatch), totalBypassed = sum(bypassed) by day, hourUtc
+| order by day desc, hourUtc asc
+```
+
+**Healthy:** `totalBypassed` ≪ `totalInBatch` (e.g. Jun 25 06:00 — 3/86). **Exhausted:** `totalBypassed == totalInBatch` (e.g. Jun 24 12:00 — 95/95; Jun 24 18:00 — 86/86).
+
+### D. Single evening window deep-dive (example: Jun 24 18:00 UTC)
+
+```kusto
+AppTraces
+| where TimeGenerated between (datetime(2026-06-24T17:55:00Z) .. datetime(2026-06-24T18:30:00Z))
+| where AppRoleName == "indexer-infra"
+| where Message has "pass-selection"
+    or Message has "indexer-operation-ids"
+    or Message has "indexer-pass-complete"
+    or Message has "batch-4-rollup"
+    or Message has "YouTubeAuthorityIndexingAudit"
+| project TimeGenerated, OperationId, Message
+| order by TimeGenerated asc
+```
+
+Jun 24 18:00 operation IDs: orchestration `8febe8aa2e19fdc545db0367df7eb3e6`; pass 3 `73d5717d-9ef1-5449-a7f6-6d2b218128e7`; pass 4 `4ed40d0f-ded2-5535-ac06-382ffa643ae6`.
+
+### E. Compare exhaustion day vs non-exhaustion day (exceptions)
+
+```kusto
+let exhaustedDay = datetime(2026-06-24);
+let healthyDay = datetime(2026-06-17);
+AppExceptions
+| where AppRoleName == "indexer-infra"
+| where startofday(TimeGenerated) in (exhaustedDay, healthyDay)
+| where hourofday(TimeGenerated) in (6, 18)
+| extend day = startofday(TimeGenerated)
+| extend hourUtc = hourofday(TimeGenerated)
+| summarize
+    ringExhausted = countif(OuterMessage has "ring exhausted"),
+    quotaForbidden = countif(OuterMessage has "Exceeded Quota" or OuterMessage has "exceeded your")
+  by day, hourUtc
+| order by day desc, hourUtc asc
+```
+
+### F. Pre-window depletion check (same Pacific day)
+
+Before blaming 18:00 alone, check whether **12:00** already exhausted the ring:
+
+```kusto
+AppExceptions
+| where AppRoleName == "indexer-infra"
+| where OuterMessage has "ring exhausted"
+| where startofday(TimeGenerated) == datetime(2026-06-24)
+| summarize count() by hourofday(TimeGenerated)
+| order by hourofday_TimeGenerated asc
+```
+
+Jun 24: **147 @ 12:00**, then **136 @ 18:00** — evening inherited a dead ring from the noon window.
+
+### G. az CLI one-liner (ring exhaustion heatmap)
+
+```powershell
+az monitor log-analytics query -w 2b1c62ee-689f-422a-816b-be1605ae88fa -t P14D --analytics-query "AppExceptions | where AppRoleName == 'indexer-infra' | where OuterMessage has 'ring exhausted' | extend day = startofday(TimeGenerated), hourUtc = hourofday(TimeGenerated) | summarize count() by day, hourUtc | order by day desc" -o json
+```
+
+**Note:** use **single-line** `--analytics-query` with `-t P14D`; multi-line heredocs can return unfiltered workspace noise.
+
+---
+
+## PowerShell helper — run a query file
+
+```powershell
+$workspaceId = "2b1c62ee-689f-422a-816b-be1605ae88fa"
+$query = Get-Content -Raw ".tmp-q18-batch4.kql"   # or paste from this doc
+az monitor log-analytics query -w $workspaceId --analytics-query $query -o json | Out-File .tmp-query-out.json
+```
+
+---
+
+*Created Jun 2026 for indexing investigation handoff.*

--- a/docs/youtube-keys.md
+++ b/docs/youtube-keys.md
@@ -1,0 +1,184 @@
+# YouTube API keys — storage, deploy, and local dev
+
+How YouTube Data API keys are named, stored, and applied across **Azure Key Vault** (deploy-time source), **Function app settings** (literal values at runtime), and **dotnet user-secrets** (local development).
+
+Canonical production layout: [`Infrastructure/functions.bicep`](../Infrastructure/functions.bicep) (`youtube` + `youTubeKeyUsage`).
+
+## Architecture — how keys flow
+
+```
+Key Vault (cultpodcasts-deployment)
+    │  deploy time only — functions.bicepparam reads via az.getSecret()
+    ▼
+functions.bicep @secure() params → literal app settings on Function apps
+    │  e.g. youtube__Applications__13__ApiKey = <actual key string>
+    ▼
+YouTubeSettings (IOptions) ← IConfiguration / app settings only
+```
+
+| Layer | Key Vault? | Notes |
+|-------|------------|-------|
+| `functions.bicep` | No references | `@secure()` params become **literal** app-setting values — not `@Microsoft.KeyVault(...)` URIs |
+| `functions.bicepparam` | Yes, deploy time | `az.getSecret()` reads KV during `az deployment` / GitHub Actions provision |
+| Application code | **Never** | `YouTubeSettings` binds from `youtube` configuration section only (`BindConfiguration<YouTubeSettings>("youtube")`) |
+| Interim manual apply | No | Set literal values on Function apps via portal, `az functionapp config appsettings set`, or `apply-youtube-keys.ps1` |
+
+Key Vault is the **authoritative secret store for deploy pipelines**. Storing keys there does **not** mean the running Function app resolves them from Key Vault — the app only sees whatever literal string is in its app settings.
+
+## Azure resources
+
+| Item | Value |
+|------|--------|
+| Key Vault | `cultpodcasts-deployment` |
+| Key Vault resource group | `Management` |
+| Function apps resource group | `AutomatedInfra` |
+| Function apps | `indexer-infra`, `discover-infra`, `api-infra` |
+
+Bicep reads secrets via `functions.bicepparam` using env vars `AZURE_KEYVAULT_NAME`, `MANAGEMENT_RESOURCEGROUP_NAME`, and `INPUT_SUBSCRIPTION-ID` (set in GitHub Actions `deploy.yml`).
+
+## Key Vault secret naming
+
+YouTube keys use **Pascal-case prefix** `Youtube-ApiKey-N` where `N` is the vault slot (0–16):
+
+| KV secret | Bicep param | App slot (`youtube__Applications__N__*`) | Role |
+|-----------|-------------|------------------------------------------|------|
+| `Youtube-ApiKey-0` … `Youtube-ApiKey-12` | `youTubeApiKey0` … `youTubeApiKey12` | 0–12 | Cli, Indexer ring, Discover, Bluesky, Api |
+| `Youtube-ApiKey-13` | `youTubeApiKey13` | *(legacy — no longer wired)* | Former legacy discover key; safe to leave in vault |
+| `Youtube-ApiKey-14` | `youTubeApiKey14` | 14, 16 | Indexer ring keys 10 and 12 (slot 16 dedupes with 14) |
+| **`Youtube-ApiKey-15`** | **`youTubeApiKey15`** | **13** | **Indexer ring key 09 (cultpodcasts project)** |
+| **`Youtube-ApiKey-16`** | **`youTubeApiKey16`** | **15** | **Indexer ring key 11 (cultpodcasts project)** |
+
+Slots 13 and 15 use lowercase **`cultpodcasts`** as the Google Cloud project id (`Name` field); other slots keep `CultPodcasts`.
+
+### DisplayName scheme (Indexer)
+
+All indexer keys form **one flat rotation ring**. Names are sequential by config slot order — there are no hour-window or reattempt tiers.
+
+| App slot | DisplayName | Ring order |
+|----------|-------------|------------|
+| 1–4 | `Indexer-Key-01` … `Indexer-Key-04` | 1–4 |
+| 8–11 | `Indexer-Key-05` … `Indexer-Key-08` | 5–8 |
+| 13 | `Indexer-Key-09-CultPodcasts` | 9 |
+| 14 | `Indexer-Key-10-CultPodcasts` | 10 |
+| 15 | `Indexer-Key-11-CultPodcasts` | 11 |
+| 16 | `Indexer-Key-12-CultPodcasts` | 12 (deduped if same ApiKey as slot 14) |
+
+At runtime the indexer walks this ring in config order (deduped by `ApiKey`), rotating on quota exhaustion. Session resume uses persisted `YouTubeIndexerKeyState`; when no state exists, start position spreads by UTC hour (`hour * ringCount / 24 % ringCount`).
+
+The `Reattempt` field on `Application` is unused for Indexer (kept in schema for backward compatibility).
+
+## Step 1 — Store keys in Key Vault (optional, for deploy pipeline)
+
+Store secrets in Key Vault so `functions.bicepparam` can read them when bicep deploy works again. This is **not** runtime resolution — it is the deploy-time source of truth.
+
+```powershell
+az login
+
+$vault = 'cultpodcasts-deployment'
+
+# Replace placeholders with API keys from Google Cloud Console
+az keyvault secret set --vault-name $vault --name 'Youtube-ApiKey-15' --value 'YOUR_KEY_FOR_INDEXER_KEY_09'
+az keyvault secret set --vault-name $vault --name 'Youtube-ApiKey-16' --value 'YOUR_KEY_FOR_INDEXER_KEY_11'
+```
+
+Verify:
+
+```powershell
+az keyvault secret list --vault-name cultpodcasts-deployment --query "[?starts_with(name, 'Youtube')].name" -o table
+```
+
+## Step 2 — Apply to live Function apps (bicep deploy offline)
+
+Set **literal** API key values on app settings. Do **not** use `@Microsoft.KeyVault(...)` reference URIs.
+
+### All three function apps — script (recommended)
+
+From repo root:
+
+```powershell
+# Full apply from Key Vault (keys + DisplayNames)
+.\scripts\apply-youtube-keys.ps1 -FromKeyVault
+
+# Display names only (no API key values)
+.\scripts\apply-youtube-keys.ps1 -DisplayNamesOnly
+```
+
+Legacy wrapper (same as `-DisplayNamesOnly`):
+
+```powershell
+.\scripts\apply-youtube-display-names.ps1
+```
+
+Each function app restarts after settings change.
+
+### indexer-infra — manual `az` (slots 13 and 15 only)
+
+```powershell
+az login
+
+$rg = 'AutomatedInfra'
+$app = 'indexer-infra'
+
+az functionapp config appsettings set `
+  --resource-group $rg `
+  --name $app `
+  --settings `
+    'youtube__Applications__13__ApiKey=YOUR_KEY' `
+    'youtube__Applications__13__Name=cultpodcasts' `
+    'youtube__Applications__13__DisplayName=Indexer-Key-09-CultPodcasts' `
+    'youtube__Applications__15__ApiKey=YOUR_KEY' `
+    'youtube__Applications__15__Name=cultpodcasts' `
+    'youtube__Applications__15__DisplayName=Indexer-Key-11-CultPodcasts'
+```
+
+## Step 3 — Local dotnet development (user-secrets)
+
+**Never put YouTube API keys in `local.settings.json`.** API keys belong in **dotnet user-secrets** (local) or **literal app settings** (Azure).
+
+All console apps and Cloud function projects share `UserSecretsId` **`e4eaaf12-4507-4875-857d-a8d4032107f3`**. For Indexer local runs, use:
+
+```powershell
+$proj = 'Cloud/Indexer/Indexer.csproj'
+```
+
+### Example — set cultpodcasts indexer keys
+
+```powershell
+$proj = 'Cloud/Indexer/Indexer.csproj'
+
+dotnet user-secrets set "youtube:Applications:13:ApiKey" "YOUR_KEY" --project $proj
+dotnet user-secrets set "youtube:Applications:13:Name" "cultpodcasts" --project $proj
+dotnet user-secrets set "youtube:Applications:13:DisplayName" "Indexer-Key-09-CultPodcasts" --project $proj
+
+dotnet user-secrets set "youtube:Applications:15:ApiKey" "YOUR_KEY" --project $proj
+dotnet user-secrets set "youtube:Applications:15:Name" "cultpodcasts" --project $proj
+dotnet user-secrets set "youtube:Applications:15:DisplayName" "Indexer-Key-11-CultPodcasts" --project $proj
+```
+
+## Step 4 — When bicep deploys work again
+
+No manual step if Key Vault already has all `Youtube-ApiKey-*` secrets. CI / `functions.bicep` provision writes literal values and flat `Indexer-Key-NN` DisplayNames.
+
+## Slot map (quick reference)
+
+```
+Slot  Usage      DisplayName
+----  ---------  ---------------------------
+0     Cli        ApiKey-0 - Cli
+1-4   Indexer    Indexer-Key-01 .. 04
+5-6   Discover   ApiKey-5/6 - Discover
+7     Bluesky    ApiKey-7 - Bluesky
+8-11  Indexer    Indexer-Key-05 .. 08
+12    Api        ApiKey-12 - Api
+13    Indexer    Indexer-Key-09  ← KV Youtube-ApiKey-15
+14    Indexer    Indexer-Key-10  ← KV Youtube-ApiKey-14
+15    Indexer    Indexer-Key-11  ← KV Youtube-ApiKey-16
+16    Indexer    Indexer-Key-12  ← KV Youtube-ApiKey-14 (shared)
+```
+
+## Related
+
+- [README — Configuration](../README.md#configuration)
+- [interim-deployment.md](interim-deployment.md) — when GitHub Actions / bicep provision is offline
+- [indexing-app-insights-queries.md](indexing-app-insights-queries.md) — indexer key ring telemetry
+- [indexer-youtube-go-live.md](indexer-youtube-go-live.md) — production go-live checklist

--- a/scripts/apply-youtube-display-names.ps1
+++ b/scripts/apply-youtube-display-names.ps1
@@ -1,0 +1,20 @@
+# Applies Indexer YouTube application DisplayName app settings on Function apps.
+# Use when Infrastructure/functions.bicep is not deploying.
+# Prefer apply-youtube-keys.ps1 -DisplayNamesOnly for the same behaviour.
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$ResourceGroup = 'AutomatedInfra',
+
+    [string[]]$FunctionApps = @('indexer-infra', 'discover-infra', 'api-infra')
+)
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$params = @{
+    ResourceGroup = $ResourceGroup
+    FunctionApps  = $FunctionApps
+    DisplayNamesOnly = $true
+}
+if ($PSCmdlet.ShouldProcess($FunctionApps -join ', ', 'Apply Indexer YouTube DisplayName app settings')) {
+    & "$scriptDir\apply-youtube-keys.ps1" @params
+}

--- a/scripts/apply-youtube-keys.ps1
+++ b/scripts/apply-youtube-keys.ps1
@@ -1,0 +1,402 @@
+# Applies YouTube API key app settings on Function apps when Infrastructure/functions.bicep is not deploying.
+# Mirrors youtube + youTubeKeyUsage (+ app-specific YouTube settings) in functions.bicep.
+#
+# App settings are written as literal key values. The running app reads configuration only
+# (YouTubeSettings via IConfiguration) — it never calls Key Vault.
+#
+# Full apply from Key Vault (recommended when bicep provision is offline):
+#   .\scripts\apply-youtube-keys.ps1 -FromKeyVault
+#
+# Interim flow (new indexer keys only):
+#   .\scripts\apply-youtube-keys.ps1 -ApiKey15 'YOUR_KEY' -ApiKey16 'YOUR_KEY' -ApplyNewKeysOnly
+#
+# Display names only (no key values); also clears stale Indexer __Reattempt keys:
+#   .\scripts\apply-youtube-keys.ps1 -DisplayNamesOnly
+
+[CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = 'FromKeyVault')]
+param(
+    [string]$ResourceGroup = 'AutomatedInfra',
+
+    [string[]]$FunctionApps = @('indexer-infra', 'discover-infra', 'api-infra'),
+
+    [string]$KeyVaultName = 'cultpodcasts-deployment',
+
+    [string]$KeyVaultResourceGroup = 'Management',
+
+    [Parameter(ParameterSetName = 'DisplayNamesOnly')]
+    [switch]$DisplayNamesOnly,
+
+    [Parameter(ParameterSetName = 'FromKeyVault')]
+    [switch]$FromKeyVault,
+
+    [Parameter(ParameterSetName = 'ManualKeys')]
+    [string]$ApiKey15,
+
+    [Parameter(ParameterSetName = 'ManualKeys')]
+    [string]$ApiKey16,
+
+    [Parameter(ParameterSetName = 'ManualKeys')]
+    [switch]$ApplyNewKeysOnly,
+
+    [switch]$SkipRestart
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    throw 'Azure CLI (az) was not found on PATH.'
+}
+
+$account = az account show --query name -o tsv 2>$null
+if (-not $account) {
+    throw 'Azure CLI is not logged in. Run az login first.'
+}
+
+# App slot -> Key Vault secret suffix (Youtube-ApiKey-N). Mirrors Infrastructure/functions.bicep youtube var.
+$slotToKvKey = @{
+    0  = 0
+    1  = 1
+    2  = 2
+    3  = 3
+    4  = 4
+    5  = 5
+    6  = 6
+    7  = 7
+    8  = 8
+    9  = 9
+    10 = 10
+    11 = 11
+    12 = 12
+    13 = 15
+    14 = 14
+    15 = 16
+    16 = 14
+}
+
+# Mirrors Infrastructure/functions.bicep youTubeKeyUsage.
+$youTubeKeyUsage = @{
+    0  = @{ Name = 'CultPodcasts'; Usage = 'Cli';      DisplayName = 'ApiKey-0 - Cli' }
+    1  = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-01-CultPodcasts' }
+    2  = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-02-CultPodcasts' }
+    3  = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-03-CultPodcasts' }
+    4  = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-04-CultPodcasts' }
+    5  = @{ Name = 'CultPodcasts'; Usage = 'Discover'; DisplayName = 'ApiKey-5 - Discover' }
+    6  = @{ Name = 'CultPodcasts'; Usage = 'Discover'; DisplayName = 'ApiKey-6 - Discover' }
+    7  = @{ Name = 'CultPodcasts'; Usage = 'Bluesky'; DisplayName = 'ApiKey-7 - Bluesky' }
+    8  = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-05-CultPodcasts' }
+    9  = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-06-CultPodcasts' }
+    10 = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-07-CultPodcasts' }
+    11 = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-08-CultPodcasts' }
+    12 = @{ Name = 'CultPodcasts'; Usage = 'Api';     DisplayName = 'ApiKey-12 - Api' }
+    13 = @{ Name = 'cultpodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-09-CultPodcasts' }
+    14 = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-10-CultPodcasts' }
+    15 = @{ Name = 'cultpodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-11-CultPodcasts' }
+    16 = @{ Name = 'CultPodcasts'; Usage = 'Indexer'; DisplayName = 'Indexer-Key-12-CultPodcasts' }
+}
+
+# Slots whose Usage is Indexer — Reattempt is unused (flat ring); remove stale keys on apply.
+$indexerSlots = @($youTubeKeyUsage.Keys | Where-Object { $youTubeKeyUsage[$_].Usage -eq 'Indexer' } | Sort-Object)
+
+function Get-IndexerReattemptSettingNames {
+    foreach ($slot in $indexerSlots) {
+        "youtube__Applications__${slot}__Reattempt"
+    }
+}
+
+function Get-KeyVaultYouTubeSecrets {
+    $secrets = @{}
+    $requiredKvKeys = 0..16
+    foreach ($kvKey in $requiredKvKeys) {
+        $secretName = "Youtube-ApiKey-$kvKey"
+        Write-Verbose "Reading Key Vault secret '$secretName'..."
+        $value = az keyvault secret show `
+            --vault-name $KeyVaultName `
+            --name $secretName `
+            --query value `
+            -o tsv 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($value)) {
+            throw "Failed to read Key Vault secret '$secretName' from vault '$KeyVaultName'."
+        }
+        $secrets[$kvKey] = $value
+    }
+    return $secrets
+}
+
+function Get-YouTubeApplicationsSettings {
+    param(
+        [hashtable]$KvSecrets,
+        [int[]]$Slots,
+        [switch]$IncludeApiKeys
+    )
+
+    $settings = [ordered]@{}
+    foreach ($slot in $Slots) {
+        $usage = $youTubeKeyUsage[$slot]
+        if (-not $usage) {
+            throw "No youTubeKeyUsage entry for slot $slot."
+        }
+
+        if ($IncludeApiKeys) {
+            $kvKey = $slotToKvKey[$slot]
+            if ($null -eq $kvKey) {
+                throw "No KV mapping for app slot $slot."
+            }
+            $settings["youtube__Applications__${slot}__ApiKey"] = $KvSecrets[$kvKey]
+        }
+
+        $settings["youtube__Applications__${slot}__Name"] = $usage.Name
+        $settings["youtube__Applications__${slot}__Usage"] = $usage.Usage
+        $settings["youtube__Applications__${slot}__DisplayName"] = $usage.DisplayName
+        # Indexer uses a flat key ring — never set Reattempt. Non-Indexer usages may define it.
+        if ($usage.Usage -ne 'Indexer' -and $usage.Reattempt) {
+            $settings["youtube__Applications__${slot}__Reattempt"] = $usage.Reattempt
+        }
+    }
+    return $settings
+}
+
+function Get-AppSpecificYouTubeSettings {
+    param([string]$AppName)
+
+    $settings = [ordered]@{
+        'delayedYouTubePublication__EvaluationThreshold' = '6:00:00'
+    }
+
+    switch ($AppName) {
+        'indexer-infra' {
+            $settings['indexer__ByPassYouTube'] = 'false'
+            $settings['youtubeChannel__PreferUploadsPlaylist'] = 'true'
+        }
+        'api-infra' {
+            $settings['indexer__ByPassYouTube'] = 'false'
+            $settings['youtubeChannel__PreferUploadsPlaylist'] = 'true'
+        }
+        'discover-infra' {
+            $settings['discover__IncludeYouTube'] = 'true'
+            $settings['discover__Queries__4__DiscoverService'] = 'YouTube'
+            $settings['discover__Queries__4__Term'] = 'Cult'
+            $settings['discover__Queries__5__DiscoverService'] = 'YouTube'
+            $settings['discover__Queries__5__Term'] = 'Cults'
+        }
+        default {
+            throw "Unknown function app '$AppName'."
+        }
+    }
+
+    return $settings
+}
+
+function Set-FunctionAppSettings {
+    param(
+        [string]$AppName,
+        [hashtable]$Settings
+    )
+
+    if ($Settings.Count -eq 0) {
+        return
+    }
+
+    $subscriptionId = az account show --query id -o tsv
+    $uri = "https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Web/sites/$AppName/config/appsettings?api-version=2023-12-01"
+
+    $body = @{ properties = @{} }
+    foreach ($key in $Settings.Keys) {
+        $body.properties[$key] = [string]$Settings[$key]
+    }
+    $jsonBody = $body | ConvertTo-Json -Depth 5 -Compress
+
+    $tempFile = [System.IO.Path]::GetTempFileName()
+    try {
+        [System.IO.File]::WriteAllText($tempFile, $jsonBody, [System.Text.UTF8Encoding]::new($false))
+        az rest --method PATCH --uri $uri --body "@$tempFile" -o none
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to update app settings for '$AppName' via az rest (exit code $LASTEXITCODE)."
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Remove-FunctionAppSettings {
+    param(
+        [string]$AppName,
+        [string[]]$SettingNames
+    )
+
+    if ($SettingNames.Count -eq 0) {
+        return
+    }
+
+    az functionapp config appsettings delete `
+        --resource-group $ResourceGroup `
+        --name $AppName `
+        --setting-names $SettingNames `
+        -o none
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to delete app settings for '$AppName' (exit code $LASTEXITCODE)."
+    }
+}
+
+function Show-YouTubeSettingsVerification {
+    param([string]$AppName)
+
+    $rows = az functionapp config appsettings list `
+        --resource-group $ResourceGroup `
+        --name $AppName `
+        --query "[?contains(name, 'youtube__Applications') || contains(name, 'delayedYouTubePublication') || contains(name, 'youtubeChannel') || name=='indexer__ByPassYouTube' || name=='discover__IncludeYouTube' || starts_with(name, 'discover__Queries__4') || starts_with(name, 'discover__Queries__5')].{name:name,value:value}" `
+        -o json | ConvertFrom-Json
+
+    $kvRefCount = 0
+    $literalApiKeyCount = 0
+    $displayNameOk = $true
+    $slot13Literal = $false
+    $slot15Literal = $false
+    $indexerReattemptRemaining = @()
+
+    foreach ($row in $rows) {
+        if ($row.name -like '*__ApiKey') {
+            if ($row.value -like '@Microsoft.KeyVault*') {
+                $kvRefCount++
+            }
+            else {
+                $literalApiKeyCount++
+            }
+            if ($row.name -eq 'youtube__Applications__13__ApiKey' -and $row.value -notlike '@Microsoft.KeyVault*') {
+                $slot13Literal = $true
+            }
+            if ($row.name -eq 'youtube__Applications__15__ApiKey' -and $row.value -notlike '@Microsoft.KeyVault*') {
+                $slot15Literal = $true
+            }
+            $row.value = '***'
+        }
+
+        if ($row.name -like '*__DisplayName') {
+            $slot = [int]($row.name -replace 'youtube__Applications__(\d+)__DisplayName', '$1')
+            $expected = $youTubeKeyUsage[$slot].DisplayName
+            if ($row.value -ne $expected) {
+                $displayNameOk = $false
+                $row | Add-Member -NotePropertyName expected -NotePropertyValue $expected -Force
+            }
+        }
+
+        if ($row.name -like '*__Reattempt') {
+            $slot = [int]($row.name -replace 'youtube__Applications__(\d+)__Reattempt', '$1')
+            if ($youTubeKeyUsage[$slot].Usage -eq 'Indexer') {
+                $indexerReattemptRemaining += $row.name
+            }
+        }
+    }
+
+    Write-Host "`n--- Verification: $AppName ---"
+    $null = $rows | Sort-Object name | Format-Table -AutoSize
+    $indexerReattemptOk = $indexerReattemptRemaining.Count -eq 0
+    Write-Host "ApiKey literals: $literalApiKeyCount | KV refs: $kvRefCount | Slot13 literal: $slot13Literal | Slot15 literal: $slot15Literal | DisplayNames match bicep: $displayNameOk | Indexer Reattempt cleared: $indexerReattemptOk"
+    if (-not $indexerReattemptOk) {
+        Write-Host "Stale indexer Reattempt keys: $($indexerReattemptRemaining -join ', ')"
+    }
+
+    return [PSCustomObject]@{
+        App                       = $AppName
+        SettingsCount             = $rows.Count
+        LiteralApiKeys            = $literalApiKeyCount
+        KeyVaultRefs              = $kvRefCount
+        Slot13Literal             = $slot13Literal
+        Slot15Literal             = $slot15Literal
+        DisplayNamesMatch         = $displayNameOk
+        IndexerReattemptRemaining = $indexerReattemptRemaining
+    }
+}
+
+$allSlots = 0..16
+$settingsByApp = @{}
+
+if ($FromKeyVault) {
+    Write-Host "Reading YouTube API keys from Key Vault '$KeyVaultName'..."
+    $kvSecrets = Get-KeyVaultYouTubeSecrets
+    foreach ($app in $FunctionApps) {
+        $appSettings = Get-YouTubeApplicationsSettings -KvSecrets $kvSecrets -Slots $allSlots -IncludeApiKeys
+        $appSpecific = Get-AppSpecificYouTubeSettings -AppName $app
+        foreach ($key in $appSpecific.Keys) {
+            $appSettings[$key] = $appSpecific[$key]
+        }
+        $settingsByApp[$app] = $appSettings
+    }
+}
+elseif ($DisplayNamesOnly) {
+    foreach ($app in $FunctionApps) {
+        $settingsByApp[$app] = Get-YouTubeApplicationsSettings -KvSecrets @{} -Slots $allSlots
+    }
+}
+elseif ($ApplyNewKeysOnly) {
+    if ([string]::IsNullOrWhiteSpace($ApiKey15) -or [string]::IsNullOrWhiteSpace($ApiKey16)) {
+        throw 'Provide -ApiKey15 and -ApiKey16, or use -FromKeyVault / -DisplayNamesOnly.'
+    }
+    $manualSecrets = @{ 15 = $ApiKey15; 16 = $ApiKey16 }
+    foreach ($app in $FunctionApps) {
+        $appSettings = Get-YouTubeApplicationsSettings -KvSecrets $manualSecrets -Slots @(13, 15) -IncludeApiKeys
+        $usageOnly = Get-YouTubeApplicationsSettings -KvSecrets @{} -Slots $allSlots
+        foreach ($key in $usageOnly.Keys) {
+            if (-not $appSettings.Contains($key)) {
+                $appSettings[$key] = $usageOnly[$key]
+            }
+        }
+        $settingsByApp[$app] = $appSettings
+    }
+}
+else {
+    throw 'Specify -FromKeyVault, -DisplayNamesOnly, or -ApplyNewKeysOnly with -ApiKey15/-ApiKey16.'
+}
+
+Write-Host "Azure subscription: $account"
+Write-Host "Resource group: $ResourceGroup"
+Write-Host "Function apps: $($FunctionApps -join ', ')"
+
+$indexerReattemptToRemove = Get-IndexerReattemptSettingNames
+Write-Host "Indexer slots (Reattempt will be removed if present): $($indexerSlots -join ', ')"
+
+$verification = @()
+$anySettingsApplied = $false
+foreach ($app in $FunctionApps) {
+    $settings = $settingsByApp[$app]
+    Write-Host "`n=== $app ($($settings.Count) settings, $($indexerReattemptToRemove.Count) indexer Reattempt keys to clear) ==="
+    if ($PSCmdlet.ShouldProcess($app, 'Apply YouTube app settings')) {
+        Set-FunctionAppSettings -AppName $app -Settings $settings
+        Remove-FunctionAppSettings -AppName $app -SettingNames $indexerReattemptToRemove
+        $anySettingsApplied = $true
+        if (-not $SkipRestart) {
+            Write-Host "Restarting $app..."
+            az functionapp restart --resource-group $ResourceGroup --name $app -o none
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to restart '$app' (exit code $LASTEXITCODE)."
+            }
+        }
+    }
+    $verification += Show-YouTubeSettingsVerification -AppName $app
+}
+
+$verificationResults = @($verification | Where-Object { $_.App })
+
+Write-Host "`n=== Summary ==="
+foreach ($result in $verificationResults) {
+    Write-Host ("{0}: {1} settings | ApiKey literals: {2} | KV refs: {3} | Slot13 literal: {4} | Slot15 literal: {5} | DisplayNames OK: {6}" -f `
+        $result.App, $result.SettingsCount, $result.LiteralApiKeys, $result.KeyVaultRefs, $result.Slot13Literal, $result.Slot15Literal, $result.DisplayNamesMatch)
+}
+
+if ($verificationResults.Count -ne $FunctionApps.Count) {
+    throw "Verification failed: expected $($FunctionApps.Count) app results, got $($verificationResults.Count)."
+}
+
+if ($verificationResults | Where-Object { $_.KeyVaultRefs -gt 0 -or -not $_.DisplayNamesMatch }) {
+    throw 'Verification failed: KV references remain or DisplayNames do not match bicep.'
+}
+
+if ($anySettingsApplied -and ($verificationResults | Where-Object { $_.IndexerReattemptRemaining.Count -gt 0 })) {
+    throw 'Verification failed: stale youtube__Applications__*__Reattempt keys remain on Indexer slots.'
+}
+
+if ($FromKeyVault -and ($verificationResults | Where-Object { -not $_.Slot13Literal -or -not $_.Slot15Literal })) {
+    throw 'Verification failed: slots 13 and/or 15 ApiKey are not literal values.'
+}
+
+Write-Host "`nYouTube app settings applied successfully."

--- a/scripts/query-cosmos-lookups.ps1
+++ b/scripts/query-cosmos-lookups.ps1
@@ -1,0 +1,227 @@
+# Query Cosmos DB LookUps (and optional Podcasts/Episodes) for indexing investigation.
+# Uses data-plane REST API — Azure CLI has no `az cosmosdb sql query` command.
+
+[CmdletBinding()]
+param(
+    [ValidateSet('QuotaReport', 'IndexerKeyState', 'Podcast', 'Episodes')]
+    [string]$Query = 'QuotaReport',
+
+    [string]$SubscriptionId = 'a6b8f1a2-6163-41bc-aa6d-e33928939a6e',
+
+    [string]$ResourceGroup = 'AutomatedData',
+
+    [string]$AccountName = 'cultpodcasts-db',
+
+    [string]$DatabaseName = 'cultpodcasts-db',
+
+    [string]$LookUpsContainer = 'LookUps',
+
+    [string]$ReportDate = '',
+
+    [string]$SourceApplication = 'Indexer',
+
+    [string]$PodcastId = '8a0c0f4e-79e0-4d87-bcd5-2156fc0d2f9e'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function New-CosmosDbAuthorizationHeader {
+    param(
+        [string]$Verb,
+        [string]$ResourceType,
+        [string]$ResourceId,
+        [string]$Key,
+        [datetime]$Date
+    )
+
+    $keyBytes = [Convert]::FromBase64String($Key)
+    $payload = "$($Verb.ToLowerInvariant())`n$($ResourceType.ToLowerInvariant())`n$ResourceId`n$($Date.ToString('r').ToLowerInvariant())`n`n"
+    $hmacSha256 = New-Object System.Security.Cryptography.HMACSHA256
+    $hmacSha256.Key = $keyBytes
+    $hash = $hmacSha256.ComputeHash([Text.Encoding]::UTF8.GetBytes($payload))
+    $signature = [Convert]::ToBase64String($hash)
+    [uri]::EscapeDataString("type=master&ver=1.0&sig=$signature")
+}
+
+function Get-YouTubeQuotaReportId {
+    param(
+        [string]$ReportDate,
+        [string]$SourceApplication
+    )
+
+    $yyyyMMdd = ($ReportDate -replace '-', '')
+    $input = '{0}:{1}' -f $yyyyMMdd, $SourceApplication
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    $hash = $sha256.ComputeHash([Text.Encoding]::UTF8.GetBytes($input))
+    $guidBytes = New-Object 'System.Byte[]' 16
+    [Array]::Copy($hash, 0, $guidBytes, 0, 16)
+    $guidBytes[6] = [byte](($guidBytes[6] -band 0x0F) -bor 0x40)
+    $guidBytes[8] = [byte](($guidBytes[8] -band 0x3F) -bor 0x80)
+    return ([Guid]$guidBytes).ToString()
+}
+
+function Invoke-CosmosDbReadDocument {
+    param(
+        [string]$Endpoint,
+        [string]$Key,
+        [string]$DatabaseName,
+        [string]$ContainerName,
+        [string]$DocumentId,
+        [string]$PartitionKey
+    )
+
+    $resourceId = "dbs/$DatabaseName/colls/$ContainerName/docs/$DocumentId"
+    $uri = "$Endpoint$resourceId"
+    $date = [datetime]::UtcNow
+    $auth = New-CosmosDbAuthorizationHeader -Verb GET -ResourceType docs -ResourceId $resourceId -Key $Key -Date $date
+
+    $headers = @{
+        Authorization                      = $auth
+        'x-ms-date'                        = $date.ToString('r')
+        'x-ms-version'                     = '2018-12-31'
+        'x-ms-documentdb-partitionkey'     = "[`"$PartitionKey`"]"
+    }
+
+    Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+}
+
+function Invoke-CosmosDbQuery {
+    param(
+        [string]$Endpoint,
+        [string]$Key,
+        [string]$DatabaseName,
+        [string]$ContainerName,
+        [string]$QueryText,
+        [hashtable]$Parameters = @{}
+    )
+
+    $resourceId = "dbs/$DatabaseName/colls/$ContainerName"
+    $uri = "$Endpoint$resourceId/docs"
+    $date = [datetime]::UtcNow
+    $auth = New-CosmosDbAuthorizationHeader -Verb POST -ResourceType docs -ResourceId $resourceId -Key $Key -Date $date
+
+    $body = @{
+        query     = $QueryText
+        parameters = @(
+            foreach ($name in $Parameters.Keys) {
+                @{ name = $name; value = $Parameters[$name] }
+            }
+        )
+    } | ConvertTo-Json -Depth 5 -Compress
+
+    $headers = @{
+        Authorization               = $auth
+        'x-ms-date'                 = $date.ToString('r')
+        'x-ms-version'              = '2018-12-31'
+        'x-ms-documentdb-isquery'   = 'True'
+        'Content-Type'              = 'application/query+json'
+        'x-ms-documentdb-query-enablecrosspartition' = 'True'
+        'x-ms-max-item-count'       = '100'
+    }
+
+    Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $body
+}
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    throw 'Azure CLI (az) was not found on PATH.'
+}
+
+$account = az account show --query name -o tsv 2>$null
+if (-not $account) {
+    throw 'Azure CLI is not logged in. Run: az login'
+}
+
+$key = az cosmosdb keys list `
+    --subscription $SubscriptionId `
+    --resource-group $ResourceGroup `
+    --name $AccountName `
+    --type keys `
+    --query primaryMasterKey `
+    -o tsv
+
+if (-not $key) {
+    throw "Could not read primary key for Cosmos account '$AccountName' in '$ResourceGroup'."
+}
+
+$endpoint = "https://$AccountName.documents.azure.com:443/"
+
+switch ($Query) {
+    'QuotaReport' {
+        if (-not $ReportDate) {
+            $ReportDate = (Get-Date).ToUniversalTime().AddDays(-1).ToString('yyyy-MM-dd')
+        }
+
+        $reportId = Get-YouTubeQuotaReportId -ReportDate $ReportDate -SourceApplication $SourceApplication
+
+        Write-Host "Cosmos: $AccountName / $DatabaseName / $LookUpsContainer"
+        Write-Host "Read: YouTubeQuotaReport id=$reportId reportDate=$ReportDate sourceApplication=$SourceApplication"
+        Write-Host ''
+
+        Invoke-CosmosDbReadDocument `
+            -Endpoint $endpoint `
+            -Key $key `
+            -DatabaseName $DatabaseName `
+            -ContainerName $LookUpsContainer `
+            -DocumentId $reportId `
+            -PartitionKey $reportId | ConvertTo-Json -Depth 10
+    }
+
+    'IndexerKeyState' {
+        $documentId = 'a7c3e1f4-9b2d-4f6a-8c5e-1d3f7a9b2c4e'
+
+        Write-Host "Cosmos: $AccountName / $DatabaseName / $LookUpsContainer"
+        Write-Host "Read: YouTubeIndexerKeyState id=$documentId"
+        Write-Host ''
+
+        Invoke-CosmosDbReadDocument `
+            -Endpoint $endpoint `
+            -Key $key `
+            -DatabaseName $DatabaseName `
+            -ContainerName $LookUpsContainer `
+            -DocumentId $documentId `
+            -PartitionKey $documentId | ConvertTo-Json -Depth 10
+    }
+
+    'Podcast' {
+        $sql = @"
+SELECT c.id, c.name, c.lastIndexed, c.latestReleased, c.releaseAuthority,
+       c.youTubeChannelId, c.youTubePlaylistId, c.spotifyId, c.appleId
+FROM c
+WHERE c.id = @podcastId
+"@
+
+        Write-Host "Cosmos: $AccountName / $DatabaseName / Podcasts"
+        Write-Host "Query: podcast id=$PodcastId"
+        Write-Host ''
+
+        Invoke-CosmosDbQuery `
+            -Endpoint $endpoint `
+            -Key $key `
+            -DatabaseName $DatabaseName `
+            -ContainerName 'Podcasts' `
+            -QueryText $sql `
+            -Parameters @{ '@podcastId' = $PodcastId } | ConvertTo-Json -Depth 10
+    }
+
+    'Episodes' {
+        $sql = @"
+SELECT c.id, c.title, c.release, c.urls
+FROM c
+WHERE c.podcastId = @podcastId
+  AND (CONTAINS(c.urls.youTube, 'hh4MIFHUzRM') OR CONTAINS(c.urls.youTube, 'wuSWvcS2Yfo'))
+ORDER BY c.release DESC
+"@
+
+        Write-Host "Cosmos: $AccountName / $DatabaseName / Episodes"
+        Write-Host "Query: episodes for podcastId=$PodcastId with target YouTube URLs"
+        Write-Host ''
+
+        Invoke-CosmosDbQuery `
+            -Endpoint $endpoint `
+            -Key $key `
+            -DatabaseName $DatabaseName `
+            -ContainerName 'Episodes' `
+            -QueryText $sql `
+            -Parameters @{ '@podcastId' = $PodcastId } | ConvertTo-Json -Depth 10
+    }
+}


### PR DESCRIPTION
## Summary
- **Indexer key ring**: flat rotation across all indexer YouTube API keys, tolerant services with quota-aware key switching, hour-fallback ring index fix, and persistence for key state and per-pass quota usage.
- **Quota reporting**: daily report uses `estimatedQuotaUsed`, `quotaConsumedByOperation`, `ringExhaustionCount`, `nonQuotaErrorCount`, and podcast skip counters (`podcastsNotIndexedDueToQuota`, `podcastsNotEnrichedDueToQuota`); records quota on API quota hits via `RecordQuotaConsumed`; tracks `Videos.List` usage.
- **Tooling & docs**: `apply-youtube-keys.ps1` drops Indexer Reattempt slots, fixes verification `Format-Table` output, corrects display-name / `cultpodcasts` typos in tests; updates `youtube-keys.md`, App Insights KQL, and Cosmos lookup scripts for new report fields.
- **Indexer orchestration**: hourly catch-up, load-recent-candidates, quota report trigger, and scheduled YouTube discovery fixes in `EpisodeProvider`.

## Test plan
- [x] `dotnet test` `RedditPodcastPoster.PodcastServices.YouTube.Tests` (101 passed, 1 skipped)
- [ ] `dotnet test` `Cloud/Unit-Tests/Indexer.Tests` (hourly catch-up evaluator)
- [ ] Dry-run `scripts/apply-youtube-keys.ps1` against a non-prod app setting set
- [ ] After deploy: confirm `Saved YouTube quota report` log line and Cosmos `YouTubeQuotaReport` document shape for prior Pacific day