### PR TITLE
Add deploy-discover.ps1 for local discover-infra deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,6 +413,10 @@ Console-Apps/RedditPodcastPoster/Properties/launchSettings.json
 /Console-Apps/dupes.txt
 /scripts/publish-api
 /scripts/api.zip
+/scripts/publish-indexer
+/scripts/publish-discover
+/scripts/indexer.zip
+/scripts/discover.zip
 /scripts/deploy-api.json
 /Cloud/Config
 scripts/.deploy-local/*

--- a/.gitignore
+++ b/.gitignore
@@ -420,3 +420,5 @@ Console-Apps/RedditPodcastPoster/Properties/launchSettings.json
 /scripts/deploy-api.json
 /Cloud/Config
 scripts/.deploy-local/*
+# Local investigation scratch (KQL exports, one-off tools, etc.)
+.tmp*/

--- a/scripts/deploy-discover.json.example
+++ b/scripts/deploy-discover.json.example
@@ -1,0 +1,6 @@
+{
+  "resourceGroup": "AutomatedInfra",
+  "appName": "discover-infra",
+  "storageAccount": "cultpodcastsstg",
+  "container": "discovery-deployment"
+}

--- a/scripts/deploy-discover.ps1
+++ b/scripts/deploy-discover.ps1
@@ -1,0 +1,124 @@
+# Deploy Discover to Azure App Service using remote-build
+# Copy deploy-discover.json.example to deploy-discover.json to skip interactive prompts.
+
+$jsonPath = Join-Path $PSScriptRoot "deploy-discover.json"
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$projectPath = Join-Path $repoRoot "Cloud/Discovery/Discovery.csproj"
+$publishDir = Join-Path $PSScriptRoot "publish-discover"
+$zipName = Join-Path $PSScriptRoot "discover.zip"
+
+function Check-StorageRole {
+    param($storageAccount)
+    Write-Host "Checking for Storage Blob Data Contributor role..."
+    $userObjectId = az ad signed-in-user show --query id -o tsv
+    $subscriptionId = az account show --query id -o tsv
+    $scope = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroup/providers/Microsoft.Storage/storageAccounts/$storageAccount"
+    $roles = az role assignment list --assignee $userObjectId --scope $scope --query "[].roleDefinitionName" -o tsv
+    if ($roles -notcontains "Storage Blob Data Contributor" -and $roles -notcontains "Storage Blob Data Owner") {
+        Write-Error "You must be assigned the 'Storage Blob Data Contributor' or 'Storage Blob Data Owner' role on the storage account $storageAccount."
+        exit 1
+    }
+}
+
+$details = $null
+$usePrevious = $false
+if (Test-Path $jsonPath) {
+    Write-Host "Loading previous deployment details from $jsonPath..."
+    $details = Get-Content $jsonPath | ConvertFrom-Json
+    Write-Host "Loaded:"
+    Write-Host "Resource Group: $($details.resourceGroup)"
+    Write-Host "App Service: $($details.appName)"
+    Write-Host "Storage Account: $($details.storageAccount)"
+    Write-Host "Blob Container: $($details.container)"
+    $response = Read-Host "Use these details? (Y/n)"
+    if ($response -ne 'n' -and $response -ne 'N') {
+        $resourceGroup = $details.resourceGroup
+        $appName = $details.appName
+        $storageAccount = $details.storageAccount
+        $container = $details.container
+        $usePrevious = $true
+    }
+}
+if (-not $usePrevious) {
+    if (-not $resourceGroup) {
+        Write-Host "Fetching Azure resource groups..."
+        $resourceGroups = az group list --query "[].name" -o tsv
+        $resourceGroups | ForEach-Object { Write-Host $_ }
+        $resourceGroup = Read-Host "Enter the resource group name from the list above"
+    }
+    # Loop until a valid app name is selected
+    $appName = $null
+    while (-not $appName) {
+        Write-Host "Fetching Web Apps and Function Apps in resource group $resourceGroup..."
+        $webApps = az webapp list --resource-group $resourceGroup --query "[].name" -o tsv
+        $functionApps = az functionapp list --resource-group $resourceGroup --query "[].name" -o tsv
+        $allApps = @()
+        if ($webApps) { $allApps += $webApps }
+        if ($functionApps) { $allApps += $functionApps }
+        $allApps = $allApps | Sort-Object -Unique
+        if (-not $allApps) {
+            Write-Host "No Web Apps or Function Apps found in $resourceGroup."
+            $tryAgain = Read-Host "Enter a different resource group? (Y/n)"
+            if ($tryAgain -eq 'n' -or $tryAgain -eq 'N') { exit }
+            $resourceGroups = az group list --query "[].name" -o tsv
+            $resourceGroups | ForEach-Object { Write-Host $_ }
+            $resourceGroup = Read-Host "Enter the resource group name from the list above"
+        } else {
+            $allApps | ForEach-Object { Write-Host $_ }
+            $appName = Read-Host "Enter the App Service or Function App name for Discover from the list above"
+        }
+    }
+    if (-not $storageAccount) {
+        Write-Host "Fetching Storage Accounts in resource group $resourceGroup..."
+        $storageAccounts = az storage account list --resource-group $resourceGroup --query "[].name" -o tsv
+        $storageAccounts | ForEach-Object { Write-Host $_ }
+        $storageAccount = Read-Host "Enter the Storage Account name from the list above"
+    }
+    if (-not $container) {
+        Write-Host "Fetching Blob Containers in storage account $storageAccount..."
+        $containerList = az storage container list --account-name $storageAccount --query "[].name" -o tsv
+        $containerList | ForEach-Object { Write-Host $_ }
+        $container = Read-Host "Enter the Blob Container name from the list above"
+    }
+    # Save details for next time
+    @{
+        resourceGroup = $resourceGroup
+        appName = $appName
+        storageAccount = $storageAccount
+        container = $container
+    } | ConvertTo-Json | Set-Content $jsonPath
+}
+
+Check-StorageRole $storageAccount
+
+# Build and publish the project
+Write-Host "Publishing Discover project..."
+if (Test-Path $publishDir) { Remove-Item $publishDir -Recurse -Force }
+dotnet publish $projectPath -c Release -r linux-x64 -o $publishDir
+if (!(Test-Path $publishDir)) {
+    Write-Error "Publish directory not found: $publishDir"
+    exit 1
+}
+if (Test-Path $zipName) { Remove-Item $zipName -Force }
+Compress-Archive -Path (Join-Path $publishDir '*') -DestinationPath $zipName -Force
+if (!(Test-Path $zipName)) {
+    Write-Error "Zip file not created: $zipName"
+    exit 1
+}
+
+# Upload zip to Azure Blob Storage (requires az login)
+Write-Host "Uploading zip to Azure Blob Storage..."
+az storage blob upload --account-name $storageAccount --container-name $container --file $zipName --name (Split-Path $zipName -Leaf) --auth-mode login --overwrite
+
+# Get the blob SAS URL (update expiry as needed)
+$expiry = (Get-Date).AddHours(2).ToString("yyyy-MM-ddTHH:mm:ssZ")
+$sasToken = az storage blob generate-sas --account-name $storageAccount --container-name $container --name (Split-Path $zipName -Leaf) --permissions r --expiry $expiry --https-only --auth-mode login --as-user --output tsv
+if ($sasToken) {
+    $zipFileUrl = "https://$storageAccount.blob.core.windows.net/$container/$(Split-Path $zipName -Leaf)?$sasToken"
+} else {
+    $zipFileUrl = "https://$storageAccount.blob.core.windows.net/$container/$(Split-Path $zipName -Leaf)"
+}
+
+# Deploy the zip package (do NOT update environment variables)
+. (Join-Path $PSScriptRoot "AzureWebAppDeploy.ps1")
+Invoke-WebAppZipDeploy -ResourceGroup $resourceGroup -AppName $appName -ZipFileUrl $zipFileUrl


### PR DESCRIPTION
## Summary
- Add `scripts/deploy-discover.ps1` matching the indexer/api blob-upload + `Invoke-WebAppZipDeploy` local deploy pattern.
- Add `scripts/deploy-discover.json.example` with production defaults (`discover-infra`, `discovery-deployment`, `cultpodcastsstg`, `AutomatedInfra`).

## Test plan
- [ ] Copy `deploy-discover.json.example` to `deploy-discover.json` and run `scripts/deploy-discover.ps1` with `az login`
- [ ] Confirm publish targets `Cloud/Discovery/Discovery.csproj` and uploads `discover.zip` to the discovery deployment container
- [ ] Confirm Kudu reports deployment success for `discover-infra`