### PR TITLE
Register People DI across Indexer/Twitter/Bluesky/ContentPublisher hosts

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Extensions/ServiceCollectionExtensions.cs
@@ -5,15 +5,20 @@ using RedditPodcastPoster.Bluesky.Factories;
 using RedditPodcastPoster.Bluesky.YouTube;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.DependencyInjection;
+using RedditPodcastPoster.People.Extensions;
 
 namespace RedditPodcastPoster.Bluesky.Extensions;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers Bluesky posting services. Also registers People services required by
+    /// <c>BlueskyEmbedCardPostFactory</c> (<c>IPersonGuestHandleResolver</c>).
+    /// </summary>
     public static IServiceCollection AddBlueskyServices(this IServiceCollection services)
     {
-
         return services
+            .AddPeopleServices()
             .AddSingleton<IBlueskyClientFactory, BlueskyClientFactory>()
             .AddSingleton(x => x.GetService<IBlueskyClientFactory>()!.Create())
             .AddScoped<IBlueskyEmbedCardPostFactory, BlueskyEmbedCardPostFactory>()

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Extensions/ServiceCollectionExtensions.cs
@@ -1,14 +1,20 @@
 using Microsoft.Extensions.DependencyInjection;
 using RedditPodcastPoster.Cloudflare.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.People.Extensions;
 
 namespace RedditPodcastPoster.ContentPublisher.Extensions;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers content publishers. Also registers People services required by
+    /// <c>PeoplePublisher</c> (<c>IPersonRepository</c>).
+    /// </summary>
     public static IServiceCollection AddContentPublishing(this IServiceCollection services)
     {
         return services
+            .AddPeopleServices()
             .AddScoped<IHomepagePublisher, HomepagePublisher>()
             .AddScoped<ISubjectsPublisher, SubjectsPublisher>()
             .AddScoped<IPeoplePublisher, PeoplePublisher>()

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/RedditPodcastPoster.ContentPublisher.csproj
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/RedditPodcastPoster.ContentPublisher.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\Third-Party\sirkris-Reddit.NET-1.5.3\src\Reddit.NET\Reddit.NET.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Cloudflare\RedditPodcastPoster.Cloudflare.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Discovery\RedditPodcastPoster.Discovery.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.People\RedditPodcastPoster.People.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Persistence.Abstractions\RedditPodcastPoster.Persistence.Abstractions.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Reddit\RedditPodcastPoster.Reddit.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Text\RedditPodcastPoster.Text.csproj" />

--- a/Class-Libraries/RedditPodcastPoster.Indexing/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Indexing/Extensions/ServiceCollectionExtensions.cs
@@ -1,11 +1,18 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using RedditPodcastPoster.People.Extensions;
 
 namespace RedditPodcastPoster.Indexing.Extensions;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers <c>IIndexer</c>. Also registers People services required by
+    /// guest enrichment (<c>IEpisodeGuestEnricher</c>).
+    /// </summary>
     public static IServiceCollection AddIndexer(this IServiceCollection services)
     {
-        return services.AddScoped<IIndexer, Indexer>();
+        return services
+            .AddPeopleServices()
+            .AddScoped<IIndexer, Indexer>();
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Twitter/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Twitter/Extensions/ServiceCollectionExtensions.cs
@@ -1,13 +1,19 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.People.Extensions;
 
 namespace RedditPodcastPoster.Twitter.Extensions;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers Twitter posting services. Also registers People services required by
+    /// <c>TweetBuilder</c> (<c>IPersonGuestHandleResolver</c>).
+    /// </summary>
     public static IServiceCollection AddTwitterServices(this IServiceCollection services)
     {
         return services
+            .AddPeopleServices()
             .AddScoped<ITweeter, Tweeter>()
             .AddScoped<ITwitterClient, TwitterClient>()
             .AddScoped<ITweetBuilder, TweetBuilder>()

--- a/Console-Apps/Index/Index.csproj
+++ b/Console-Apps/Index/Index.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.EntitySearchIndexer\RedditPodcastPoster.EntitySearchIndexer.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Indexing\RedditPodcastPoster.Indexing.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.People\RedditPodcastPoster.People.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.PodcastServices\RedditPodcastPoster.PodcastServices.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Subjects\RedditPodcastPoster.Subjects.csproj" />
   </ItemGroup>

--- a/Console-Apps/Index/Program.cs
+++ b/Console-Apps/Index/Program.cs
@@ -10,6 +10,7 @@ using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
 using RedditPodcastPoster.Episodes.Extensions;
 using RedditPodcastPoster.Indexing.Extensions;
+using RedditPodcastPoster.People.Extensions;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices;
 using RedditPodcastPoster.PodcastServices.Abstractions;
@@ -47,6 +48,7 @@ builder.Services
     .AddSubjectServices()
     .AddCachedSubjectProvider()
     .AddTextSanitiser()
+    .AddPeopleServices()
     .AddIndexer()
     .AddEpisodeSearchIndexerService()
     .AddHttpClient();

--- a/Console-Apps/Poster/Poster.csproj
+++ b/Console-Apps/Poster/Poster.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Cloudflare\RedditPodcastPoster.Cloudflare.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Common\RedditPodcastPoster.Common.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.ContentPublisher\RedditPodcastPoster.ContentPublisher.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.People\RedditPodcastPoster.People.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.PodcastServices\RedditPodcastPoster.PodcastServices.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Subjects\RedditPodcastPoster.Subjects.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Twitter\RedditPodcastPoster.Twitter.csproj" />

--- a/Console-Apps/Poster/Program.cs
+++ b/Console-Apps/Poster/Program.cs
@@ -10,6 +10,7 @@ using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.ContentPublisher.Extensions;
 using RedditPodcastPoster.Episodes.Extensions;
+using RedditPodcastPoster.People.Extensions;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.PodcastServices.Extensions;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
@@ -38,6 +39,7 @@ builder.Services
     .AddRepositories()
     .AddCommonServices()
     .AddPodcastServices()
+    .AddPeopleServices()
     .AddContentPublishing()
     .AddRedditServices()
     .AddTwitterServices()

--- a/Console-Apps/Tweet/Program.cs
+++ b/Console-Apps/Tweet/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.People.Extensions;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.Subjects.Extensions;
 using RedditPodcastPoster.Text.Extensions;
@@ -24,6 +25,7 @@ builder.Services
     .AddLogging()
     .AddRepositories()
     .AddSingleton<TweetProcessor>()
+    .AddPeopleServices()
     .AddTwitterServices()
     .AddSubjectServices()
     .AddCachedSubjectProvider()

--- a/Console-Apps/Tweet/Tweet.csproj
+++ b/Console-Apps/Tweet/Tweet.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Common\RedditPodcastPoster.Common.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.People\RedditPodcastPoster.People.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Subjects\RedditPodcastPoster.Subjects.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Twitter\RedditPodcastPoster.Twitter.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Broader audit after #880: Index, Poster, and Tweet CLIs also activate People-dependent types and were missing `AddPeopleServices()`.
- Nest `AddPeopleServices()` into `AddIndexer`, `AddTwitterServices`, `AddBlueskyServices`, and `AddContentPublishing` so every host is covered.
- Explicit composition-root calls on Index / Poster / Tweet (same pattern as SubmitUrl).

## Hosts
| App | Needs People? | Status |
|-----|---------------|--------|
| SubmitUrl | Yes (PodcastProcessor) | Fixed in #880 |
| Index | Yes (IIndexer) | Fixed here |
| Poster | Yes (Twitter/Bluesky handles) | Fixed here |
| Tweet | Yes (TweetBuilder) | Fixed here |
| R2Publisher | Yes (PeoplePublisher) | Already had |
| Api | Yes | Already had (+ nested) |
| Indexer (cloud) | Yes (Twitter/Bluesky/Content) | Already had |
| Discover (cloud/CLI) | Indirect via ContentPublishing | Covered by nested AddContentPublishing |
| EnrichExisting / Wikipedia | Yes via UrlSubmission | Covered by #880 |

## Test plan
- [x] Build Index, Poster, Tweet, SubmitUrl, Api, Indexer, Discovery + library projects
- [ ] Merge + `scripts/deploy-api.ps1`
- [ ] Re-run publish-console-apps for SubmitUrl, Index, Poster, Tweet