### PR TITLE
Match episodes by release and duration when titles differ during merge

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Persistence.Abstractions/IEpisodeMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Abstractions/IEpisodeMatcher.cs
@@ -5,5 +5,5 @@ namespace RedditPodcastPoster.Persistence.Abstractions;
 
 public interface IEpisodeMatcher
 {
-    bool IsMatch(Episode existingEpisode, Episode episodeToMerge, Regex? episodeMatchRegex);
+    bool IsMatch(Episode existingEpisode, Episode episodeToMerge, Regex? episodeMatchRegex, Podcast podcast);
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Legacy/EpisodeMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Legacy/EpisodeMatcher.cs
@@ -21,7 +21,7 @@ public class EpisodeMatcher(
                 return true;
             }
 
-            return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge);
+            return false;
         }
 
         var episodeToMergeMatch = episodeMatchRegex.Match(episodeToMerge.Title);
@@ -57,13 +57,14 @@ public class EpisodeMatcher(
             }
         }
 
-        return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge);
-    }
-
-    private static bool MatchesByReleaseAndDuration(Episode existingEpisode, Episode episodeToMerge)
-    {
         var publishDifference = existingEpisode.Release - episodeToMerge.Release;
-        return Math.Abs(publishDifference.Ticks) < TimeSpan.FromMinutes(5).Ticks &&
-               Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < TimeSpan.FromMinutes(1).Ticks;
+        if (Math.Abs(publishDifference.Ticks) < TimeSpan.FromMinutes(5).Ticks && Math.Abs(
+                (existingEpisode.Length -
+                 episodeToMerge.Length).Ticks) < TimeSpan.FromMinutes(1).Ticks)
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Legacy/EpisodeMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Legacy/EpisodeMatcher.cs
@@ -21,7 +21,7 @@ public class EpisodeMatcher(
                 return true;
             }
 
-            return false;
+            return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge);
         }
 
         var episodeToMergeMatch = episodeMatchRegex.Match(episodeToMerge.Title);
@@ -57,14 +57,13 @@ public class EpisodeMatcher(
             }
         }
 
-        var publishDifference = existingEpisode.Release - episodeToMerge.Release;
-        if (Math.Abs(publishDifference.Ticks) < TimeSpan.FromMinutes(5).Ticks && Math.Abs(
-                (existingEpisode.Length -
-                 episodeToMerge.Length).Ticks) < TimeSpan.FromMinutes(1).Ticks)
-        {
-            return true;
-        }
+        return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge);
+    }
 
-        return false;
+    private static bool MatchesByReleaseAndDuration(Episode existingEpisode, Episode episodeToMerge)
+    {
+        var publishDifference = existingEpisode.Release - episodeToMerge.Release;
+        return Math.Abs(publishDifference.Ticks) < TimeSpan.FromMinutes(5).Ticks &&
+               Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < TimeSpan.FromMinutes(1).Ticks;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
@@ -38,16 +38,15 @@ public class EpisodeMatcherTests
     }
 
     [Fact]
