### PR TITLE
Fix URL submission People DI (IEpisodeGuestEnricher)

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/UrlSubmissionDependencyInjectionTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/UrlSubmissionDependencyInjectionTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Episodes.Extensions;
+using RedditPodcastPoster.People;
 using RedditPodcastPoster.UrlSubmission.Extensions;
 
 namespace RedditPodcastPoster.UrlSubmission.Tests;
@@ -33,5 +34,15 @@ public class UrlSubmissionDependencyInjectionTests
 
         var act = () => provider.GetRequiredService<IEpisodeEnricher>();
         act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void AddUrlSubmission_registers_episode_guest_enricher()
+    {
+        var services = new ServiceCollection();
+        services.AddUrlSubmission();
+
+        services.Should().Contain(d => d.ServiceType == typeof(IEpisodeGuestEnricher));
+        services.Should().Contain(d => d.ServiceType == typeof(IPodcastProcessor));
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using RedditPodcastPoster.People.Extensions;
 using RedditPodcastPoster.PodcastServices.Apple;
 using RedditPodcastPoster.PodcastServices.Spotify.Categorisers;
 using RedditPodcastPoster.PodcastServices.YouTube.Services;
@@ -10,13 +11,16 @@ namespace RedditPodcastPoster.UrlSubmission.Extensions;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-        /// UrlSubmission pipeline services. Does not register episodes domain —
-        /// callers must call <c>AddEpisodesDomain()</c> explicitly at the composition root
-        /// (required for <c>IEpisodeEnricher</c> → <c>IPlatformEnrichmentApplicator</c>).
+    /// UrlSubmission pipeline services. Registers People services required by
+    /// <c>IPodcastProcessor</c> / <c>IPodcastAndEpisodeFactory</c> (<c>IEpisodeGuestEnricher</c>).
+    /// Does not register episodes domain — callers must call <c>AddEpisodesDomain()</c>
+    /// explicitly at the composition root (required for <c>IEpisodeEnricher</c> →
+    /// <c>IPlatformEnrichmentApplicator</c>).
     /// </summary>
     public static IServiceCollection AddUrlSubmission(this IServiceCollection services)
     {
         return services
+            .AddPeopleServices()
             .AddScoped<IUrlCategoriser, UrlCategoriser>()
             .AddScoped<IAppleUrlCategoriser, AppleUrlCategoriser>()
             .AddScoped<ISpotifyUrlCategoriser, SpotifyUrlCategoriser>()

--- a/Console-Apps/SubmitUrl/Program.cs
+++ b/Console-Apps/SubmitUrl/Program.cs
@@ -10,6 +10,7 @@ using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
 using RedditPodcastPoster.Episodes.Extensions;
 using RedditPodcastPoster.InternetArchive.Extensions;
+using RedditPodcastPoster.People.Extensions;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices;
 using RedditPodcastPoster.PodcastServices.Abstractions;
@@ -44,6 +45,7 @@ builder.Services
     .AddYouTubeServices(ApplicationUsage.Cli)
     .AddScoped<IRemoteClient, RemoteClient>()
     .AddScoped(s => new iTunesSearchManager())
+    .AddPeopleServices()
     .AddUrlSubmission()
     .AddSubjectServices()
     .AddCachedSubjectProvider()

--- a/Console-Apps/SubmitUrl/SubmitUrl.csproj
+++ b/Console-Apps/SubmitUrl/SubmitUrl.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Common\RedditPodcastPoster.Common.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.EntitySearchIndexer\RedditPodcastPoster.EntitySearchIndexer.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.People\RedditPodcastPoster.People.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.PodcastServices\RedditPodcastPoster.PodcastServices.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.UrlSubmission\RedditPodcastPoster.UrlSubmission.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- `PodcastProcessor` depends on `IEpisodeGuestEnricher` after #879, but SubmitUrl did not call `AddPeopleServices()`.
- `AddUrlSubmission()` now registers People services so every UrlSubmission host gets the enricher.
- SubmitUrl also calls `AddPeopleServices()` explicitly (same pattern as Api/Indexer).

## Test plan
- [x] `dotnet build` SubmitUrl + Api
- [x] UrlSubmission DI unit tests (3 passed)
- [ ] Redeploy `api-infra` via `scripts/deploy-api.ps1`
- [ ] Re-run `publish-console-apps` (or local publish) for SubmitUrl CLI