### PR TITLE
Fix Bluesky YouTube factory NullReferenceException

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeServiceFactoryTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/YouTubeServiceFactoryTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RedditPodcastPoster.PodcastServices.YouTube.Clients;
+using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
+using RedditPodcastPoster.PodcastServices.YouTube.Factories;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Strategies;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests;
+
+public class YouTubeServiceFactoryTests
+{
+    [Fact]
+    public void Create_ForBluesky_UsesApiKeyStrategyInsteadOfIndexerRing()
+    {
+        var blueskyApplication = new ApplicationWrapper(
+            new Application
+            {
+                ApiKey = "bluesky-key",
+                Name = "BlueskyApp",
+                DisplayName = "ApiKey-7 - Bluesky",
+                Usage = ApplicationUsage.Bluesky
+            },
+            Index: 0,
+            Reattempts: 0);
+
+        var strategy = new Mock<IYouTubeApiKeyStrategy>();
+        strategy.Setup(x => x.GetApplication(ApplicationUsage.Bluesky)).Returns(blueskyApplication);
+
+        var serviceProvider = new Mock<IServiceProvider>();
+
+        var factory = new YouTubeServiceFactory(
+            strategy.Object,
+            serviceProvider.Object,
+            NullLogger<YouTubeServiceFactory>.Instance,
+            NullLogger<YouTubeServiceWrapper>.Instance);
+
+        var wrapper = factory.Create(ApplicationUsage.Bluesky);
+
+        wrapper.CurrentApplication.ApiKey.Should().Be("bluesky-key");
+        wrapper.Usage.Should().Be(ApplicationUsage.Bluesky);
+        strategy.Verify(x => x.GetApplication(ApplicationUsage.Bluesky), Times.Once);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Factories/YouTubeServiceFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Factories/YouTubeServiceFactory.cs
@@ -38,8 +38,9 @@ public class YouTubeServiceFactory(
             ?? (usage == ApplicationUsage.Indexer
                 ? youTubeApiKeyStrategy.GetApplication(usage).Index
                 : 0);
-        var application = session?.Ring[initialRingIndex]
-            ?? indexerKeyRing![initialRingIndex];
+        var application = usage == ApplicationUsage.Indexer
+            ? session?.Ring[initialRingIndex] ?? indexerKeyRing![initialRingIndex]
+            : youTubeApiKeyStrategy.GetApplication(usage);
 
         logger.LogInformation(
             "Obtained api-key: '{apiKey}' at ring index {RingIndex}.",


### PR DESCRIPTION
## Summary
- Fix production NRE in YouTubeServiceFactory.Create when usage is ApplicationUsage.Bluesky
- PR #862 added indexer key-ring resolution but non-Indexer paths still dereferenced null indexerKeyRing at line 41
- Non-Indexer usages now call youTubeApiKeyStrategy.GetApplication(usage) as before

## Test plan
- [x] dotnet test --filter FullyQualifiedName~YouTubeServiceFactoryTests (1 passed)

Made with [Cursor](https://cursor.com)