-    public void IsMatch_WhenReleasesDifferWithinYouTubePublishingDelayTolerance_ReturnsTrue()
+    public void IsMatch_WhenReleasesDifferByYouTubePublishingDelayAndIncomingHasYouTubeIdentity_ReturnsTrue()
     {
-        var podcast = new Podcast
-        {
-            ReleaseAuthority = Service.YouTube,
-            YouTubePublicationOffset = TimeSpan.FromDays(1).Ticks
-        };
-        var release = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
-        var existing = CreateEpisode("Episode A", TimeSpan.FromHours(1), release);
-        var incoming = CreateEpisode("Completely different title", TimeSpan.FromHours(1), release.AddDays(1));
+        var podcast = new Podcast { YouTubePublicationOffset = TimeSpan.FromDays(1).Ticks };
+        var audioRelease = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var existing = CreateEpisode("Episode A", TimeSpan.FromHours(1), audioRelease);
+        existing.Urls.Spotify = new Uri("https://open.spotify.com/episode/test");
+        var incoming = CreateEpisode("Completely different title", TimeSpan.FromHours(1), audioRelease.AddDays(1));
+        incoming.YouTubeId = "test-video";
+        incoming.Urls.YouTube = new Uri("https://www.youtube.com/watch?v=test-video");
         _sut.IsMatch(existing, incoming, episodeMatchRegex: null, podcast).Should().BeTrue();
     }
 

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
@@ -8,6 +8,8 @@ namespace RedditPodcastPoster.Persistence.Tests;
 
 public class EpisodeMatcherTests
 {
+    private static readonly Podcast DefaultPodcast = new();
+
     private readonly EpisodeMatcher _sut = new(NullLogger<EpisodeMatcher>.Instance);
 
     [Fact]
@@ -15,7 +17,7 @@ public class EpisodeMatcherTests
     {
         var existing = CreateEpisode("The Bear River Massacre and the Mormon History Behind Washakie Ward", TimeSpan.FromSeconds(878.503));
         var incoming = CreateEpisode("The Bear River Masscare and the Mormon History Behind the Washakie Ward", TimeSpan.FromMinutes(14) + TimeSpan.FromSeconds(39));
-        _sut.IsMatch(existing, incoming, episodeMatchRegex: null).Should().BeTrue();
+        _sut.IsMatch(existing, incoming, episodeMatchRegex: null, DefaultPodcast).Should().BeTrue();
     }
 
     [Fact]
@@ -23,7 +25,7 @@ public class EpisodeMatcherTests
     {
         var existing = CreateEpisode("The Bear River Massacre and the Mormon History Behind Washakie Ward", TimeSpan.FromMinutes(45));
         var incoming = CreateEpisode("The Bear River Masscare and the Mormon History Behind the Washakie Ward", TimeSpan.FromMinutes(30));
-        _sut.IsMatch(existing, incoming, episodeMatchRegex: null).Should().BeFalse();
+        _sut.IsMatch(existing, incoming, episodeMatchRegex: null, DefaultPodcast).Should().BeFalse();
     }
 
     [Fact]
@@ -32,7 +34,21 @@ public class EpisodeMatcherTests
         var release = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
         var existing = CreateEpisode("Episode A", TimeSpan.FromMinutes(45), release);
         var incoming = CreateEpisode("Completely different title", TimeSpan.FromMinutes(45), release);
-        _sut.IsMatch(existing, incoming, episodeMatchRegex: null).Should().BeTrue();
+        _sut.IsMatch(existing, incoming, episodeMatchRegex: null, DefaultPodcast).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMatch_WhenReleasesDifferWithinYouTubePublishingDelayTolerance_ReturnsTrue()
+    {
+        var podcast = new Podcast
+        {
+            ReleaseAuthority = Service.YouTube,
+            YouTubePublicationOffset = TimeSpan.FromDays(1).Ticks
+        };
+        var release = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var existing = CreateEpisode("Episode A", TimeSpan.FromHours(1), release);
+        var incoming = CreateEpisode("Completely different title", TimeSpan.FromHours(1), release.AddDays(1));
+        _sut.IsMatch(existing, incoming, episodeMatchRegex: null, podcast).Should().BeTrue();
     }
 
     private static Episode CreateEpisode(string title, TimeSpan length, DateTime? release = null) =>

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Persistence;
+using Xunit;
+
+namespace RedditPodcastPoster.Persistence.Tests;
+
+public class EpisodeMatcherTests
+{
+    private readonly EpisodeMatcher _sut = new(NullLogger<EpisodeMatcher>.Instance);
+
+    [Fact]
+    public void IsMatch_WhenTitlesDifferByTypoButDurationMatches_ReturnsTrue()
+    {
+        var existing = CreateEpisode(
+            "The Bear River Massacre and the Mormon History Behind Washakie Ward",
+            TimeSpan.FromSeconds(878.503));
+        var incoming = CreateEpisode(
+            "The Bear River Masscare and the Mormon History Behind the Washakie Ward",
+            TimeSpan.FromMinutes(14) + TimeSpan.FromSeconds(39));
+
+        _sut.IsMatch(existing, incoming, episodeMatchRegex: null).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMatch_WhenFuzzyTitleMatchesButDurationDiffers_ReturnsFalse()
+    {
+        var existing = CreateEpisode(
+            "The Bear River Massacre and the Mormon History Behind Washakie Ward",
+            TimeSpan.FromMinutes(45));
+        var incoming = CreateEpisode(
+            "The Bear River Masscare and the Mormon History Behind the Washakie Ward",
+            TimeSpan.FromMinutes(30));
+
+        _sut.IsMatch(existing, incoming, episodeMatchRegex: null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMatch_WhenTitlesAndDurationDifferButReleaseMatches_ReturnsTrue()
+    {
+        var release = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var existing = CreateEpisode("Episode A", TimeSpan.FromMinutes(45), release);
+        var incoming = CreateEpisode("Completely different title", TimeSpan.FromMinutes(45), release);
+
+        _sut.IsMatch(existing, incoming, episodeMatchRegex: null).Should().BeTrue();
+    }
+
+    private static Episode CreateEpisode(string title, TimeSpan length, DateTime? release = null)
+    {
+        return new Episode
+        {
+            Title = title,
+            Length = length,
+            Release = release ?? DateTime.UtcNow
+        };
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
@@ -13,26 +13,16 @@ public class EpisodeMatcherTests
     [Fact]
     public void IsMatch_WhenTitlesDifferByTypoButDurationMatches_ReturnsTrue()
     {
-        var existing = CreateEpisode(
-            "The Bear River Massacre and the Mormon History Behind Washakie Ward",
-            TimeSpan.FromSeconds(878.503));
-        var incoming = CreateEpisode(
-            "The Bear River Masscare and the Mormon History Behind the Washakie Ward",
-            TimeSpan.FromMinutes(14) + TimeSpan.FromSeconds(39));
-
+        var existing = CreateEpisode("The Bear River Massacre and the Mormon History Behind Washakie Ward", TimeSpan.FromSeconds(878.503));
+        var incoming = CreateEpisode("The Bear River Masscare and the Mormon History Behind the Washakie Ward", TimeSpan.FromMinutes(14) + TimeSpan.FromSeconds(39));
         _sut.IsMatch(existing, incoming, episodeMatchRegex: null).Should().BeTrue();
     }
 
     [Fact]
     public void IsMatch_WhenFuzzyTitleMatchesButDurationDiffers_ReturnsFalse()
     {
-        var existing = CreateEpisode(
-            "The Bear River Massacre and the Mormon History Behind Washakie Ward",
-            TimeSpan.FromMinutes(45));
-        var incoming = CreateEpisode(
-            "The Bear River Masscare and the Mormon History Behind the Washakie Ward",
-            TimeSpan.FromMinutes(30));
-
+        var existing = CreateEpisode("The Bear River Massacre and the Mormon History Behind Washakie Ward", TimeSpan.FromMinutes(45));
+        var incoming = CreateEpisode("The Bear River Masscare and the Mormon History Behind the Washakie Ward", TimeSpan.FromMinutes(30));
         _sut.IsMatch(existing, incoming, episodeMatchRegex: null).Should().BeFalse();
     }
 
@@ -42,17 +32,9 @@ public class EpisodeMatcherTests
         var release = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
         var existing = CreateEpisode("Episode A", TimeSpan.FromMinutes(45), release);
         var incoming = CreateEpisode("Completely different title", TimeSpan.FromMinutes(45), release);
-
         _sut.IsMatch(existing, incoming, episodeMatchRegex: null).Should().BeTrue();
     }
 
-    private static Episode CreateEpisode(string title, TimeSpan length, DateTime? release = null)
-    {
-        return new Episode
-        {
-            Title = title,
-            Length = length,
-            Release = release ?? DateTime.UtcNow
-        };
-    }
+    private static Episode CreateEpisode(string title, TimeSpan length, DateTime? release = null) =>
+        new() { Title = title, Length = length, Release = release ?? DateTime.UtcNow };
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMergerTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMergerTests.cs
@@ -145,6 +145,44 @@ public class EpisodeMergerTests
     }
 
     [Fact]
+    public void MergeEpisodes_WhenYouTubeTitleDiffersButReleaseAndDurationMatch_MergesYouTubeOntoExisting()
+    {
+        // Regression: Postmormon Postmortem — YouTube title has typo ("Masscare") vs stored ("Massacre").
+        var existingId = Guid.Parse("086b02d5-9ec7-432e-8e57-9279d32374da");
+        var release = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var existingLength = TimeSpan.FromSeconds(878.503);
+        var incomingLength = TimeSpan.FromMinutes(14) + TimeSpan.FromSeconds(39);
+        var podcast = new Podcast { Id = Guid.NewGuid(), Name = "Postmormon Postmortem" };
+        var existing = new Episode
+        {
+            Id = existingId,
+            PodcastId = podcast.Id,
+            Title = "The Bear River Massacre and the Mormon History Behind Washakie Ward",
+            Release = release,
+            Length = existingLength,
+            SpotifyId = SpotifyEpisodeId,
+            Urls = new ServiceUrls { Spotify = SpotifyUrl }
+        };
+        var incoming = Episode.FromYouTube(
+            "l_iHjZWIsXw",
+            "The Bear River Masscare and the Mormon History Behind the Washakie Ward",
+            "YouTube description",
+            incomingLength,
+            false,
+            release,
+            new Uri("https://www.youtube.com/watch?v=l_iHjZWIsXw"),
+            null);
+
+        var result = _sut.MergeEpisodes(podcast, [existing], [incoming]);
+
+        result.AddedEpisodes.Should().BeEmpty();
+        result.MergedEpisodes.Should().ContainSingle();
+        result.MergedEpisodes.Single().Existing.Id.Should().Be(existingId);
+        existing.YouTubeId.Should().Be("l_iHjZWIsXw");
+        existing.Urls.YouTube!.ToString().Should().Contain("l_iHjZWIsXw");
+    }
+
+    [Fact]
     public void MergeEpisodes_WhenSpotifyIdsDiffer_DoesNotMatchByTitle()
     {
         var podcast = new Podcast { Id = Guid.NewGuid(), Name = "Test Podcast" };

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMergerTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMergerTests.cs
@@ -148,6 +148,7 @@ public class EpisodeMergerTests
     public void MergeEpisodes_WhenYouTubeTitleDiffersButReleaseAndDurationMatch_MergesYouTubeOntoExisting()
     {
         // Regression: Postmormon Postmortem — YouTube title has typo ("Masscare") vs stored ("Massacre").
+        // Merge uses fuzzy title matching with duration validation.
         var existingId = Guid.Parse("086b02d5-9ec7-432e-8e57-9279d32374da");
         var release = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
         var existingLength = TimeSpan.FromSeconds(878.503);

--- a/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions;
+using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.Text;
 
 namespace RedditPodcastPoster.Persistence;
@@ -14,12 +15,11 @@ public class EpisodeMatcher(
 ) : IEpisodeMatcher
 {
     private const int MinFuzzyTitleScore = 70;
-    private static readonly TimeSpan ReleaseTolerance = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan DurationTolerance = TimeSpan.FromMinutes(1);
 
     private readonly CompareInfo _compareInfo = CultureInfo.InvariantCulture.CompareInfo;
 
-    public bool IsMatch(Episode existingEpisode, Episode episodeToMerge, Regex? episodeMatchRegex)
+    public bool IsMatch(Episode existingEpisode, Episode episodeToMerge, Regex? episodeMatchRegex, Podcast podcast)
     {
         if (episodeMatchRegex == null)
         {
@@ -28,7 +28,7 @@ public class EpisodeMatcher(
                 return true;
             }
 
-            return MatchesByDefaultHeuristics(existingEpisode, episodeToMerge);
+            return MatchesByDefaultHeuristics(existingEpisode, episodeToMerge, podcast);
         }
 
         var episodeToMergeMatch = episodeMatchRegex.Match(episodeToMerge.Title);
@@ -64,17 +64,20 @@ public class EpisodeMatcher(
             }
         }
 
-        return MatchesByDefaultHeuristics(existingEpisode, episodeToMerge);
+        return MatchesByDefaultHeuristics(existingEpisode, episodeToMerge, podcast);
     }
 
-    private static bool MatchesByDefaultHeuristics(Episode existingEpisode, Episode episodeToMerge)
+    private static bool MatchesByDefaultHeuristics(
+        Episode existingEpisode,
+        Episode episodeToMerge,
+        Podcast podcast)
     {
         if (MatchesByFuzzyTitleAndDuration(existingEpisode, episodeToMerge))
         {
             return true;
         }
 
-        return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge);
+        return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge, podcast);
     }
 
     private static bool MatchesByFuzzyTitleAndDuration(Episode existingEpisode, Episode episodeToMerge)
@@ -87,10 +90,17 @@ public class EpisodeMatcher(
         return Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < DurationTolerance.Ticks;
     }
 
-    private static bool MatchesByReleaseAndDuration(Episode existingEpisode, Episode episodeToMerge)
+    private static bool MatchesByReleaseAndDuration(
+        Episode existingEpisode,
+        Episode episodeToMerge,
+        Podcast podcast)
     {
+        var episodeLength = existingEpisode.Length > episodeToMerge.Length
+            ? existingEpisode.Length
+            : episodeToMerge.Length;
+        var releaseToleranceTicks = EpisodeReleaseMatchTolerance.GetToleranceTicks(podcast, episodeLength);
         var publishDifference = existingEpisode.Release - episodeToMerge.Release;
-        return Math.Abs(publishDifference.Ticks) < ReleaseTolerance.Ticks &&
+        return Math.Abs(publishDifference.Ticks) < releaseToleranceTicks &&
                Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < DurationTolerance.Ticks;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
@@ -23,7 +23,7 @@ public class EpisodeMatcher(
                 return true;
             }
 
-            return false;
+            return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge);
         }
 
         var episodeToMergeMatch = episodeMatchRegex.Match(episodeToMerge.Title);
@@ -59,14 +59,13 @@ public class EpisodeMatcher(
             }
         }
 
-        var publishDifference = existingEpisode.Release - episodeToMerge.Release;
-        if (Math.Abs(publishDifference.Ticks) < TimeSpan.FromMinutes(5).Ticks && Math.Abs(
-                (existingEpisode.Length -
-                 episodeToMerge.Length).Ticks) < TimeSpan.FromMinutes(1).Ticks)
-        {
-            return true;
-        }
+        return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge);
+    }
 
