### PR TITLE
Propagate Spotify bypass mid-batch; extract indexing context helpers

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/IndexingContextExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/IndexingContextExtensions.cs
@@ -5,6 +5,69 @@ namespace RedditPodcastPoster.PodcastServices.Abstractions;
 public static class IndexingContextExtensions
 {
     /// <summary>
+    /// Snapshot for batch-level bypass rollup after each podcast. YouTube bypass is per-podcast
+    /// during the batch; Spotify bypass is batch-global once rate-limited.
+    /// </summary>
+    public record PodcastBatchBypassState(
+        bool InitialSkipYouTube,
+        bool InitialSkipSpotify,
+        bool AnyYouTubeBypassed = false,
+        bool AnyYouTubeQuotaExhausted = false,
+        bool AnySpotifyBypassed = false);
+
+    /// <summary>
+    /// Isolated copy for one podcast in a batch. Always clone from the batch parent (not a prior
+    /// podcast clone) so per-podcast YouTube bypass does not leak between iterations, while
+    /// batch-global flags such as <see cref="IndexingContext.SkipSpotifyUrlResolving"/> are
+    /// inherited from the parent.
+    /// </summary>
+    public static IndexingContext ForPodcastUpdate(this IndexingContext batchContext) =>
+        batchContext with { };
+
+    /// <summary>
+    /// Merges bypass flags after a podcast update. Spotify bypass propagates immediately to the
+    /// batch parent so subsequent <see cref="ForPodcastUpdate"/> calls skip Spotify; YouTube bypass
+    /// is tracked for end-of-batch rollup only.
+    /// </summary>
+    public static PodcastBatchBypassState AbsorbPodcastPass(
+        this IndexingContext batchContext,
+        IndexingContext podcastContext,
+        PodcastBatchBypassState state)
+    {
+        if (podcastContext.SkipSpotifyUrlResolving)
+        {
+            batchContext.SkipSpotifyUrlResolving = true;
+        }
+
+        return state with
+        {
+            AnyYouTubeBypassed = state.AnyYouTubeBypassed ||
+                                 (!state.InitialSkipYouTube && podcastContext.SkipYouTubeUrlResolving),
+            AnyYouTubeQuotaExhausted = state.AnyYouTubeQuotaExhausted ||
+                                       (!state.InitialSkipYouTube && podcastContext.YouTubeQuotaExhausted),
+            AnySpotifyBypassed = state.AnySpotifyBypassed ||
+                                 (!state.InitialSkipSpotify && podcastContext.SkipSpotifyUrlResolving)
+        };
+    }
+
+    /// <summary>
+    /// Applies tracked YouTube bypass flags to the batch context for orchestration reporting.
+    /// Spotify bypass is already on the batch parent via <see cref="AbsorbPodcastPass"/>.
+    /// </summary>
+    public static void ApplyBatchBypassRollup(this IndexingContext batchContext, PodcastBatchBypassState state)
+    {
+        if (state.AnyYouTubeBypassed)
+        {
+            batchContext.SkipYouTubeUrlResolving = true;
+        }
+
+        if (state.AnyYouTubeQuotaExhausted)
+        {
+            batchContext.YouTubeQuotaExhausted = true;
+        }
+    }
+
+    /// <summary>
     /// Full playlist pagination is only allowed when the podcast is known-expensive and this pass
     /// permits expensive YouTube queries (hour 0 UTC primary pass). Channel listing and single-page
     /// playlist fetches are unaffected by <see cref="IndexingContext.SkipExpensiveYouTubeQueries"/>.

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/IndexingContextExtensionsTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/IndexingContextExtensionsTests.cs
@@ -7,6 +7,60 @@ namespace RedditPodcastPoster.PodcastServices.YouTube.Tests;
 public class IndexingContextExtensionsTests
 {
     [Fact]
+    public void ForPodcastUpdate_InheritsBatchGlobalSpotifyBypass()
+    {
+        var batchContext = new IndexingContext(DateTime.UtcNow.AddDays(-2), SkipSpotifyUrlResolving: true);
+
+        batchContext.ForPodcastUpdate().SkipSpotifyUrlResolving.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AbsorbPodcastPass_PropagatesSpotifyBypassToBatchImmediately()
+    {
+        var batchContext = new IndexingContext(DateTime.UtcNow.AddDays(-2));
+        var podcastContext = batchContext.ForPodcastUpdate();
+        podcastContext.SkipSpotifyUrlResolving = true;
+
+        var state = new IndexingContextExtensions.PodcastBatchBypassState(false, false);
+        state = batchContext.AbsorbPodcastPass(podcastContext, state);
+
+        batchContext.SkipSpotifyUrlResolving.Should().BeTrue();
+        state.AnySpotifyBypassed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AbsorbPodcastPass_DoesNotRollUpYouTubeBypassUntilBatchEnd()
+    {
+        var batchContext = new IndexingContext(DateTime.UtcNow.AddDays(-2));
+        var podcastContext = batchContext.ForPodcastUpdate();
+        podcastContext.SkipYouTubeUrlResolving = true;
+
+        var state = new IndexingContextExtensions.PodcastBatchBypassState(false, false);
+        state = batchContext.AbsorbPodcastPass(podcastContext, state);
+
+        batchContext.SkipYouTubeUrlResolving.Should().BeFalse();
+        state.AnyYouTubeBypassed.Should().BeTrue();
+
+        batchContext.ApplyBatchBypassRollup(state);
+        batchContext.SkipYouTubeUrlResolving.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ApplyBatchBypassRollup_DoesNotReapplySpotifyBypass()
+    {
+        var batchContext = new IndexingContext(DateTime.UtcNow.AddDays(-2));
+        var podcastContext = batchContext.ForPodcastUpdate();
+        podcastContext.SkipSpotifyUrlResolving = true;
+
+        var state = new IndexingContextExtensions.PodcastBatchBypassState(false, false);
+        state = batchContext.AbsorbPodcastPass(podcastContext, state);
+
+        batchContext.SkipSpotifyUrlResolving.Should().BeTrue();
+        batchContext.ApplyBatchBypassRollup(state);
+        batchContext.SkipSpotifyUrlResolving.Should().BeTrue();
+    }
+
+    [Fact]
     public void RunExpensiveYouTubePlaylistPagination_WhenSkipExpensive_ReturnsFalse()
     {
         var podcast = new Podcast { YouTubePlaylistQueryIsExpensive = true };

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastsUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastsUpdater.cs
@@ -54,6 +54,10 @@ public class PodcastsUpdater(
                     anyYouTubeBypassed |= !initialSkipYouTube && podcastIndexingContext.SkipYouTubeUrlResolving;
                     anyYouTubeQuotaExhausted |= !initialSkipYouTube && podcastIndexingContext.YouTubeQuotaExhausted;
                     anySpotifyBypassed |= !initialSkipSpotify && podcastIndexingContext.SkipSpotifyUrlResolving;
+                    if (podcastIndexingContext.SkipSpotifyUrlResolving)
+                    {
+                        indexingContext.SkipSpotifyUrlResolving = true;
+                    }
                     var resultReport = result.ToString();
                     if (!result.Success)
                     {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastsUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastsUpdater.cs
@@ -16,15 +16,13 @@ public class PodcastsUpdater(
     public async Task<bool> UpdatePodcasts(Guid[] podcastIds, IndexingContext indexingContext)
     {
         var success = true;
-        var initialSkipYouTube = indexingContext.SkipYouTubeUrlResolving;
-        var initialSkipSpotify = indexingContext.SkipSpotifyUrlResolving;
+        var batchBypassState = new IndexingContextExtensions.PodcastBatchBypassState(
+            indexingContext.SkipYouTubeUrlResolving,
+            indexingContext.SkipSpotifyUrlResolving);
         var youtubeEnabled = !indexingContext.SkipYouTubeUrlResolving;
         var youtubeAuthorityInBatch = 0;
         var youtubeAuthorityIndexedWithYouTubePass = 0;
         var youtubeAuthorityBypassed = 0;
-        var anyYouTubeBypassed = false;
-        var anyYouTubeQuotaExhausted = false;
-        var anySpotifyBypassed = false;
 
         var podcasts = await Task.WhenAll(podcastIds.Select(async podcastId =>
             (Id: podcastId, Podcast: await podcastRepository.GetPodcast(podcastId))));
@@ -49,15 +47,11 @@ public class PodcastsUpdater(
             {
                 try
                 {
-                    var podcastIndexingContext = indexingContext with { };
+                    var podcastIndexingContext = indexingContext.ForPodcastUpdate();
                     var result = await podcastUpdater.Update(podcast!, false, podcastIndexingContext);
-                    anyYouTubeBypassed |= !initialSkipYouTube && podcastIndexingContext.SkipYouTubeUrlResolving;
-                    anyYouTubeQuotaExhausted |= !initialSkipYouTube && podcastIndexingContext.YouTubeQuotaExhausted;
-                    anySpotifyBypassed |= !initialSkipSpotify && podcastIndexingContext.SkipSpotifyUrlResolving;
-                    if (podcastIndexingContext.SkipSpotifyUrlResolving)
-                    {
-                        indexingContext.SkipSpotifyUrlResolving = true;
-                    }
+                    batchBypassState = indexingContext.AbsorbPodcastPass(
+                        podcastIndexingContext,
+                        batchBypassState);
                     var resultReport = result.ToString();
                     if (!result.Success)
                     {
@@ -121,20 +115,7 @@ public class PodcastsUpdater(
                 youtubeAuthorityBypassed);
         }
 
-        if (anyYouTubeBypassed)
-        {
-            indexingContext.SkipYouTubeUrlResolving = true;
-        }
-
-        if (anyYouTubeQuotaExhausted)
-        {
-            indexingContext.YouTubeQuotaExhausted = true;
-        }
-
-        if (anySpotifyBypassed)
-        {
-            indexingContext.SkipSpotifyUrlResolving = true;
-        }
+        indexingContext.ApplyBatchBypassRollup(batchBypassState);
 
         logger.LogInformation("{nameofUpdatePodcasts} Indexing complete.", nameof(UpdatePodcasts));
         return success;


### PR DESCRIPTION
## Summary
- When a podcast clone hits Spotify 429, `SpotifyClientWrapper` sets `SkipSpotifyUrlResolving` on that clone's `IndexingContext`. `PodcastsUpdater` promotes that flag to the shared batch context immediately via `AbsorbPodcastPass`, so remaining podcasts skip Spotify URL resolution.
- Extracted explicit batch/podcast bypass helpers on `IndexingContextExtensions`:
  - `ForPodcastUpdate` — per-podcast clone from the batch parent (YouTube bypass isolated per podcast; Spotify bypass inherited batch-globally).
  - `AbsorbPodcastPass` + `PodcastBatchBypassState` — Spotify propagates to the batch immediately; YouTube/quota flags tracked for end-of-batch rollup.
  - `ApplyBatchBypassRollup` — applies YouTube bypass/quota to the batch for orchestration (`IndexerContext.SpotifyError` reads the already-propagated `SkipSpotifyUrlResolving`).
- Does **not** preemptively disable Spotify via `IndexSpotify` / `SkipSpotifyUrlResolving` in `Indexer` or gate Spotify episode enrichment on `IndexSpotify` (those approaches were reverted).

## Test plan
- [x] `IndexingContextExtensionsTests` — `ForPodcastUpdate`, `AbsorbPodcastPass`, `ApplyBatchBypassRollup` (7 passed).
- [ ] Run indexer batch where Spotify returns 429 mid-run; confirm subsequent podcasts skip Spotify URL calls.
- [ ] Confirm passes with `IndexSpotify` true still resolve and enrich Spotify when no rate limit occurs.
