### PR TITLE
Fix YouTube-discovered enrichment and negative-delay merge/enrichment

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMatcherTests.cs
@@ -50,6 +50,30 @@ public class EpisodeMatcherTests
         _sut.IsMatch(existing, incoming, episodeMatchRegex: null, podcast).Should().BeTrue();
     }
 
+    [Fact]
+    public void IsMatch_WhenNegativeDelayAndTitlesDiffer_DoesNotMatchByReleaseAndDurationAlone()
+    {
+        var podcast = new Podcast
+        {
+            ReleaseAuthority = Service.YouTube,
+            YouTubePublicationOffset = TimeSpan.FromDays(-33).Add(TimeSpan.FromHours(-12)).Ticks
+        };
+        var existing = CreateEpisode(
+            "Why He Thinks Daughters Should Parent Their Siblings",
+            TimeSpan.FromMinutes(61) + TimeSpan.FromSeconds(35),
+            new DateTime(2026, 5, 31, 21, 15, 27, DateTimeKind.Utc));
+        existing.YouTubeId = "u6ZF-2sWQQc";
+        existing.Urls.YouTube = new Uri("https://www.youtube.com/watch?v=u6ZF-2sWQQc");
+        var incoming = CreateEpisode(
+            "Becoming a Fundamentalist Trad Wife Almost Killed Me",
+            TimeSpan.FromMinutes(61) + TimeSpan.FromSeconds(30),
+            new DateTime(2026, 6, 28, 0, 0, 0, DateTimeKind.Utc));
+        incoming.SpotifyId = "1BTQKaev5KLjScdwHII14B";
+        incoming.Urls.Spotify = new Uri("https://open.spotify.com/episode/1BTQKaev5KLjScdwHII14B");
+
+        _sut.IsMatch(existing, incoming, episodeMatchRegex: null, podcast).Should().BeFalse();
+    }
+
     private static Episode CreateEpisode(string title, TimeSpan length, DateTime? release = null) =>
         new() { Title = title, Length = length, Release = release ?? DateTime.UtcNow };
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMergerNegativeDelayTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Tests/EpisodeMergerNegativeDelayTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Persistence;
+
+namespace RedditPodcastPoster.Persistence.Tests;
+
+public class EpisodeMergerNegativeDelayTests
+{
+    private static readonly Guid PodcastId = Guid.Parse("1aa72d3d-f1e4-458f-a172-62990ef6c200");
+    private static readonly TimeSpan MembersFirstDelay = TimeSpan.FromDays(-33).Add(TimeSpan.FromHours(-12));
+
+    private readonly EpisodeMerger _sut = new(new EpisodeMatcher(NullLogger<EpisodeMatcher>.Instance));
+
+    [Fact]
+    public void MergeEpisodes_WhenSpotifyIncomingMatchesExistingOwnerById_MergesOntoOwnerNotYouTubeOnlyEpisode()
+    {
+        var podcast = new Podcast
+        {
+            Id = PodcastId,
+            Name = "Cults to Consciousness",
+            ReleaseAuthority = Service.YouTube,
+            YouTubePublicationOffset = MembersFirstDelay.Ticks
+        };
+
+        var correctOwnerId = Guid.Parse("1c804814-12ac-40c8-a223-88ab7c703d38");
+        var wrongYouTubeOnlyId = Guid.Parse("53ba0c64-58a7-4292-b7fe-ba135d4d3160");
+        const string otoSpotifyId = "16LveQifI6eBwDXAINpd7G";
+        var otoSpotifyUrl = new Uri($"https://open.spotify.com/episode/{otoSpotifyId}");
+
+        var correctOwner = new Episode
+        {
+            Id = correctOwnerId,
+            PodcastId = PodcastId,
+            Title = "What Really Happens During \"Ordo Templi Orientis\" Initiations?  (Trapped in a Secret Society)",
+            Release = new DateTime(2026, 5, 20, 22, 15, 16, DateTimeKind.Utc),
+            Length = TimeSpan.FromMinutes(61) + TimeSpan.FromSeconds(42),
+            SpotifyId = otoSpotifyId,
+            YouTubeId = "l3aIdJeg0vE",
+            Urls = new ServiceUrls
+            {
+                Spotify = otoSpotifyUrl,
+                YouTube = new Uri("https://www.youtube.com/watch?v=l3aIdJeg0vE")
+            }
+        };
+
+        var wrongYouTubeOnly = new Episode
+        {
+            Id = wrongYouTubeOnlyId,
+            PodcastId = PodcastId,
+            Title = "Why He Thinks Daughters Should Parent Their Siblings  (ft. Tia Levings)",
+            Release = new DateTime(2026, 5, 31, 21, 15, 27, DateTimeKind.Utc),
+            Length = TimeSpan.FromMinutes(61) + TimeSpan.FromSeconds(35),
+            YouTubeId = "u6ZF-2sWQQc",
+            Urls = new ServiceUrls { YouTube = new Uri("https://www.youtube.com/watch?v=u6ZF-2sWQQc") }
+        };
+
+        var incoming = Episode.FromSpotify(
+            otoSpotifyId,
+            "What Really Happens During Ordo Templi Orientis Initiations",
+            "Incoming description",
+            TimeSpan.FromMinutes(61) + TimeSpan.FromSeconds(42),
+            false,
+            new DateTime(2026, 6, 24, 0, 0, 0, DateTimeKind.Utc),
+            otoSpotifyUrl,
+            null);
+
+        var result = _sut.MergeEpisodes(podcast, [correctOwner, wrongYouTubeOnly], [incoming]);
+
+        result.AddedEpisodes.Should().BeEmpty();
+        result.MergedEpisodes.Should().ContainSingle();
+        result.MergedEpisodes.Single().Existing.Id.Should().Be(correctOwnerId);
+        wrongYouTubeOnly.SpotifyId.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public void MergeEpisodes_WhenNegativeDelayAndTitlesDiffer_DoesNotMergeByReleaseAndDurationAlone()
+    {
+        var podcast = new Podcast
+        {
+            Id = PodcastId,
+            Name = "Cults to Consciousness",
+            ReleaseAuthority = Service.YouTube,
+            YouTubePublicationOffset = MembersFirstDelay.Ticks
+        };
+
+        var existing = new Episode
+        {
+            Id = Guid.Parse("53ba0c64-58a7-4292-b7fe-ba135d4d3160"),
+            PodcastId = PodcastId,
+            Title = "Why He Thinks Daughters Should Parent Their Siblings  (ft. Tia Levings)",
+            Release = new DateTime(2026, 5, 31, 21, 15, 27, DateTimeKind.Utc),
+            Length = TimeSpan.FromMinutes(61) + TimeSpan.FromSeconds(35),
+            YouTubeId = "u6ZF-2sWQQc",
+            Urls = new ServiceUrls { YouTube = new Uri("https://www.youtube.com/watch?v=u6ZF-2sWQQc") }
+        };
+
+        var incoming = Episode.FromSpotify(
+            "1BTQKaev5KLjScdwHII14B",
+            "Becoming a Fundamentalist Trad Wife Almost Killed Me",
+            "Incoming description",
+            TimeSpan.FromMinutes(61) + TimeSpan.FromSeconds(30),
+            false,
+            new DateTime(2026, 6, 28, 0, 0, 0, DateTimeKind.Utc),
+            new Uri("https://open.spotify.com/episode/1BTQKaev5KLjScdwHII14B"),
+            null);
+
+        var result = _sut.MergeEpisodes(podcast, [existing], [incoming]);
+
+        result.MergedEpisodes.Should().BeEmpty();
+        result.AddedEpisodes.Should().ContainSingle();
+        existing.SpotifyId.Should().BeNullOrEmpty();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMatcher.cs
@@ -100,6 +100,16 @@ public class EpisodeMatcher(
             return false;
         }
 
-        return Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) < DurationTolerance.Ticks;
+        if (Math.Abs((existingEpisode.Length - episodeToMerge.Length).Ticks) >= DurationTolerance.Ticks)
+        {
+            return false;
+        }
+
+        if (podcast.YouTubePublishingDelay().Ticks < 0)
+        {
+            return FuzzyMatcher.IsMatch(existingEpisode.Title, episodeToMerge, e => e.Title, MinFuzzyTitleScore);
+        }
+
+        return true;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMerger.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/EpisodeMerger.cs
@@ -25,7 +25,9 @@ public partial class EpisodeMerger(IEpisodeMatcher episodeMatcher) : IEpisodeMer
 
         foreach (var episodeToMerge in episodesToMerge)
         {
-            var matchingExisting = existingList.Where(x => Match(x, episodeToMerge, episodeMatchRegex, podcast)).ToList();
+            var matchingExisting = existingList
+                .Where(x => Match(x, episodeToMerge, episodeMatchRegex, podcast, existingList))
+                .ToList();
 
             if (matchingExisting.Count <= 1)
             {
@@ -62,11 +64,21 @@ public partial class EpisodeMerger(IEpisodeMatcher episodeMatcher) : IEpisodeMer
     }
 
 
-    private bool Match(Episode episode, Episode episodeToMerge, Regex? episodeMatchRegex, Podcast podcast)
+    private bool Match(
+        Episode episode,
+        Episode episodeToMerge,
+        Regex? episodeMatchRegex,
+        Podcast podcast,
+        IReadOnlyList<Episode> existingEpisodes)
     {
         if (SpotifyEpisodesMatch(episode, episodeToMerge))
         {
             return true;
+        }
+
+        if (IncomingPlatformIdOwnedByAnotherEpisode(episode, episodeToMerge, existingEpisodes))
+        {
+            return false;
         }
 
         if (!string.IsNullOrWhiteSpace(episode.SpotifyId) && !string.IsNullOrWhiteSpace(episodeToMerge.SpotifyId))
@@ -180,6 +192,49 @@ public partial class EpisodeMerger(IEpisodeMatcher episodeMatcher) : IEpisodeMer
         }
 
         return updated;
+    }
+
+    private static bool IncomingPlatformIdOwnedByAnotherEpisode(
+        Episode candidate,
+        Episode episodeToMerge,
+        IReadOnlyList<Episode> existingEpisodes)
+    {
+        var incomingSpotifyId = ResolveSpotifyEpisodeId(episodeToMerge.SpotifyId, episodeToMerge.Urls.Spotify);
+        if (!string.IsNullOrWhiteSpace(incomingSpotifyId))
+        {
+            foreach (var existingEpisode in existingEpisodes)
+            {
+                if (existingEpisode.Id == candidate.Id)
+                {
+                    continue;
+                }
+
+                var existingSpotifyId =
+                    ResolveSpotifyEpisodeId(existingEpisode.SpotifyId, existingEpisode.Urls.Spotify);
+                if (existingSpotifyId == incomingSpotifyId)
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (episodeToMerge.AppleId is > 0)
+        {
+            foreach (var existingEpisode in existingEpisodes)
+            {
+                if (existingEpisode.Id == candidate.Id)
+                {
+                    continue;
+                }
+
+                if (existingEpisode.AppleId == episodeToMerge.AppleId)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static bool SpotifyEpisodesMatch(Episode episode, Episode episodeToMerge)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/EpisodeReleaseMatchTolerance.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/EpisodeReleaseMatchTolerance.cs
@@ -14,12 +14,13 @@ public static class EpisodeReleaseMatchTolerance
             : episodeToMerge.Length;
         var toleranceTicks = GetToleranceTicks(podcast, referenceLength);
 
-        if (Math.Abs((existingEpisode.Release - episodeToMerge.Release).Ticks) < toleranceTicks)
+        var delay = podcast.YouTubePublishingDelay();
+        if (delay.Ticks >= 0 &&
+            Math.Abs((existingEpisode.Release - episodeToMerge.Release).Ticks) < toleranceTicks)
         {
             return true;
         }
 
-        var delay = podcast.YouTubePublishingDelay();
         if (delay == TimeSpan.Zero)
         {
             return false;
@@ -46,6 +47,14 @@ public static class EpisodeReleaseMatchTolerance
             // FindSpotifyEpisodeRequestFactory.CalculateRelativeRelease: audio release = stored release - delay
             var expectedAudioRelease = existingEpisode.Release - delay;
             return Math.Abs((episodeToMerge.Release - expectedAudioRelease).Ticks) < toleranceTicks;
+        }
+
+        if (incomingIsYouTube && HasSpotifyIdentity(existingEpisode) &&
+            podcast.ReleaseAuthority == Service.YouTube)
+        {
+            var expectedYouTubeRelease = existingEpisode.Release.Add(delay);
+            return Math.Abs((episodeToMerge.Release - expectedYouTubeRelease).Ticks) <
+                   YouTubePublishDelayMatchThreshold.Ticks;
         }
 
         return false;
@@ -78,6 +87,26 @@ public static class EpisodeReleaseMatchTolerance
         return release;
     }
 
+    public static bool SpotifyCatalogueReleaseMatches(DateTime spotifyCatalogueRelease, DateTime expectedRelease)
+    {
+        var spotifyDate = DateOnly.FromDateTime(spotifyCatalogueRelease);
+        var expectedDate = DateOnly.FromDateTime(expectedRelease);
+        return Math.Abs(expectedDate.DayNumber - spotifyDate.DayNumber) <= 1;
+    }
+
+    public static bool SpotifyCatalogueReleaseMatches(
+        DateTime spotifyCatalogueRelease,
+        DateTime expectedRelease,
+        long toleranceTicks)
+    {
+        if (SpotifyCatalogueReleaseMatches(spotifyCatalogueRelease, expectedRelease))
+        {
+            return true;
+        }
+
+        return Math.Abs((spotifyCatalogueRelease - expectedRelease).Ticks) < toleranceTicks;
+    }
+
     public static long GetToleranceTicks(Podcast podcast, TimeSpan episodeLength)
     {
         var delay = podcast.YouTubePublishingDelay();
@@ -88,7 +117,7 @@ public static class EpisodeReleaseMatchTolerance
 
         if (delay.Ticks < 0)
         {
-            return Math.Abs(delay.Ticks);
+            return YouTubePublishDelayMatchThreshold.Add(SameReleaseThreshold).Ticks;
         }
 
         if (podcast.ReleaseAuthority == Service.YouTube)
@@ -123,7 +152,7 @@ public static class EpisodeReleaseMatchTolerance
 
         if (delay.Ticks < 0)
         {
-            return Math.Abs(delay.Ticks);
+            return YouTubePublishDelayMatchThreshold.Add(SameReleaseThreshold).Ticks;
         }
 
         if (releaseAuthority == Service.YouTube)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/EpisodeReleaseMatchTolerance.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/EpisodeReleaseMatchTolerance.cs
@@ -51,6 +51,33 @@ public static class EpisodeReleaseMatchTolerance
         return false;
     }
 
+    public static DateTime GetAudioReleaseForPlatformLookup(Podcast podcast, Episode episode) =>
+        GetAudioReleaseForPlatformLookup(podcast, episode.Release, HasYouTubeIdentity(episode));
+
+    public static DateTime GetAudioReleaseForPlatformLookup(
+        Podcast podcast,
+        DateTime release,
+        bool episodeHasYouTubeIdentity)
+    {
+        var delay = podcast.YouTubePublishingDelay();
+        if (delay == TimeSpan.Zero)
+        {
+            return release;
+        }
+
+        if (podcast.ReleaseAuthority == Service.YouTube)
+        {
+            return release - delay;
+        }
+
+        if (episodeHasYouTubeIdentity && HasAudioPlatformConfigured(podcast))
+        {
+            return release - delay;
+        }
+
+        return release;
+    }
+
     public static long GetToleranceTicks(Podcast podcast, TimeSpan episodeLength)
     {
         var delay = podcast.YouTubePublishingDelay();
@@ -118,4 +145,7 @@ public static class EpisodeReleaseMatchTolerance
 
     private static bool HasSpotifyIdentity(Episode episode) =>
         !string.IsNullOrWhiteSpace(episode.SpotifyId) || episode.Urls.Spotify != null;
+
+    private static bool HasAudioPlatformConfigured(Podcast podcast) =>
+        !string.IsNullOrWhiteSpace(podcast.SpotifyId) || podcast.AppleId != null;
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeReleaseMatchToleranceTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeReleaseMatchToleranceTests.cs
@@ -85,4 +85,40 @@ public class EpisodeReleaseMatchToleranceTests
 
         EpisodeReleaseMatchTolerance.EpisodesReleaseMatch(podcast, existing, incoming).Should().BeTrue();
     }
+
+    [Fact]
+    public void GetAudioReleaseForPlatformLookup_WhenEpisodeDiscoveredViaYouTubeOnSpotifyPrimaryPodcast_SubtractsPublishingDelay()
+    {
+        var delay = TimeSpan.FromHours(9);
+        var podcast = new Podcast
+        {
+            SpotifyId = "spotify-show",
+            YouTubePublicationOffset = delay.Ticks
+        };
+        var youTubePublish = new DateTime(2026, 7, 2, 9, 0, 0, DateTimeKind.Utc);
+        var episode = new Episode
+        {
+            Release = youTubePublish,
+            YouTubeId = "video-id",
+            Urls = new ServiceUrls { YouTube = new Uri("https://www.youtube.com/watch?v=video-id") }
+        };
+
+        EpisodeReleaseMatchTolerance.GetAudioReleaseForPlatformLookup(podcast, episode)
+            .Should().Be(youTubePublish - delay);
+    }
+
+    [Fact]
+    public void GetAudioReleaseForPlatformLookup_WhenYouTubeIsReleaseAuthority_SubtractsPublishingDelay()
+    {
+        var delay = TimeSpan.FromDays(1);
+        var podcast = new Podcast
+        {
+            ReleaseAuthority = Service.YouTube,
+            YouTubePublicationOffset = delay.Ticks
+        };
+        var release = new DateTime(2026, 7, 2, 9, 0, 0, DateTimeKind.Utc);
+
+        EpisodeReleaseMatchTolerance.GetAudioReleaseForPlatformLookup(podcast, release, episodeHasYouTubeIdentity: false)
+            .Should().Be(release - delay);
+    }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeReleaseMatchToleranceTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeReleaseMatchToleranceTests.cs
@@ -23,6 +23,15 @@ public class EpisodeReleaseMatchToleranceTests
     }
 
     [Fact]
+    public void SpotifyCatalogueReleaseMatches_WhenSpotifyDateIsMidnightAndExpectedHasTimeWithinOneDay_ReturnsTrue()
+    {
+        var expected = new DateTime(2026, 7, 2, 9, 15, 27, DateTimeKind.Utc);
+        var spotifyCatalogue = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        EpisodeReleaseMatchTolerance.SpotifyCatalogueReleaseMatches(spotifyCatalogue, expected).Should().BeTrue();
+    }
+
+    [Fact]
     public void GetToleranceTicks_WhenNoYouTubeDelay_UsesFourteenDayThreshold()
     {
         var podcast = new Podcast

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.Apple;
+
+namespace RedditPodcastPoster.PodcastServices.Apple.Tests;
+
+public class AppleEpisodeResolverTests
+{
+    [Fact]
+    public async Task FindEpisode_WhenYouTubeDiscoveredTitleDiffersButDurationAndReleaseAlign_ReturnsMatch()
+    {
+        var lookupRelease = new DateTime(2026, 7, 2, 7, 0, 12, DateTimeKind.Utc);
+        var episodeLength = TimeSpan.FromMinutes(54) + TimeSpan.FromSeconds(30);
+        var appleEpisodes = new[]
+        {
+            new AppleEpisode(
+                1000775078015,
+                "My Family Was America's Most Dangerous Cult",
+                new DateTime(2026, 7, 1, 23, 0, 0, DateTimeKind.Utc),
+                episodeLength + TimeSpan.FromMinutes(3),
+                new Uri("https://podcasts.apple.com/us/podcast/my-family-was-americas-most-dangerous-cult/id1860966643?i=1000775078015"),
+                string.Empty,
+                false),
+            new AppleEpisode(
+                1000757443994,
+                "Epstein's survivor: Jena-Lisa Jones Reveals all",
+                new DateTime(2026, 3, 26, 8, 0, 11, DateTimeKind.Utc),
+                TimeSpan.FromMinutes(82),
+                new Uri("https://podcasts.apple.com/us/podcast/id1860966643?i=1000757443994"),
+                string.Empty,
+                false)
+        };
+
+        var request = new FindAppleEpisodeRequest(
+            1860966643,
+            "The Shadow Sessions Podcast",
+            null,
+            "\"I Grew Up in a Murder Cult\" Cult Survivor Reveals What It's Like To Grow Up Inside It",
+            lookupRelease,
+            null,
+            episodeLength,
+            TimeSpan.FromHours(1),
+            EnrichingYouTubeDiscoveredEpisode: true);
+
+        var sut = new AppleEpisodeResolver(
+            new StubApplePodcastService(appleEpisodes),
+            NullLogger<AppleEpisodeResolver>.Instance);
+
+        var result = await sut.FindEpisode(
+            request,
+            new IndexingContext(),
+            y => Math.Abs((y.Release - lookupRelease).Ticks) < TimeSpan.FromDays(14).Ticks);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(1000775078015);
+    }
+
+    private sealed class StubApplePodcastService(IEnumerable<AppleEpisode> episodes) : ICachedApplePodcastService
+    {
+        public void Flush()
+        {
+        }
+
+        public Task<AppleEpisode?> SingleUseGetEpisode(
+            ApplePodcastId podcastId,
+            long episodeId,
+            IndexingContext indexingContext) =>
+            GetEpisode(podcastId, episodeId, indexingContext);
+
+        public Task<AppleEpisode?> GetEpisode(ApplePodcastId podcastId, long episodeId, IndexingContext indexingContext) =>
+            Task.FromResult(episodes.FirstOrDefault(x => x.Id == episodeId));
+
+        public Task<IEnumerable<AppleEpisode>?> GetEpisodes(ApplePodcastId podcastId, IndexingContext indexingContext) =>
+            Task.FromResult<IEnumerable<AppleEpisode>?>(episodes);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/AppleEpisodeResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/AppleEpisodeResolver.cs
@@ -16,7 +16,52 @@ public class AppleEpisodeResolver(
     private const int MinSameLengthFuzzyScore = 80;
     private static readonly long TimeDifferenceThreshold = TimeSpan.FromSeconds(30).Ticks;
     private static readonly long BroaderTimeDifferenceThreshold = TimeSpan.FromSeconds(90).Ticks;
+    private static readonly long YouTubeDiscoveredDurationThreshold = TimeSpan.FromMinutes(5).Ticks;
     private static readonly TimeSpan SameReleaseThreshold = TimeSpan.FromHours(3);
+    private static readonly TimeSpan YouTubeDiscoveredReleaseThreshold = TimeSpan.FromHours(12);
+
+    private static long GetDurationThresholdTicks(FindAppleEpisodeRequest request) =>
+        request.EnrichingYouTubeDiscoveredEpisode
+            ? YouTubeDiscoveredDurationThreshold
+            : TimeDifferenceThreshold;
+
+    private static AppleEpisode? MatchYouTubeDiscoveredEpisodeByDuration(
+        IList<AppleEpisode> sampleList,
+        TimeSpan episodeLength,
+        DateTime? released)
+    {
+        var sameLength = sampleList
+            .Where(x => Math.Abs((x.Duration - episodeLength).Ticks) < YouTubeDiscoveredDurationThreshold)
+            .ToList();
+
+        if (sameLength.Count == 1)
+        {
+            return sameLength[0];
+        }
+
+        if (sameLength.Count > 1 && released.HasValue)
+        {
+            return sameLength.MinBy(x => Math.Abs((x.Release - released.Value).Ticks));
+        }
+
+        if (released.HasValue)
+        {
+            var releaseMatches = sampleList
+                .Where(x => Math.Abs((x.Release - released.Value).Ticks) < YouTubeDiscoveredReleaseThreshold.Ticks)
+                .ToList();
+            if (releaseMatches.Count == 1)
+            {
+                return releaseMatches[0];
+            }
+
+            if (releaseMatches.Count > 1)
+            {
+                return releaseMatches.MinBy(x => Math.Abs((x.Release - released.Value).Ticks));
+            }
+        }
+
+        return null;
+    }
 
     public async Task<AppleEpisode?> FindEpisode(
         FindAppleEpisodeRequest request,
@@ -79,12 +124,26 @@ public class AppleEpisodeResolver(
                         sampleList = podcastEpisodes.ToList();
                     }
 
-                    if (request.EpisodeLength.HasValue)
+                    if (request.EpisodeLength is { } episodeLength && episodeLength > TimeSpan.Zero)
                     {
+                        if (request.EnrichingYouTubeDiscoveredEpisode)
+                        {
+                            var youTubeDiscoveredMatch = MatchYouTubeDiscoveredEpisodeByDuration(
+                                sampleList,
+                                episodeLength,
+                                request.Released);
+                            if (youTubeDiscoveredMatch != null)
+                            {
+                                return youTubeDiscoveredMatch;
+                            }
+                        }
+
+                        var durationThreshold = GetDurationThresholdTicks(request);
                         var sameLength = sampleList
-                            .Where(x => Math.Abs((x.Duration - request.EpisodeLength.Value).Ticks) <
-                                        TimeDifferenceThreshold);
-                        if (sameLength.Count() > 1)
+                            .Where(x => Math.Abs((x.Duration - episodeLength).Ticks) < durationThreshold)
+                            .ToList();
+
+                        if (sameLength.Count > 1)
                         {
                             return FuzzyMatcher.Match(request.EpisodeTitle, sameLength, x => x.Title, MinSameLengthFuzzyScore);
                         }
@@ -97,13 +156,14 @@ public class AppleEpisodeResolver(
                             {
                                 sameLength = sampleList.Where(x =>
                                     Math.Abs((x.Release - request.Released!).Value.Ticks) <
-                                    SameReleaseThreshold.Ticks);
+                                    SameReleaseThreshold.Ticks).ToList();
                             }
 
                             if (request.ReleaseAuthority == Service.YouTube)
-
                             {
-                                sameLength = sampleList.Where(x => Math.Abs((x.Duration - request.EpisodeLength.Value).Ticks) < BroaderTimeDifferenceThreshold);
+                                sameLength = sampleList.Where(x =>
+                                    Math.Abs((x.Duration - episodeLength).Ticks) <
+                                    BroaderTimeDifferenceThreshold).ToList();
                             }
 
                             return FuzzyMatcher.Match(request.EpisodeTitle, sameLength, x => x.Title,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/FindAppleEpisodeRequest.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/FindAppleEpisodeRequest.cs
@@ -10,4 +10,5 @@ public record FindAppleEpisodeRequest(
     DateTime? Released,
     Service? ReleaseAuthority,
     TimeSpan? EpisodeLength,
-    TimeSpan? YouTubePublishingDelay);
+    TimeSpan? YouTubePublishingDelay,
+    bool EnrichingYouTubeDiscoveredEpisode = false);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/FindAppleEpisodeRequestFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/FindAppleEpisodeRequestFactory.cs
@@ -8,6 +8,8 @@ public static class FindAppleEpisodeRequestFactory
     public static FindAppleEpisodeRequest Create(Podcast podcast, Episode episode)
     {
         var release = EpisodeReleaseMatchTolerance.GetAudioReleaseForPlatformLookup(podcast, episode);
+        var enrichingYouTubeDiscoveredEpisode =
+            !string.IsNullOrWhiteSpace(episode.YouTubeId) || episode.Urls.YouTube != null;
         return new FindAppleEpisodeRequest(
             podcast.AppleId,
             podcast.Name,
@@ -16,7 +18,8 @@ public static class FindAppleEpisodeRequestFactory
             release,
             podcast.ReleaseAuthority,
             episode.Length,
-            podcast.YouTubePublishingDelay()
+            podcast.YouTubePublishingDelay(),
+            enrichingYouTubeDiscoveredEpisode
         );
     }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/FindAppleEpisodeRequestFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/FindAppleEpisodeRequestFactory.cs
@@ -7,7 +7,7 @@ public static class FindAppleEpisodeRequestFactory
 {
     public static FindAppleEpisodeRequest Create(Podcast podcast, Episode episode)
     {
-        var release = CalculateRelativeRelease(podcast, episode.Release);
+        var release = EpisodeReleaseMatchTolerance.GetAudioReleaseForPlatformLookup(podcast, episode);
         return new FindAppleEpisodeRequest(
             podcast.AppleId,
             podcast.Name,
@@ -20,16 +20,6 @@ public static class FindAppleEpisodeRequestFactory
         );
     }
 
-    private static DateTime CalculateRelativeRelease(Podcast podcast, DateTime release)
-    {
-        if (podcast.ReleaseAuthority == Service.YouTube && podcast.YouTubePublishingDelay() != TimeSpan.Zero)
-        {
-            release -= podcast.YouTubePublishingDelay();
-        }
-
-        return release;
-    }
-
     public static FindAppleEpisodeRequest Create(
         Podcast? podcast,
         iTunesSearch.Library.Models.Podcast applePodcast,
@@ -38,7 +28,7 @@ public static class FindAppleEpisodeRequestFactory
         var release = criteria.Release;
         if (podcast != null)
         {
-            release = CalculateRelativeRelease(podcast, criteria.Release);
+            release = EpisodeReleaseMatchTolerance.GetAudioReleaseForPlatformLookup(podcast, criteria.Release, false);
         }
 
         return new FindAppleEpisodeRequest(

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Factories/FindSpotifyEpisodeRequestFactoryTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Factories/FindSpotifyEpisodeRequestFactoryTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.Spotify.Factories;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.Factories;
+
+public class FindSpotifyEpisodeRequestFactoryTests
+{
+    [Fact]
+    public void Create_WhenEpisodeDiscoveredViaYouTubeOnSpotifyPrimaryPodcast_AdjustsReleaseAndUsesDurationMatching()
+    {
+        var delay = TimeSpan.FromHours(9);
+        var podcast = new Podcast
+        {
+            SpotifyId = "spotify-show",
+            Name = "The Shadow Sessions Podcast",
+            YouTubePublicationOffset = delay.Ticks
+        };
+        var youTubePublish = new DateTime(2026, 7, 2, 9, 0, 0, DateTimeKind.Utc);
+        var episode = new Episode
+        {
+            Title = "My Family Was America's Most Dangerous Cult",
+            Release = youTubePublish,
+            Length = TimeSpan.FromMinutes(62),
+            YouTubeId = "video-id",
+            Urls = new ServiceUrls { YouTube = new Uri("https://www.youtube.com/watch?v=video-id") }
+        };
+
+        var request = FindSpotifyEpisodeRequestFactory.Create(podcast, episode);
+
+        request.Released.Should().Be(youTubePublish - delay);
+        request.EnrichingYouTubeDiscoveredEpisode.Should().BeTrue();
+        request.Length.Should().Be(episode.Length);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Finders/SearchResultFinderTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Finders/SearchResultFinderTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedditPodcastPoster.PodcastServices.Spotify.Finders;
+using SpotifyAPI.Web;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.Finders;
+
+public class SearchResultFinderTests
+{
+    private readonly SearchResultFinder _sut = new(NullLogger<SearchResultFinder>.Instance);
+
+    [Fact]
+    public void FindMatchingEpisodeByLength_WhenTitlesDifferButDurationIsUnique_AcceptsWithoutTitleMatch()
+    {
+        var episodeLength = TimeSpan.FromMinutes(62);
+        var episodes = new List<SimpleEpisode>
+        {
+            new()
+            {
+                Id = "577DaJslYV1BZUXasvwLBT",
+                Name = "My Family Was America's Most Dangerous Cult",
+                DurationMs = (int)episodeLength.TotalMilliseconds,
+                ReleaseDate = "2026-07-02"
+            },
+            new()
+            {
+                Id = "other-episode",
+                Name = "Different Episode",
+                DurationMs = (int)TimeSpan.FromMinutes(30).TotalMilliseconds,
+                ReleaseDate = "2026-07-02"
+            }
+        };
+
+        var result = _sut.FindMatchingEpisodeByLength(
+            "\"I Grew Up in a Murder Cult\" Cult Survivor Reveals What It's Like To Grow Up Inside It",
+            episodeLength,
+            episodes,
+            acceptUniqueDurationWithoutTitleMatch: true);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("577DaJslYV1BZUXasvwLBT");
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyEpisodeEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyEpisodeEnricher.cs
@@ -41,7 +41,10 @@ public class SpotifyEpisodeEnricher(
             indexingContext,
             y => !assignedSpotifyIds.Contains(y.Id) &&
                  findSpotifyEpisodeRequest.Released.HasValue &&
-                 Math.Abs((y.GetReleaseDate() - findSpotifyEpisodeRequest.Released.Value).Ticks) < ticks);
+                 EpisodeReleaseMatchTolerance.SpotifyCatalogueReleaseMatches(
+                     y.GetReleaseDate(),
+                     findSpotifyEpisodeRequest.Released.Value,
+                     ticks));
 
         if (findEpisodeResult.FullEpisode != null &&
             request.Episodes.All(x => x.SpotifyId != findEpisodeResult.FullEpisode.Id))

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Factories/FindSpotifyEpisodeRequestFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Factories/FindSpotifyEpisodeRequestFactory.cs
@@ -11,7 +11,7 @@ public static class FindSpotifyEpisodeRequestFactory
         var release = criteria.Release;
         if (podcast != null)
         {
-            release = CalculateRelativeRelease(podcast, criteria.Release);
+            release = EpisodeReleaseMatchTolerance.GetAudioReleaseForPlatformLookup(podcast, criteria.Release, false);
         }
 
         return new FindSpotifyEpisodeRequest(
@@ -28,7 +28,8 @@ public static class FindSpotifyEpisodeRequestFactory
 
     public static FindSpotifyEpisodeRequest Create(Podcast podcast, Episode episode)
     {
-        var release = CalculateRelativeRelease(podcast, episode.Release);
+        var enrichingYouTubeDiscoveredEpisode = EpisodeHasYouTubeIdentity(episode);
+        var release = EpisodeReleaseMatchTolerance.GetAudioReleaseForPlatformLookup(podcast, episode);
 
         return new FindSpotifyEpisodeRequest(
             podcast.SpotifyId,
@@ -40,7 +41,8 @@ public static class FindSpotifyEpisodeRequestFactory
             podcast.YouTubePublishingDelay(),
             podcast.ReleaseAuthority,
             episode.Length,
-            podcast.SpotifyMarket);
+            podcast.SpotifyMarket,
+            enrichingYouTubeDiscoveredEpisode);
     }
 
     public static FindSpotifyEpisodeRequest Create(string episodeSpotifyId)
@@ -54,13 +56,6 @@ public static class FindSpotifyEpisodeRequestFactory
             true);
     }
 
-    private static DateTime CalculateRelativeRelease(Podcast podcast, DateTime release)
-    {
-        if (podcast.ReleaseAuthority == Service.YouTube && podcast.YouTubePublishingDelay() != TimeSpan.Zero)
-        {
-            release -= podcast.YouTubePublishingDelay();
-        }
-
-        return release;
-    }
+    private static bool EpisodeHasYouTubeIdentity(Episode episode) =>
+        !string.IsNullOrWhiteSpace(episode.YouTubeId) || episode.Urls.YouTube != null;
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/ISearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/ISearchResultFinder.cs
@@ -20,5 +20,6 @@ public interface ISearchResultFinder
         IEnumerable<SimpleEpisode> episodeLists,
         Func<SimpleEpisode, bool>? reducer = null,
         Service? releaseAuthority = null,
-        DateTime? released = null);
+        DateTime? released = null,
+        bool acceptUniqueDurationWithoutTitleMatch = false);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/SearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/SearchResultFinder.cs
@@ -37,7 +37,8 @@ public class SearchResultFinder(
         IEnumerable<SimpleEpisode> episodes,
         Func<SimpleEpisode, bool>? reducer = null,
         Service? releaseAuthority = null,
-        DateTime? released = null)
+        DateTime? released = null,
+        bool acceptUniqueDurationWithoutTitleMatch = false)
     {
         var requestEpisodeTitle = WebUtility.HtmlDecode(episodeTitle.Trim());
 
@@ -67,8 +68,14 @@ public class SearchResultFinder(
             }
 
             var sameLength = sampleList
-                .Where(x => Math.Abs((x.GetDuration() - episodeLength).Ticks) < TimeDifferenceThreshold);
-            if (sameLength.Count() > 1)
+                .Where(x => Math.Abs((x.GetDuration() - episodeLength).Ticks) < TimeDifferenceThreshold)
+                .ToList();
+            if (sameLength.Count == 1 && acceptUniqueDurationWithoutTitleMatch)
+            {
+                return sameLength[0];
+            }
+
+            if (sameLength.Count > 1)
             {
                 return FuzzyMatcher.Match(episodeTitle, sameLength, x => x.Name, MinSameLengthFuzzyScore);
             }
@@ -80,13 +87,13 @@ public class SearchResultFinder(
                 if (released.HasValue)
                 {
                     sameLength = sampleList.Where(x =>
-                        Math.Abs((x.GetReleaseDate() - released.Value).Ticks) < SameReleaseThreshold.Ticks);
+                        Math.Abs((x.GetReleaseDate() - released.Value).Ticks) < SameReleaseThreshold.Ticks).ToList();
                 }
 
                 if (releaseAuthority == Service.YouTube)
                 {
                     sameLength = sampleList.Where(x =>
-                        Math.Abs((x.GetDuration() - episodeLength).Ticks) < BroaderTimeDifferenceThreshold);
+                        Math.Abs((x.GetDuration() - episodeLength).Ticks) < BroaderTimeDifferenceThreshold).ToList();
                 }
 
                 return FuzzyMatcher.Match(episodeTitle, sameLength, x => x.Name, SameLengthMinFuzzyScore);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/FindSpotifyEpisodeRequest.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/FindSpotifyEpisodeRequest.cs
@@ -12,4 +12,5 @@ public record FindSpotifyEpisodeRequest(
     TimeSpan? YouTubePublishingDelay= null,
     Service? ReleaseAuthority = null,
     TimeSpan? Length = null,
-    string? Market = null);
+    string? Market = null,
+    bool EnrichingYouTubeDiscoveredEpisode = false);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
@@ -46,16 +46,17 @@ public class SpotifyEpisodeResolver(
         var podcastEpisodes = await spotifyPodcastEpisodesProvider.GetAllEpisodes(request, indexingContext, market);
 
         SimpleEpisode? matchingEpisode;
-        if (request is { Length: not null } &&
+        if (request.Length is { } episodeLength && episodeLength > TimeSpan.Zero &&
             (request.ReleaseAuthority == Service.YouTube || request.EnrichingYouTubeDiscoveredEpisode))
         {
             matchingEpisode = searchResultFinder.FindMatchingEpisodeByLength(
                 request.EpisodeTitle,
-                request.Length.Value,
+                episodeLength,
                 podcastEpisodes.Episodes,
                 reducer,
                 request.ReleaseAuthority,
-                request.Released);
+                request.Released,
+                request.EnrichingYouTubeDiscoveredEpisode);
         }
         else
         {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
@@ -46,7 +46,8 @@ public class SpotifyEpisodeResolver(
         var podcastEpisodes = await spotifyPodcastEpisodesProvider.GetAllEpisodes(request, indexingContext, market);
 
         SimpleEpisode? matchingEpisode;
-        if (request is { ReleaseAuthority: Service.YouTube, Length: not null })
+        if (request is { Length: not null } &&
+            (request.ReleaseAuthority == Service.YouTube || request.EnrichingYouTubeDiscoveredEpisode))
         {
             matchingEpisode = searchResultFinder.FindMatchingEpisodeByLength(
                 request.EpisodeTitle,


### PR DESCRIPTION
## Summary
- Enrich Spotify and Apple URLs for episodes discovered via YouTube by shifting platform lookup release dates with the podcast YouTube publishing delay and using duration-based matching when catalogue titles differ
- Fix false episode merges on negative-delay podcasts (e.g. Cults to Consciousness): cap release tolerance, skip raw release-only matching when delay is negative, require fuzzy title match for release+duration fallback, and block merges when incoming Spotify/Apple IDs already belong to another episode
- Fix Spotify enrichment reducer for catalogue midnight release dates by comparing DateOnly ±1 day instead of tick-level tolerance only

## Test plan
- [x] \dotnet test Class-Libraries/RedditPodcastPoster.Persistence.Tests\
- [x] \dotnet test Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests\
- [x] \dotnet test Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests\
- [x] Rebuild \index.exe\ and run \index -p 0083adfe-ed35-45ae-aace-d5cfc7ea7858\ — Shadow Sessions episode \3f19944c-6d91-4a10-9bc8-ed2244ffe305\ gets Spotify/Apple URLs despite title mismatch
- [x] Rebuild \index.exe\ and run \index -p 1aa72d3d-f1e4-458f-a172-62990ef6c200\ — C2C episode \53ba0c64-58a7-4292-b7fe-ba135d4d3160\ gets Spotify \15mgyInwuQGbrUerfQGknX\ and Apple \1000775010050\ after clearing platform IDs