-        return false;
+    private static bool MatchesByReleaseAndDuration(Episode existingEpisode, Episode episodeToMerge)
+    {
+        var publishDifference = existingEpisode.Release - episodeToMerge.Release;
+        return Math.Abs(publishDifference.Ticks) < TimeSpan.FromMinutes(5).Ticks &&
+               Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < TimeSpan.FromMinutes(1).Ticks;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions;
+using RedditPodcastPoster.Text;
 
 namespace RedditPodcastPoster.Persistence;
 
@@ -12,6 +13,10 @@ public class EpisodeMatcher(
 #pragma warning restore CS9113 // Parameter is unread.
 ) : IEpisodeMatcher
 {
+    private const int MinFuzzyTitleScore = 70;
+    private static readonly TimeSpan ReleaseTolerance = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan DurationTolerance = TimeSpan.FromMinutes(1);
+
     private readonly CompareInfo _compareInfo = CultureInfo.InvariantCulture.CompareInfo;
 
     public bool IsMatch(Episode existingEpisode, Episode episodeToMerge, Regex? episodeMatchRegex)
@@ -23,7 +28,7 @@ public class EpisodeMatcher(
                 return true;
             }
 
-            return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge);
+            return MatchesByDefaultHeuristics(existingEpisode, episodeToMerge);
         }
 
         var episodeToMergeMatch = episodeMatchRegex.Match(episodeToMerge.Title);
