### PR TITLE
Episode domain refactor Phase B: UrlSubmission through applier

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Episodes/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/ServiceCollectionExtensions.cs
@@ -14,8 +14,9 @@ public static class ServiceCollectionExtensions
         /// <summary>
         /// Episode platform matcher, merger, applier, and their strategies/policies.
         /// Required when resolving <c>IEpisodeMatcher</c>, <c>IEpisodeMerger</c>, or UrlSubmission
-        /// <c>IEpisodeEnricher</c>. Register at the host composition root alongside
-        /// <c>AddRepositories()</c> when needed — not nested inside persistence registration.
+        /// <c>IEpisodeEnricher</c>. Each host must call this explicitly at its composition root
+        /// (alongside <c>AddRepositories()</c> when needed) — never nested inside
+        /// <c>AddRepositories()</c>, <c>AddUrlSubmission()</c>, or any other extension method.
         /// </summary>
         public IServiceCollection AddEpisodesDomain()
         {

--- a/Class-Libraries/RedditPodcastPoster.Episodes/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/ServiceCollectionExtensions.cs
@@ -11,6 +11,12 @@ public static class ServiceCollectionExtensions
 {
     extension(IServiceCollection services)
     {
+        /// <summary>
+        /// Episode platform matcher, merger, applier, and their strategies/policies.
+        /// Required when resolving <c>IEpisodeMatcher</c>, <c>IEpisodeMerger</c>, or UrlSubmission
+        /// <c>IEpisodeEnricher</c>. Register at the host composition root alongside
+        /// <c>AddRepositories()</c> when needed — not nested inside persistence registration.
+        /// </summary>
         public IServiceCollection AddEpisodesDomain()
         {
             services.AddSingleton<IEpisodePlatformApplier, EpisodePlatformApplier>();

--- a/Class-Libraries/RedditPodcastPoster.Persistence/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
 using RedditPodcastPoster.Configuration.Extensions;
-using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Persistence.Abstractions;
 
 namespace RedditPodcastPoster.Persistence.Extensions;
@@ -10,10 +9,14 @@ public static class ServiceCollectionExtensions
 {
     extension(IServiceCollection services)
     {
+        /// <summary>
+        /// Cosmos repositories and legacy <see cref="IEpisodeMatcher"/> / <see cref="IEpisodeMerger"/>.
+        /// Does not register episodes domain — callers that resolve matcher, merger, or UrlSubmission
+        /// enrichers must call <c>AddEpisodesDomain()</c> explicitly at the composition root.
+        /// </summary>
         public IServiceCollection AddRepositories()
         {
             return services
-                .AddEpisodesDomain()
                 .AddSingleton<ICosmosDbClientFactory, CosmosDbClientFactory>()
                 .AddSingleton(sp => sp.GetRequiredService<ICosmosDbClientFactory>().Create())
                 .AddSingleton<ICosmosDbContainerFactory, CosmosDbContainerFactory>()

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionEnrichmentRules.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using RedditPodcastPoster.Episodes.Applying;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.PodcastServices.Apple;
@@ -19,8 +20,7 @@ public class UrlSubmissionEnrichmentRules
     public void existing_episode_missing_platform_links_are_filled_from_resolved_items()
     {
         // Arrange
-        var descriptionHelper = CreateDescriptionHelper();
-        var enricher = new EpisodeEnricher(descriptionHelper, NullLogger<EpisodeEnricher>.Instance);
+        var enricher = CreateEnricher();
 
         var podcast = _fixture.CreatePodcast();
         podcast.SpotifyId = _fixture.CreateSpotifyId();
@@ -115,8 +115,7 @@ public class UrlSubmissionEnrichmentRules
     public void podcast_show_metadata_is_enriched_from_resolved_items()
     {
         // Arrange
-        var descriptionHelper = CreateDescriptionHelper();
-        var enricher = new EpisodeEnricher(descriptionHelper, NullLogger<EpisodeEnricher>.Instance);
+        var enricher = CreateEnricher();
 
         var podcast = _fixture.CreatePodcast();
         podcast.SpotifyId = string.Empty;
@@ -200,8 +199,7 @@ public class UrlSubmissionEnrichmentRules
     public void unchanged_existing_episode_remains_episode_already_exists()
     {
         // Arrange
-        var descriptionHelper = CreateDescriptionHelper();
-        var enricher = new EpisodeEnricher(descriptionHelper, NullLogger<EpisodeEnricher>.Instance);
+        var enricher = CreateEnricher();
 
         var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
         podcast.AppleId = _fixture.CreateAppleId();
@@ -284,8 +282,7 @@ public class UrlSubmissionEnrichmentRules
     public void enriched_existing_episode_reports_enriched_result_state()
     {
         // Arrange
-        var descriptionHelper = CreateDescriptionHelper();
-        var enricher = new EpisodeEnricher(descriptionHelper, NullLogger<EpisodeEnricher>.Instance);
+        var enricher = CreateEnricher();
 
         var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
         var storedDescription = _fixture.Create<string>();
@@ -337,7 +334,7 @@ public class UrlSubmissionEnrichmentRules
         response.AppliedEpisodeResult.Should().Be(SubmitResultState.Enriched);
     }
 
-    private static IDescriptionHelper CreateDescriptionHelper()
+    private static EpisodeEnricher CreateEnricher()
     {
         var descriptionHelper = new Mock<IDescriptionHelper>();
         descriptionHelper
@@ -346,6 +343,10 @@ public class UrlSubmissionEnrichmentRules
         descriptionHelper
             .Setup(x => x.EnrichMissingDescription(It.IsAny<CategorisedItem>()))
             .Returns("Resolved description");
-        return descriptionHelper.Object;
+
+        return new EpisodeEnricher(
+            descriptionHelper.Object,
+            new EpisodePlatformApplier(),
+            NullLogger<EpisodeEnricher>.Instance);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/UrlSubmissionDependencyInjectionTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/UrlSubmissionDependencyInjectionTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes;
+using RedditPodcastPoster.UrlSubmission.Extensions;
+
+namespace RedditPodcastPoster.UrlSubmission.Tests;
+
+public class UrlSubmissionDependencyInjectionTests
+{
+    [Fact]
+    public void EpisodeEnricher_resolves_when_episodes_domain_registered_explicitly()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddEpisodesDomain();
+        services.AddUrlSubmission();
+
+        using var provider = services.BuildServiceProvider();
+        var enricher = provider.GetRequiredService<IEpisodeEnricher>();
+
+        enricher.Should().BeOfType<EpisodeEnricher>();
+    }
+
+    [Fact]
+    public void EpisodeEnricher_fails_without_episodes_domain()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddUrlSubmission();
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IEpisodeEnricher>();
+        act.Should().Throw<InvalidOperationException>();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/EpisodeEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/EpisodeEnricher.cs
@@ -1,5 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes.Adapters;
+using RedditPodcastPoster.Episodes.Adapters.Inputs;
+using RedditPodcastPoster.Episodes.Applying;
+using RedditPodcastPoster.Episodes.Domain;
 using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.Apple;
+using RedditPodcastPoster.PodcastServices.Spotify.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Models;
 
@@ -7,8 +14,13 @@ namespace RedditPodcastPoster.UrlSubmission;
 
 public class EpisodeEnricher(
     IDescriptionHelper descriptionHelper,
+    IEpisodePlatformApplier episodePlatformApplier,
     ILogger<EpisodeEnricher> logger) : IEpisodeEnricher
 {
+    private readonly ResolvedAppleItemAdapter _appleItemAdapter = new();
+    private readonly ResolvedSpotifyItemAdapter _spotifyItemAdapter = new();
+    private readonly ResolvedYouTubeItemAdapter _youTubeItemAdapter = new();
+
     public ApplyResolvePodcastServicePropertiesResponse ApplyResolvedPodcastServiceProperties(
         Podcast matchingPodcast,
         CategorisedItem categorisedItem,
@@ -40,24 +52,27 @@ public class EpisodeEnricher(
 
             if (matchingEpisode != null)
             {
-                if (!matchingEpisode.AppleId.HasValue && categorisedItem.ResolvedAppleItem.EpisodeId.HasValue)
+                var missingAppleId = !matchingEpisode.AppleId.HasValue;
+                var missingAppleUrl = matchingEpisode.Urls.Apple == null;
+
+                ApplyPlatformLink(matchingEpisode, _appleItemAdapter.Adapt(ToInput(categorisedItem.ResolvedAppleItem)));
+
+                if (missingAppleId && matchingEpisode.AppleId.HasValue)
                 {
                     addedApple = true;
-                    matchingEpisode.AppleId = categorisedItem.ResolvedAppleItem.EpisodeId;
                     episodeResult = SubmitResultState.Enriched;
                     logger.LogInformation(
                         "Enriched episode '{matchingEpisodeId}' with apple details with apple-id {resolvedAppleItemEpisodeId}.",
-                        matchingEpisode.Id, categorisedItem.ResolvedAppleItem.EpisodeId);
+                        matchingEpisode.Id, matchingEpisode.AppleId);
                 }
 
-                if (matchingEpisode.Urls.Apple == null && categorisedItem.ResolvedAppleItem.Url != null)
+                if (missingAppleUrl && matchingEpisode.Urls.Apple != null)
                 {
                     addedApple = true;
-                    matchingEpisode.Urls.Apple = categorisedItem.ResolvedAppleItem.Url;
                     episodeResult = SubmitResultState.Enriched;
                     logger.LogInformation(
                         "Enriched episode '{matchingEpisodeId}' with apple details with apple-url {resolvedAppleItemUrl}.",
-                        matchingEpisode.Id, categorisedItem.ResolvedAppleItem.Url);
+                        matchingEpisode.Id, matchingEpisode.Urls.Apple);
                 }
 
                 if (matchingEpisode.Release.TimeOfDay == TimeSpan.Zero &&
@@ -77,12 +92,6 @@ public class EpisodeEnricher(
                     matchingEpisode.Description = description;
                     episodeResult = SubmitResultState.Enriched;
                 }
-
-                if (matchingEpisode.Images?.Apple == null && categorisedItem.ResolvedAppleItem.Image != null)
-                {
-                    matchingEpisode.Images ??= new EpisodeImages();
-                    matchingEpisode.Images.Apple = categorisedItem.ResolvedAppleItem.Image;
-                }
             }
         }
 
@@ -99,25 +108,27 @@ public class EpisodeEnricher(
 
             if (matchingEpisode != null)
             {
-                if (string.IsNullOrWhiteSpace(matchingEpisode.SpotifyId) &&
-                    !string.IsNullOrWhiteSpace(categorisedItem.ResolvedSpotifyItem.EpisodeId))
+                var missingSpotifyId = string.IsNullOrWhiteSpace(matchingEpisode.SpotifyId);
+                var missingSpotifyUrl = matchingEpisode.Urls.Spotify == null;
+
+                ApplyPlatformLink(matchingEpisode, _spotifyItemAdapter.Adapt(ToInput(categorisedItem.ResolvedSpotifyItem)));
+
+                if (missingSpotifyId && !string.IsNullOrWhiteSpace(matchingEpisode.SpotifyId))
                 {
                     addedSpotify = true;
-                    matchingEpisode.SpotifyId = categorisedItem.ResolvedSpotifyItem.EpisodeId;
                     episodeResult = SubmitResultState.Enriched;
                     logger.LogInformation(
                         "Enriched episode '{matchingEpisodeId}' with spotify details with spotify-id {resolvedSpotifyItemEpisodeId}.",
-                        matchingEpisode.Id, categorisedItem.ResolvedSpotifyItem.EpisodeId);
+                        matchingEpisode.Id, matchingEpisode.SpotifyId);
                 }
 
-                if (matchingEpisode.Urls.Spotify == null && categorisedItem.ResolvedSpotifyItem.Url != null)
+                if (missingSpotifyUrl && matchingEpisode.Urls.Spotify != null)
                 {
                     addedSpotify = true;
-                    matchingEpisode.Urls.Spotify = categorisedItem.ResolvedSpotifyItem.Url;
                     episodeResult = SubmitResultState.Enriched;
                     logger.LogInformation(
                         "Enriched episode '{matchingEpisodeId}' with spotify details with spotify-url {resolvedSpotifyItemUrl}.",
-                        matchingEpisode.Id, categorisedItem.ResolvedSpotifyItem.Url);
+                        matchingEpisode.Id, matchingEpisode.Urls.Spotify);
                 }
 
                 var description =
@@ -128,12 +139,6 @@ public class EpisodeEnricher(
                 {
                     matchingEpisode.Description = description;
                     episodeResult = SubmitResultState.Enriched;
-                }
-
-                if (matchingEpisode.Images?.Spotify == null && categorisedItem.ResolvedSpotifyItem.Image != null)
-                {
-                    matchingEpisode.Images ??= new EpisodeImages();
-                    matchingEpisode.Images.Spotify = categorisedItem.ResolvedSpotifyItem.Image;
                 }
             }
         }
@@ -152,25 +157,27 @@ public class EpisodeEnricher(
 
             if (matchingEpisode != null)
             {
-                if (string.IsNullOrWhiteSpace(matchingEpisode.YouTubeId) &&
-                    !string.IsNullOrWhiteSpace(categorisedItem.ResolvedYouTubeItem.EpisodeId))
+                var missingYouTubeId = string.IsNullOrWhiteSpace(matchingEpisode.YouTubeId);
+                var missingYouTubeUrl = matchingEpisode.Urls.YouTube == null;
+
+                ApplyPlatformLink(matchingEpisode, _youTubeItemAdapter.Adapt(ToInput(categorisedItem.ResolvedYouTubeItem)));
+
+                if (missingYouTubeId && !string.IsNullOrWhiteSpace(matchingEpisode.YouTubeId))
                 {
                     addedYouTube = true;
-                    matchingEpisode.YouTubeId = categorisedItem.ResolvedYouTubeItem.EpisodeId;
                     episodeResult = SubmitResultState.Enriched;
                     logger.LogInformation(
                         "Enriched episode '{matchingEpisodeId}' with youtube details with youtube-id {resolvedYouTubeItemEpisodeId}.",
-                        matchingEpisode.Id, categorisedItem.ResolvedYouTubeItem.EpisodeId);
+                        matchingEpisode.Id, matchingEpisode.YouTubeId);
                 }
 
-                if (matchingEpisode.Urls.YouTube == null && categorisedItem.ResolvedYouTubeItem.Url != null)
+                if (missingYouTubeUrl && matchingEpisode.Urls.YouTube != null)
                 {
                     addedYouTube = true;
-                    matchingEpisode.Urls.YouTube = categorisedItem.ResolvedYouTubeItem.Url;
                     episodeResult = SubmitResultState.Enriched;
                     logger.LogInformation(
                         "Enriched episode '{matchingEpisodeId}' with youtube details with youtube-url {resolvedYouTubeItem.}.",
-                        matchingEpisode.Id, categorisedItem.ResolvedYouTubeItem.Url);
+                        matchingEpisode.Id, matchingEpisode.Urls.YouTube);
                 }
 
                 if (matchingEpisode.Release.TimeOfDay == TimeSpan.Zero &&
@@ -188,12 +195,6 @@ public class EpisodeEnricher(
                 {
                     matchingEpisode.Description = description;
                     episodeResult = SubmitResultState.Enriched;
-                }
-
-                if (matchingEpisode.Images?.YouTube == null && categorisedItem.ResolvedYouTubeItem.Image != null)
-                {
-                    matchingEpisode.Images ??= new EpisodeImages();
-                    matchingEpisode.Images.YouTube = categorisedItem.ResolvedYouTubeItem.Image;
                 }
             }
         }
@@ -250,4 +251,41 @@ public class EpisodeEnricher(
         return new ApplyResolvePodcastServicePropertiesResponse(podcastResult, episodeResult,
             new SubmitEpisodeDetails(addedSpotify, addedApple, addedYouTube, [], addedBBC, addedInternetArchive));
     }
+
+    private void ApplyPlatformLink(Episode matchingEpisode, EpisodeCandidate candidate)
+    {
+        episodePlatformApplier.ApplyFillMissing(
+            matchingEpisode,
+            new EpisodePlatformPatch(candidate.SourceLink, Description: null, Release: null));
+    }
+
+    private static ResolvedAppleItemInput ToInput(ResolvedAppleItem item) =>
+        new(
+            item.EpisodeId,
+            item.EpisodeTitle,
+            item.EpisodeDescription,
+            item.Release,
+            item.Duration,
+            item.Url,
+            item.Image);
+
+    private static ResolvedSpotifyItemInput ToInput(ResolvedSpotifyItem item) =>
+        new(
+            item.EpisodeId,
+            item.EpisodeTitle,
+            item.EpisodeDescription,
+            item.Release,
+            item.Duration,
+            item.Url,
+            item.Image);
+
+    private static ResolvedYouTubeItemInput ToInput(ResolvedYouTubeItem item) =>
+        new(
+            item.EpisodeId,
+            item.EpisodeTitle,
+            item.EpisodeDescription,
+            item.Release,
+            item.Duration,
+            item.Url,
+            item.Image);
 }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Extensions/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class ServiceCollectionExtensions
 {
     /// <summary>
     /// UrlSubmission pipeline services. Does not register episodes domain —
-    /// callers must call <c>AddEpisodesDomain()</c> (included in persistence <c>AddRepositories()</c>).
+    /// callers must call <c>AddEpisodesDomain()</c> explicitly at the composition root.
     /// </summary>
     public static IServiceCollection AddUrlSubmission(this IServiceCollection services)
     {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Extensions/ServiceCollectionExtensions.cs
@@ -9,6 +9,10 @@ namespace RedditPodcastPoster.UrlSubmission.Extensions;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// UrlSubmission pipeline services. Does not register episodes domain —
+    /// callers must call <c>AddEpisodesDomain()</c> (included in persistence <c>AddRepositories()</c>).
+    /// </summary>
     public static IServiceCollection AddUrlSubmission(this IServiceCollection services)
     {
         return services

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/RedditPodcastPoster.UrlSubmission.csproj
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/RedditPodcastPoster.UrlSubmission.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RedditPodcastPoster.Configuration\RedditPodcastPoster.Configuration.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.Episodes\RedditPodcastPoster.Episodes.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.Apple\RedditPodcastPoster.PodcastServices.Apple.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.Spotify\RedditPodcastPoster.PodcastServices.Spotify.csproj" />

--- a/Cloud/Api/Ioc.cs
+++ b/Cloud/Api/Ioc.cs
@@ -17,6 +17,7 @@ using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.ContentPublisher.Extensions;
 using RedditPodcastPoster.Discovery;
 using RedditPodcastPoster.Discovery.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
 using RedditPodcastPoster.Indexing.Extensions;
 using RedditPodcastPoster.InternetArchive.Extensions;
@@ -44,6 +45,7 @@ public static class Ioc
         AdminRedditClientFactory.AddAdminRedditClient(serviceCollection);
 
         serviceCollection
+            .AddEpisodesDomain()
             .AddRepositories()
             .AddTextSanitiser()
             .AddYouTubeServices(ApplicationUsage.Api)

--- a/Cloud/Indexer/Ioc.cs
+++ b/Cloud/Indexer/Ioc.cs
@@ -10,6 +10,7 @@ using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.ContentPublisher.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.InternetArchive.Extensions;
 using RedditPodcastPoster.Persistence.Abstractions;
 using RedditPodcastPoster.Persistence.Extensions;
@@ -32,6 +33,7 @@ public static class Ioc
     public static void ConfigureServices(IServiceCollection serviceCollection)
     {
         serviceCollection
+            .AddEpisodesDomain()
             .AddRepositories()
             .AddTextSanitiser()
             .AddYouTubeServices(ApplicationUsage.Indexer)

--- a/Console-Apps/AddAudioPodcast/Program.cs
+++ b/Console-Apps/AddAudioPodcast/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices;
 using RedditPodcastPoster.PodcastServices.Abstractions;
@@ -32,6 +33,7 @@ builder.Configuration
 builder.Services
     .AddLogging()
     .AddScoped<AddAudioPodcastProcessor>()
+    .AddEpisodesDomain()
     .AddRepositories()
     .AddCommonServices()
     .AddPodcastServices()

--- a/Console-Apps/EnrichExistingEpisodesFromPodcastServices/Program.cs
+++ b/Console-Apps/EnrichExistingEpisodesFromPodcastServices/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices.Apple.Extensions;
 using RedditPodcastPoster.PodcastServices.Extensions;
@@ -29,6 +30,7 @@ builder.Configuration
 
 builder.Services
     .AddLogging()
+    .AddEpisodesDomain()
     .AddRepositories()
     .AddScoped<EnrichPodcastEpisodesProcessor>()
     .AddUrlSubmission()

--- a/Console-Apps/EnrichPodcastWithImages/Program.cs
+++ b/Console-Apps/EnrichPodcastWithImages/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using RedditPodcastPoster.BBC.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices.Apple.Extensions;
 using RedditPodcastPoster.PodcastServices.Extensions;
@@ -30,6 +31,7 @@ builder.Configuration
 builder.Services
     .AddSingleton<Processor>()
     .AddLogging()
+    .AddEpisodesDomain()
     .AddRepositories()
     .AddAppleServices()
     .AddYouTubeServices(ApplicationUsage.Cli)

--- a/Console-Apps/Index/Program.cs
+++ b/Console-Apps/Index/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Indexing.Extensions;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices;
@@ -33,6 +34,7 @@ builder.Configuration
 builder.Services
     .AddLogging()
     .AddSingleton<IndexProcessor>()
+    .AddEpisodesDomain()
     .AddRepositories()
     .AddCommonServices()
     .AddPodcastServices()

--- a/Console-Apps/Poster/Program.cs
+++ b/Console-Apps/Poster/Program.cs
@@ -9,6 +9,7 @@ using RedditPodcastPoster.Cloudflare.Extensions;
 using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.ContentPublisher.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices.Extensions;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
@@ -33,6 +34,7 @@ builder.Configuration
 builder.Services
     .AddLogging()
     .AddScoped<PostProcessor>()
+    .AddEpisodesDomain()
     .AddRepositories()
     .AddCommonServices()
     .AddPodcastServices()

--- a/Console-Apps/SubmitUrl/Program.cs
+++ b/Console-Apps/SubmitUrl/Program.cs
@@ -8,6 +8,7 @@ using RedditPodcastPoster.BBC.Extensions;
 using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.InternetArchive.Extensions;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices;
@@ -34,6 +35,7 @@ builder.Configuration
 
 builder.Services
     .AddLogging()
+    .AddEpisodesDomain()
     .AddRepositories()
     .AddCommonServices()
     .AddPodcastServices()

--- a/Console-Apps/WebsubStatus/Program.cs
+++ b/Console-Apps/WebsubStatus/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices.Extensions;
 using RedditPodcastPoster.YouTubePushNotifications.Extensions;
@@ -24,6 +25,7 @@ builder.Configuration
 builder.Services
     .AddLogging()
     .AddScoped<WebSubStatusProcessor>()
+    .AddEpisodesDomain()
     .AddRepositories()
     .AddPodcastServices()
     .AddCommonServices()

--- a/Console-Apps/WikipediaEpisodeEnricher/Program.cs
+++ b/Console-Apps/WikipediaEpisodeEnricher/Program.cs
@@ -10,6 +10,7 @@ using RedditPodcastPoster.BBC.Extensions;
 using RedditPodcastPoster.Cloudflare.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.ContentPublisher.Extensions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.InternetArchive.Extensions;
 using RedditPodcastPoster.Persistence.Abstractions;
 using RedditPodcastPoster.Persistence.Extensions;
@@ -37,6 +38,7 @@ builder.Configuration
 
 builder.Services
     .AddLogging()
+    .AddEpisodesDomain()
     .AddRepositories()
     .AddContentPublishing()
     .AddCloudflareClients()

--- a/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
+++ b/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
@@ -19,7 +19,7 @@
 | Phase | Status | Risk | PR |
 |-------|--------|------|----|
 | **A** — Domain types + applier/merger/matcher (internal) | 🟢 In production / Done | Medium | [#871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871) |
-| **B** — UrlSubmission through applier | 🟡 In progress | Medium | [#872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872) |
+| **B** — UrlSubmission through applier | 🟢 In production (soak) | Medium | [#872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872) |
 | **C** — Platform adapters at boundaries | ⬜ Not started | Medium–High | _PR link_ |
 | **D** — Collapse finders into single matcher | ⬜ Not started | Medium–High | _PR link_ |
 | **E** — Shared enricher template | ⬜ Not started | Medium | _PR link_ |
@@ -29,7 +29,7 @@
 
 ## Phase 0 / Phase A status
 
-Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871)). **Phase B** is in progress. Phases C–F not started.
+Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871)). **Phase B** is in production (soak via [PR #872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872); review pending). Phases C–F not started.
 
 | Step / phase | Outcome |
 |--------------|---------|
@@ -131,18 +131,29 @@ Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](htt
 - [x] Full Step 7 test set green (Episodes, PodcastServices, UrlSubmission, Persistence)
 - [x] `./scripts/coverage-gate.ps1` passes (no regression below baseline)
 - [x] PR opened for Phase B only
+- [x] Deployed for overnight soak (2026-07-04)
+- [ ] Soak review — pending (~2026-07-05)
 
-### Risk to production
+### Phase B deploy / soak status
+
+- [x] Branch deployed from [PR #872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872) (2026-07-04 overnight soak)
+- [x] **Api** — UrlSubmission Phase B (`EpisodeEnricher` → applier + resolved-item adapters)
+- [x] **Indexer** — explicit `AddEpisodesDomain()` + Phase A merge path
+- [x] **Discovery** — repos-only (no `AddEpisodesDomain()`)
+- [x] **Publishing console apps** — Poster etc. with explicit `AddEpisodesDomain()`
+- [ ] Soak review — pending (user review scheduled ~2026-07-05)
+
+### Risk to production (Phase B — live / soak context)
 
 - **Risk level:** Medium
-- **Blast radius:** UrlSubmission host — submit/enrich path (`EpisodeEnricher` → `EpisodePlatformApplier` + resolved-item adapters)
-- **What changes live:** How submitted URLs enrich existing episodes (platform ID/URL/image writes go through applier)
-- **What does not change:** Indexer match/merge (already on domain from Phase A); catalogue adapters still not wired at provider/resolver boundaries
+- **Blast radius:** UrlSubmission path on **Api** (`EpisodeEnricher` → `EpisodePlatformApplier` + resolved-item adapters); **Indexer** and publishing console apps carry explicit `AddEpisodesDomain()` registration; **Discovery** repos-only (unchanged domain wiring)
+- **What changes live:** How submitted URLs enrich existing episodes (platform ID/URL/image writes go through applier); composition roots updated for explicit domain registration on deployed hosts
+- **What does not change:** Indexer match/merge algorithms (Phase A, unchanged by B); catalogue adapters still not wired at provider/resolver boundaries; Discovery does not resolve matcher/merger/applier
 - **Residual risks:**
   - Podcast-level or non-platform fields (description, BBC/IA) regress if special-cases are dropped during the move
   - Resolved-item adapter quirks surface only on live submit traffic not covered by rules
-- **Recommended soak / deploy scope:** UrlSubmission-related host only (Indexer unchanged by this phase)
-- **Rollback notes:** Revert `EpisodeEnricher` to direct flat-field mutation; Indexer unaffected
+- **Soak / deploy scope:** Api, Indexer, Discovery, publishing console apps (deployed 2026-07-04; soak review pending)
+- **Rollback notes:** Revert `EpisodeEnricher` to direct flat-field mutation; revert explicit `AddEpisodesDomain()` at affected composition roots if needed
 
 **PR:** [#872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872)
 

--- a/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
+++ b/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
@@ -93,6 +93,28 @@ Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](htt
 - [x] Preserve podcast-level enrichment (show IDs, etc.) and non-platform episode fields (description helper, BBC/IA if still special-cased) without regressing rules
 - [x] Update UrlSubmission test construction to supply applier (real implementation, not a mock that hides behavior)
 - [x] Confirm no new processing logic outside adapters / applier for platform field writes
+- [x] **DI:** register episodes domain at composition root, not inside `AddUrlSubmission()`
+
+### DI registration (Phase B)
+
+| Extension | Registers |
+|-----------|-----------|
+| `AddEpisodesDomain()` | `IEpisodePlatformApplier`, `IEpisodePlatformMerger`, `IEpisodePlatformMatcher`, match strategies, merge policies |
+| `AddRepositories()` | Calls `AddEpisodesDomain()` first, then Cosmos repositories and legacy `EpisodeMatcher` / `EpisodeMerger` |
+| `AddUrlSubmission()` | UrlSubmission services only (including `IEpisodeEnricher`); **does not** register episodes domain |
+
+**Hosts calling `AddUrlSubmission()`** — all use `AddRepositories()` first (episodes domain included):
+
+| Host | Composition root |
+|------|------------------|
+| Api | `Cloud/Api/Ioc.cs` |
+| SubmitUrl CLI | `Console-Apps/SubmitUrl/Program.cs` |
+| Enrich existing episodes CLI | `Console-Apps/EnrichExistingEpisodesFromPodcastServices/Program.cs` |
+| Wikipedia episode enricher CLI | `Console-Apps/WikipediaEpisodeEnricher/Program.cs` |
+
+**Other episode-domain consumers** (match/merge via persistence, no UrlSubmission): Indexer, Discovery, and Cosmos-backed console apps — domain via `AddRepositories()` only.
+
+**Rationale:** keep feature extensions (`AddUrlSubmission`, future enrich templates) focused on their pipeline; domain services stay explicit at the host or persistence layer so hosts that need matcher/merger/applier without UrlSubmission are not forced to pull UrlSubmission DI.
 
 ### Exit criteria
 

--- a/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
+++ b/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
@@ -100,21 +100,30 @@ Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](htt
 | Extension | Registers |
 |-----------|-----------|
 | `AddEpisodesDomain()` | `IEpisodePlatformApplier`, `IEpisodePlatformMerger`, `IEpisodePlatformMatcher`, match strategies, merge policies |
-| `AddRepositories()` | Calls `AddEpisodesDomain()` first, then Cosmos repositories and legacy `EpisodeMatcher` / `EpisodeMerger` |
+| `AddRepositories()` | Cosmos repositories and legacy `EpisodeMatcher` / `EpisodeMerger` only — **does not** call `AddEpisodesDomain()` |
 | `AddUrlSubmission()` | UrlSubmission services only (including `IEpisodeEnricher`); **does not** register episodes domain |
 
-**Hosts calling `AddUrlSubmission()`** — all use `AddRepositories()` first (episodes domain included):
+**Hosts that call both** `AddEpisodesDomain()` and `AddRepositories()` explicitly:
+
+| Host | Composition root | Why |
+|------|------------------|-----|
+| Api | `Cloud/Api/Ioc.cs` | `AddUrlSubmission`, `AddPodcastServices`, `AddIndexer` → applier + merger |
+| Indexer (cloud) | `Cloud/Indexer/Ioc.cs` | `AddPodcastServices` → `PodcastUpdater` / `IEpisodeMerger` |
+| Index CLI | `Console-Apps/Index/Program.cs` | `AddIndexer` + `AddPodcastServices` |
+| SubmitUrl CLI | `Console-Apps/SubmitUrl/Program.cs` | `AddUrlSubmission` + `AddPodcastServices` |
+| Enrich existing episodes CLI | `Console-Apps/EnrichExistingEpisodesFromPodcastServices/Program.cs` | `AddUrlSubmission` → applier |
+| Wikipedia episode enricher CLI | `Console-Apps/WikipediaEpisodeEnricher/Program.cs` | `AddUrlSubmission` + `AddPodcastServices` |
+| Poster, AddAudioPodcast, EnrichPodcastWithImages, WebsubStatus CLIs | respective `Program.cs` | `AddPodcastServices` → merger |
+
+**Repos-only hosts** (no `AddEpisodesDomain()` — do not resolve matcher/merger/applier):
 
 | Host | Composition root |
 |------|------------------|
-| Api | `Cloud/Api/Ioc.cs` |
-| SubmitUrl CLI | `Console-Apps/SubmitUrl/Program.cs` |
-| Enrich existing episodes CLI | `Console-Apps/EnrichExistingEpisodesFromPodcastServices/Program.cs` |
-| Wikipedia episode enricher CLI | `Console-Apps/WikipediaEpisodeEnricher/Program.cs` |
+| Discovery (cloud) | `Cloud/Discovery/Ioc.cs` |
+| Discover CLI | `Console-Apps/Discover/Program.cs` |
+| Other Cosmos maintenance/backfill CLIs | e.g. `CosmosDbUploader`, `SeedKnownTerms`, `FindDuplicateEpisodes`, … |
 
-**Other episode-domain consumers** (match/merge via persistence, no UrlSubmission): Indexer, Discovery, and Cosmos-backed console apps — domain via `AddRepositories()` only.
-
-**Rationale:** keep feature extensions (`AddUrlSubmission`, future enrich templates) focused on their pipeline; domain services stay explicit at the host or persistence layer so hosts that need matcher/merger/applier without UrlSubmission are not forced to pull UrlSubmission DI.
+**Rationale:** keep feature extensions (`AddUrlSubmission`, future enrich templates) focused on their pipeline; domain services stay explicit at the host composition root so callers choose matcher/merger/applier registration independently of persistence.
 
 ### Exit criteria
 

--- a/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
+++ b/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
@@ -18,8 +18,8 @@
 
 | Phase | Status | Risk | PR |
 |-------|--------|------|----|
-| **A** — Domain types + applier/merger/matcher (internal) | 🟢 Soak passed — safe to merge | Medium | [#871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871) |
-| **B** — UrlSubmission through applier | ⬜ Not started | Medium | _PR link_ |
+| **A** — Domain types + applier/merger/matcher (internal) | 🟢 In production / Done | Medium | [#871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871) |
+| **B** — UrlSubmission through applier | 🟡 In progress | Medium | _PR link_ |
 | **C** — Platform adapters at boundaries | ⬜ Not started | Medium–High | _PR link_ |
 | **D** — Collapse finders into single matcher | ⬜ Not started | Medium–High | _PR link_ |
 | **E** — Shared enricher template | ⬜ Not started | Medium | _PR link_ |
@@ -29,14 +29,14 @@
 
 ## Phase 0 / Phase A status
 
-Steps 1–6 are complete. **Phase A** soak on **Indexer** passed (2026-07-04 review). Phases B–F not started.
+Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871)). **Phase B** is in progress. Phases C–F not started.
 
 | Step / phase | Outcome |
 |--------------|---------|
 | Steps 1–6 | Test infrastructure, domain types, Layer 1–3 business rules, adapter rules, coverage baseline + CI gate |
 | **Phase A** | Domain services in `RedditPodcastPoster.Episodes`; `EpisodeMerger` / `EpisodeMatcher` wired to `EpisodePlatformMatcher` / `EpisodePlatformMerger` |
 | Adapters | Exist under `Episodes/Adapters/` with Layer 1 rules — **not** wired at provider/resolver boundaries |
-| Applier | Used inside Episodes (via merger path) — **not** used by UrlSubmission `EpisodeEnricher` |
+| Applier | Used inside Episodes (via merger path) and UrlSubmission `EpisodeEnricher` (Phase B) |
 
 ### Phase A checklist
 
@@ -87,18 +87,18 @@ Steps 1–6 are complete. **Phase A** soak on **Indexer** passed (2026-07-04 rev
 
 ### Checklist
 
-- [ ] Inject `IEpisodePlatformApplier` (and adapters as needed) into `EpisodeEnricher`
-- [ ] Map each `Resolved*Item` on `CategorisedItem` through the corresponding adapter → candidate/patch
-- [ ] Apply missing platform links (ID, URL, image) via applier — no direct `matchingEpisode.SpotifyId = …` style writes for platform fields
-- [ ] Preserve podcast-level enrichment (show IDs, etc.) and non-platform episode fields (description helper, BBC/IA if still special-cased) without regressing rules
-- [ ] Update UrlSubmission test construction to supply applier (real implementation, not a mock that hides behavior)
-- [ ] Confirm no new processing logic outside adapters / applier for platform field writes
+- [x] Inject `IEpisodePlatformApplier` (and adapters as needed) into `EpisodeEnricher`
+- [x] Map each `Resolved*Item` on `CategorisedItem` through the corresponding adapter → candidate/patch
+- [x] Apply missing platform links (ID, URL, image) via applier — no direct `matchingEpisode.SpotifyId = …` style writes for platform fields
+- [x] Preserve podcast-level enrichment (show IDs, etc.) and non-platform episode fields (description helper, BBC/IA if still special-cased) without regressing rules
+- [x] Update UrlSubmission test construction to supply applier (real implementation, not a mock that hides behavior)
+- [x] Confirm no new processing logic outside adapters / applier for platform field writes
 
 ### Exit criteria
 
-- [ ] All UrlSubmission business-rule tests pass **without assertion changes**
-- [ ] Full Step 7 test set green (Episodes, PodcastServices, UrlSubmission, Persistence)
-- [ ] `./scripts/coverage-gate.ps1` passes (no regression below baseline)
+- [x] All UrlSubmission business-rule tests pass **without assertion changes**
+- [x] Full Step 7 test set green (Episodes, PodcastServices, UrlSubmission, Persistence)
+- [x] `./scripts/coverage-gate.ps1` passes (no regression below baseline)
 - [ ] PR opened for Phase B only
 
 ### Risk to production

--- a/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
+++ b/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
@@ -19,7 +19,7 @@
 | Phase | Status | Risk | PR |
 |-------|--------|------|----|
 | **A** — Domain types + applier/merger/matcher (internal) | 🟢 In production / Done | Medium | [#871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871) |
-| **B** — UrlSubmission through applier | 🟡 In progress | Medium | _PR link_ |
+| **B** — UrlSubmission through applier | 🟡 In progress | Medium | [#872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872) |
 | **C** — Platform adapters at boundaries | ⬜ Not started | Medium–High | _PR link_ |
 | **D** — Collapse finders into single matcher | ⬜ Not started | Medium–High | _PR link_ |
 | **E** — Shared enricher template | ⬜ Not started | Medium | _PR link_ |
@@ -99,7 +99,7 @@ Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](htt
 - [x] All UrlSubmission business-rule tests pass **without assertion changes**
 - [x] Full Step 7 test set green (Episodes, PodcastServices, UrlSubmission, Persistence)
 - [x] `./scripts/coverage-gate.ps1` passes (no regression below baseline)
-- [ ] PR opened for Phase B only
+- [x] PR opened for Phase B only
 
 ### Risk to production
 
@@ -113,7 +113,7 @@ Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](htt
 - **Recommended soak / deploy scope:** UrlSubmission-related host only (Indexer unchanged by this phase)
 - **Rollback notes:** Revert `EpisodeEnricher` to direct flat-field mutation; Indexer unaffected
 
-**PR:** _link_
+**PR:** [#872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872)
 
 ---
 

--- a/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
+++ b/plans/episode-domain-refactor/STEP-7-CHECKLIST.md
@@ -19,7 +19,7 @@
 | Phase | Status | Risk | PR |
 |-------|--------|------|----|
 | **A** — Domain types + applier/merger/matcher (internal) | 🟢 In production / Done | Medium | [#871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871) |
-| **B** — UrlSubmission through applier | 🟢 In production (soak) | Medium | [#872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872) |
+| **B** — UrlSubmission through applier | 🟢 Soak passed / ready to merge | Medium | [#872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872) |
 | **C** — Platform adapters at boundaries | ⬜ Not started | Medium–High | _PR link_ |
 | **D** — Collapse finders into single matcher | ⬜ Not started | Medium–High | _PR link_ |
 | **E** — Shared enricher template | ⬜ Not started | Medium | _PR link_ |
@@ -29,7 +29,7 @@
 
 ## Phase 0 / Phase A status
 
-Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871)). **Phase B** is in production (soak via [PR #872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872); review pending). Phases C–F not started.
+Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](https://github.com/cultpodcasts/RedditPodcastPoster/pull/871)). **Phase B** soak passed (ready to merge via [PR #872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872)). Phases C–F not started.
 
 | Step / phase | Outcome |
 |--------------|---------|
@@ -132,7 +132,7 @@ Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](htt
 - [x] `./scripts/coverage-gate.ps1` passes (no regression below baseline)
 - [x] PR opened for Phase B only
 - [x] Deployed for overnight soak (2026-07-04)
-- [ ] Soak review — pending (~2026-07-05)
+- [x] Soak review (2026-07-05) — no red flags in production telemetry; safe to merge PR #872
 
 ### Phase B deploy / soak status
 
@@ -141,7 +141,7 @@ Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](htt
 - [x] **Indexer** — explicit `AddEpisodesDomain()` + Phase A merge path
 - [x] **Discovery** — repos-only (no `AddEpisodesDomain()`)
 - [x] **Publishing console apps** — Poster etc. with explicit `AddEpisodesDomain()`
-- [ ] Soak review — pending (user review scheduled ~2026-07-05)
+- [x] Soak review (2026-07-05) — no red flags; safe to merge PR #872
 
 ### Risk to production (Phase B — live / soak context)
 
@@ -152,7 +152,17 @@ Steps 1–6 are complete. **Phase A** is in production (merged via [PR #871](htt
 - **Residual risks:**
   - Podcast-level or non-platform fields (description, BBC/IA) regress if special-cases are dropped during the move
   - Resolved-item adapter quirks surface only on live submit traffic not covered by rules
-- **Soak / deploy scope:** Api, Indexer, Discovery, publishing console apps (deployed 2026-07-04; soak review pending)
+- **Soak / deploy scope:** Api, Indexer, Discovery, publishing console apps (deployed 2026-07-04; soak passed 2026-07-05)
+- **Soak evidence (App Insights `ai-infra` + Log Analytics `loganalytics-infra`):**
+  - Deploy blobs: `indexer-deployment` 2026-07-04T20:37:39Z, `api-deployment` 2026-07-04T20:42:55Z, `discovery-deployment` 2026-07-04T20:44:54Z
+  - Window: deploy through review ~2026-07-05T10:30Z (~14h)
+  - Zero `AppExceptions` for `api-infra`, `indexer-infra`, `discover-infra`
+  - Zero traces with `Failed to ingest`; zero episode-domain / UrlSubmission / DI resolve failures
+  - Severity≥3 traces are pre-existing noise only (Twitter credits depleted, YouTube channel-not-found, indexer `No updates` LogError) — not Phase B paths
+  - **Api happy path:** 4× `POST api/SubmitUrl` (all HTTP 200, post-deploy); 2× `POST api/DiscoveryCuration` (200); api cold-start loaded 28 functions including `SubmitUrl` (DI OK)
+  - **Indexer happy path:** 3× `Hourly` + 2× `HalfHourly` post-deploy, all success; full activity chain (Indexer, Categoriser, Poster, Publisher, Tweet, Bluesky)
+  - **Discovery happy path:** 1× `DiscoveryTrigger` → `Discover` post-deploy, success; repos-only wiring unchanged (no domain DI expected)
+  - Caveat: `RedditPodcastPoster` log level Warning + 25% OTel sampling — successful applier `LogInformation` not visible; red-flag path is exceptions / `LogError` which would still export
 - **Rollback notes:** Revert `EpisodeEnricher` to direct flat-field mutation; revert explicit `AddEpisodesDomain()` at affected composition roots if needed
 
 **PR:** [#872](https://github.com/cultpodcasts/RedditPodcastPoster/pull/872)


### PR DESCRIPTION
## Summary
- Route UrlSubmission `EpisodeEnricher` platform field writes (ID, URL, image) through `EpisodePlatformApplier` via `Resolved*ItemAdapter` mapping, per [STEP-7-CHECKLIST Phase B](plans/episode-domain-refactor/STEP-7-CHECKLIST.md#phase-b--urlsubmission-through-applier).
- Preserve podcast-level show enrichment, description-helper quirks, release time-of-day backfill, and BBC/IA special-cases unchanged.
- No business-rule assertion changes; tests supply the real applier.

## Risk
- **Level:** Medium
- **Blast radius:** UrlSubmission host — submit/enrich path (`EpisodeEnricher` → `EpisodePlatformApplier` + resolved-item adapters)
- **Recommended soak:** UrlSubmission-related host only (Indexer unchanged by this phase)
- **Rollback:** Revert `EpisodeEnricher` to direct flat-field mutation; Indexer unaffected

## Test plan
- [x] UrlSubmission business-rule tests pass (no assertion changes)
- [x] Step 7 suite green (Episodes, PodcastServices, UrlSubmission, Persistence)
- [x] `./scripts/coverage-gate.ps1` passes (orchestration coverage improved vs baseline)
- [ ] UrlSubmission host soak after deploy

Made with [Cursor](https://cursor.com)