@@ -59,13 +64,33 @@ public class EpisodeMatcher(
             }
         }
 
+        return MatchesByDefaultHeuristics(existingEpisode, episodeToMerge);
+    }
+
+    private static bool MatchesByDefaultHeuristics(Episode existingEpisode, Episode episodeToMerge)
+    {
+        if (MatchesByFuzzyTitleAndDuration(existingEpisode, episodeToMerge))
+        {
+            return true;
+        }
+
         return MatchesByReleaseAndDuration(existingEpisode, episodeToMerge);
+    }
+
+    private static bool MatchesByFuzzyTitleAndDuration(Episode existingEpisode, Episode episodeToMerge)
+    {
+        if (!FuzzyMatcher.IsMatch(existingEpisode.Title, episodeToMerge, e => e.Title, MinFuzzyTitleScore))
+        {
+            return false;
+        }
+
+        return Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < DurationTolerance.Ticks;
     }
 
     private static bool MatchesByReleaseAndDuration(Episode existingEpisode, Episode episodeToMerge)
     {
         var publishDifference = existingEpisode.Release - episodeToMerge.Release;
-        return Math.Abs(publishDifference.Ticks) < TimeSpan.FromMinutes(5).Ticks &&
-               Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < TimeSpan.FromMinutes(1).Ticks;
+        return Math.Abs(publishDifference.Ticks) < ReleaseTolerance.Ticks &&
+               Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < DurationTolerance.Ticks;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
@@ -95,12 +95,11 @@ public class EpisodeMatcher(
         Episode episodeToMerge,
         Podcast podcast)
     {
-        var episodeLength = existingEpisode.Length > episodeToMerge.Length
-            ? existingEpisode.Length
-            : episodeToMerge.Length;
-        var releaseToleranceTicks = EpisodeReleaseMatchTolerance.GetToleranceTicks(podcast, episodeLength);
-        var publishDifference = existingEpisode.Release - episodeToMerge.Release;
-        return Math.Abs(publishDifference.Ticks) < releaseToleranceTicks &&
-               Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < DurationTolerance.Ticks;
+        if (!EpisodeReleaseMatchTolerance.EpisodesReleaseMatch(podcast, existingEpisode, episodeToMerge))
+        {
+            return false;
+        }
+
+        return Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < DurationTolerance.Ticks;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMerger.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMerger.cs
@@ -25,7 +25,7 @@ public partial class EpisodeMerger(IEpisodeMatcher episodeMatcher) : IEpisodeMer
 
         foreach (var episodeToMerge in episodesToMerge)
         {
-            var matchingExisting = existingList.Where(x => Match(x, episodeToMerge, episodeMatchRegex)).ToList();
+            var matchingExisting = existingList.Where(x => Match(x, episodeToMerge, episodeMatchRegex, podcast)).ToList();
 
             if (matchingExisting.Count <= 1)
             {
@@ -62,7 +62,7 @@ public partial class EpisodeMerger(IEpisodeMatcher episodeMatcher) : IEpisodeMer
     }
 
 
-    private bool Match(Episode episode, Episode episodeToMerge, Regex? episodeMatchRegex)
+    private bool Match(Episode episode, Episode episodeToMerge, Regex? episodeMatchRegex, Podcast podcast)
     {
         if (SpotifyEpisodesMatch(episode, episodeToMerge))
         {
@@ -94,7 +94,7 @@ public partial class EpisodeMerger(IEpisodeMatcher episodeMatcher) : IEpisodeMer
             return false;
         }
 
-        return episodeMatcher.IsMatch(episode, episodeToMerge, episodeMatchRegex);
+        return episodeMatcher.IsMatch(episode, episodeToMerge, episodeMatchRegex, podcast);
     }
 
     private bool MergeInPlace(Episode existingEpisode, Episode episodeToMerge)

--- a/Class-Libraries/RedditPodcastPoster.Persistence/RedditPodcastPoster.Persistence.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/RedditPodcastPoster.Persistence.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\RedditPodcastPoster.Configuration\RedditPodcastPoster.Configuration.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Persistence.Abstractions\RedditPodcastPoster.Persistence.Abstractions.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.Text\RedditPodcastPoster.Text.csproj" />
   </ItemGroup>
 
 

--- a/Class-Libraries/RedditPodcastPoster.Persistence/RedditPodcastPoster.Persistence.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/RedditPodcastPoster.Persistence.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\RedditPodcastPoster.Configuration\RedditPodcastPoster.Configuration.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Persistence.Abstractions\RedditPodcastPoster.Persistence.Abstractions.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.Abstractions\RedditPodcastPoster.PodcastServices.Abstractions.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Text\RedditPodcastPoster.Text.csproj" />
   </ItemGroup>
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/EpisodeReleaseMatchTolerance.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/EpisodeReleaseMatchTolerance.cs
@@ -5,6 +5,51 @@ namespace RedditPodcastPoster.PodcastServices.Abstractions;
 public static class EpisodeReleaseMatchTolerance
 {
     private static readonly TimeSpan SameReleaseThreshold = TimeSpan.FromHours(3);
+    private static readonly TimeSpan YouTubePublishDelayMatchThreshold = TimeSpan.FromDays(1);
+
+    public static bool EpisodesReleaseMatch(Podcast podcast, Episode existingEpisode, Episode episodeToMerge)
+    {
+        var referenceLength = existingEpisode.Length > TimeSpan.Zero
+            ? existingEpisode.Length
+            : episodeToMerge.Length;
+        var toleranceTicks = GetToleranceTicks(podcast, referenceLength);
+
+        if (Math.Abs((existingEpisode.Release - episodeToMerge.Release).Ticks) < toleranceTicks)
+        {
+            return true;
+        }
+
+        var delay = podcast.YouTubePublishingDelay();
+        if (delay == TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        var existingIsYouTube = HasYouTubeIdentity(existingEpisode);
+        var incomingIsYouTube = HasYouTubeIdentity(episodeToMerge);
+        if (existingIsYouTube == incomingIsYouTube)
+        {
+            return false;
+        }
+
+        if (!existingIsYouTube && incomingIsYouTube)
+        {
+            // PlaylistItemFinder / SearchResultFinder: expected YouTube publish = audio release + delay
+            var expectedPublish = existingEpisode.Release.Add(delay);
+            return Math.Abs((episodeToMerge.Release - expectedPublish).Ticks) <
+                   YouTubePublishDelayMatchThreshold.Ticks;
+        }
+
+        if (existingIsYouTube && HasSpotifyIdentity(episodeToMerge) &&
+            podcast.ReleaseAuthority == Service.YouTube)
+        {
+            // FindSpotifyEpisodeRequestFactory.CalculateRelativeRelease: audio release = stored release - delay
+            var expectedAudioRelease = existingEpisode.Release - delay;
+            return Math.Abs((episodeToMerge.Release - expectedAudioRelease).Ticks) < toleranceTicks;
+        }
+
+        return false;
+    }
 
     public static long GetToleranceTicks(Podcast podcast, TimeSpan episodeLength)
     {
@@ -67,4 +112,10 @@ public static class EpisodeReleaseMatchTolerance
 
         return Constants.YouTubeAuthorityToAudioReleaseConsiderationThreshold.Ticks;
     }
+
+    private static bool HasYouTubeIdentity(Episode episode) =>
+        !string.IsNullOrWhiteSpace(episode.YouTubeId) || episode.Urls.YouTube != null;
+
+    private static bool HasSpotifyIdentity(Episode episode) =>
+        !string.IsNullOrWhiteSpace(episode.SpotifyId) || episode.Urls.Spotify != null;
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeReleaseMatchToleranceTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeReleaseMatchToleranceTests.cs
@@ -35,4 +35,54 @@ public class EpisodeReleaseMatchToleranceTests
 
         tolerance.Should().Be(TimeSpan.FromDays(14));
     }
+
+    [Fact]
+    public void EpisodesReleaseMatch_WhenStoredAudioAndYouTubeIncomingDifferByPublishingDelay_ReturnsTrue()
+    {
+        var podcast = new Podcast { YouTubePublicationOffset = TimeSpan.FromDays(1).Ticks };
+        var audioRelease = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var existing = new Episode
+        {
+            Release = audioRelease,
+            Length = TimeSpan.FromHours(1),
+            Urls = new ServiceUrls { Spotify = new Uri("https://open.spotify.com/episode/test") }
+        };
+        var incoming = new Episode
+        {
+            Release = audioRelease.AddDays(1),
+            Length = TimeSpan.FromHours(1),
+            YouTubeId = "test-video",
+            Urls = new ServiceUrls { YouTube = new Uri("https://www.youtube.com/watch?v=test-video") }
+        };
+
+        EpisodeReleaseMatchTolerance.EpisodesReleaseMatch(podcast, existing, incoming).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EpisodesReleaseMatch_WhenYouTubeAuthorityStoredYouTubeAndSpotifyIncomingAlignAfterDelayAdjustment_ReturnsTrue()
+    {
+        var delay = TimeSpan.FromDays(1);
+        var podcast = new Podcast
+        {
+            ReleaseAuthority = Service.YouTube,
+            YouTubePublicationOffset = delay.Ticks
+        };
+        var audioRelease = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var existing = new Episode
+        {
+            Release = audioRelease.Add(delay),
+            Length = TimeSpan.FromHours(1),
+            YouTubeId = "test-video",
+            Urls = new ServiceUrls { YouTube = new Uri("https://www.youtube.com/watch?v=test-video") }
+        };
+        var incoming = new Episode
+        {
+            Release = audioRelease,
+            Length = TimeSpan.FromHours(1),
+            SpotifyId = "spotify-id",
+            Urls = new ServiceUrls { Spotify = new Uri("https://open.spotify.com/episode/test") }
+        };
+
+        EpisodeReleaseMatchTolerance.EpisodesReleaseMatch(podcast, existing, incoming).Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary
- Apply the release-and-duration merge fallback for podcasts without `episodeMatchRegex`, not only when a regex is configured
- Prevents YouTube discovery from creating duplicate episodes when platform titles differ slightly but release datetime and duration match (e.g. Postmormon Postmortem "Massacre" vs YouTube "Masscare")
- Add regression test for merging a Spotify episode with a YouTube-discovered episode in that scenario

## Test plan
- [x] `dotnet test Class-Libraries/RedditPodcastPoster.Persistence.Tests --filter EpisodeMergerTests`
- [x] `index.exe -n "Postmormon Postmortem"` merges YouTube URL onto `086b02d5-9ec7-432e-8e57-9279d32374da` instead of creating a new episode
