### PR TITLE
Score YouTube-audio merges instead of hard title vetoes

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
@@ -640,31 +640,104 @@ public sealed class DomainTestFixture
   }
 
   /// <summary>
-  /// Stored YouTube row and Spotify incoming with aligned release/duration but clearly different titles —
-  /// negative-delay guard must not merge on release alone.
+  /// Stored YouTube row and Spotify incoming with weak catalogue-day release alignment (±5 day band)
+  /// and similar duration, but NOT delay-aligned and with clearly different titles.
+  /// Scoring must not reach the cross-platform match threshold (#869 false-positive shape).
   /// </summary>
   public (Episode Stored, Episode Incoming) CreateNegativeDelayNonMatchingPair(Podcast podcast)
   {
-    const int storedDaysAgo = 34;
-    const int incomingDaysAfterStored = 28;
-    var storedRelease = UtcAtTime(-storedDaysAgo, CreateNonMidnightTimeOfDay());
-    var incomingRelease = UtcDateDaysAgo(storedDaysAgo - incomingDaysAfterStored);
+    var delay = podcast.YouTubePublishingDelay();
+    var youTubeRelease = UtcAtTime(-40, TimeSpan.FromHours(15));
+    var expectedAudioRelease = youTubeRelease - delay;
+    // Three calendar days off expected audio — inside ±5 catalogue day tolerance, outside 1-day delay align.
+    var incomingRelease = expectedAudioRelease.Date.AddDays(3);
     var storedLength = CreateDuration();
     var incomingLength = storedLength - TimeSpan.FromSeconds(5);
 
     var stored = CreateStoredEpisodeWithYouTubeOnly(
       podcast,
-      storedRelease,
+      youTubeRelease,
       storedLength,
-      CreateTitle());
+      "Alpha market briefing on early catalogue drift signals");
     var incoming = CreateSpotifyCatalogueEpisode(b => b
-      .WithTitle(CreateTitle())
+      .WithTitle("Omega wellness interview about unrelated guest journeys")
       .WithRelease(incomingRelease)
       .WithDuration(incomingLength));
 
     return (stored, incoming);
   }
 
+  /// <summary>
+  /// YouTube-only stored + Apple incoming with delay-aligned releases, duration within five minutes,
+  /// and disjoint marketing titles (Hassan-shaped). Scoring should merge without title confidence.
+  /// </summary>
+  public (Episode Stored, Episode Incoming, long AppleId) CreateNegativeDelayAlignedDivergentTitlePair(
+    Podcast podcast)
+  {
+    var delay = podcast.YouTubePublishingDelay();
+    var youTubeRelease = UtcAtTime(-40, TimeSpan.FromHours(14));
+    var appleRelease = youTubeRelease - delay;
+    var storedLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(38);
+    var incomingLength = storedLength - TimeSpan.FromSeconds(1);
+    const string youTubeTitle =
+      "The Neighborhood Scheme: Shocking Truth About Wellness Influencer Networks";
+    const string appleTitle =
+      "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost";
+
+    var stored = CreateStoredEpisodeWithYouTubeOnly(
+      podcast,
+      youTubeRelease,
+      storedLength,
+      youTubeTitle);
+    var appleInput = CreateAppleCatalogueInput(b => b
+      .WithTitle(appleTitle)
+      .WithRelease(appleRelease)
+      .WithDuration(incomingLength));
+    var incoming = CreateAppleCatalogueEpisode(b => b
+      .WithAppleId(appleInput.AppleId)
+      .WithTitle(appleTitle)
+      .WithRelease(appleRelease)
+      .WithDuration(incomingLength));
+
+    return (stored, incoming, appleInput.AppleId);
+  }
+
+
+  /// <summary>
+  /// YouTube-only stored + Spotify incoming with delay-aligned releases, duration within five minutes,
+  /// and disjoint marketing titles (Hassan-shaped). Scoring should merge without title confidence.
+  /// </summary>
+  public (Episode Stored, Episode Incoming, string SpotifyId) CreateNegativeDelayAlignedDivergentTitleSpotifyPair(
+    Podcast podcast)
+  {
+    var delay = podcast.YouTubePublishingDelay();
+    var youTubeRelease = UtcAtTime(-40, TimeSpan.FromHours(14));
+    var spotifyRelease = youTubeRelease - delay;
+    var storedLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(38);
+    var incomingLength = storedLength - TimeSpan.FromSeconds(1);
+    const string youTubeTitle =
+      "The Neighborhood Scheme: Shocking Truth About Wellness Influencer Networks";
+    const string spotifyTitle =
+      "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost";
+
+    var stored = CreateStoredEpisodeWithYouTubeOnly(
+      podcast,
+      youTubeRelease,
+      storedLength,
+      youTubeTitle);
+    var spotifyInput = CreateSpotifyCatalogueInput(b => b
+      .WithTitle(spotifyTitle)
+      .WithRelease(spotifyRelease)
+      .WithDuration(incomingLength));
+    var incoming = CreateSpotifyCatalogueEpisode(b => b
+      .WithSpotifyId(spotifyInput.SpotifyId)
+      .WithTitle(spotifyTitle)
+      .WithSpotifyUrl(spotifyInput.SpotifyUrl)
+      .WithRelease(spotifyRelease)
+      .WithDuration(incomingLength));
+
+    return (stored, incoming, spotifyInput.SpotifyId);
+  }
   public SpotifyCatalogueInput CreateSpotifyCatalogueInputDaysAfterYouTubeRelease(
     DateTime youTubeRelease,
     int calendarDaysAfter,

--- a/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
@@ -669,7 +669,7 @@ public sealed class DomainTestFixture
 
   /// <summary>
   /// YouTube-only stored + Apple incoming with delay-aligned releases, duration within five minutes,
-  /// and disjoint marketing titles (Hassan-shaped). Scoring should merge without title confidence.
+  /// and disjoint marketing titles. Scoring should merge without title confidence.
   /// </summary>
   public (Episode Stored, Episode Incoming, long AppleId) CreateNegativeDelayAlignedDivergentTitlePair(
     Podcast podcast)
@@ -705,7 +705,7 @@ public sealed class DomainTestFixture
 
   /// <summary>
   /// YouTube-only stored + Spotify incoming with delay-aligned releases, duration within five minutes,
-  /// and disjoint marketing titles (Hassan-shaped). Scoring should merge without title confidence.
+  /// and disjoint marketing titles. Scoring should merge without title confidence.
   /// </summary>
   public (Episode Stored, Episode Incoming, string SpotifyId) CreateNegativeDelayAlignedDivergentTitleSpotifyPair(
     Podcast podcast)

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -643,26 +643,26 @@ public class CatalogueMatchingRules
         "When enriching a YouTube-discovered episode with both EnrichingYouTubeDiscoveredEpisode and " +
         "AcceptUniqueDurationWithoutTitleMatch set (legacy Spotify finder combo), indexing must still " +
         "refuse a wrong-week Spotify catalogue row within five minutes whose title is wholly disjoint.")]
-    public void youtube_enrichment_with_unique_duration_flag_still_rejects_hassan_wrong_week_spotify()
+    public void youtube_enrichment_with_unique_duration_flag_still_rejects_wrong_week_duration_snipe()
     {
         // Arrange — production Spotify finder previously set both flags true
-        const string localElectionsTitle =
-            "Can Local Elections Stop Authoritarianism? Defending Democracy One Vote at a Time";
-        const string mlmSpotifyTitle =
-            "She Spent $115K in a Wellness MLM with Brandie Hadfield: A new mom, an autistic baby, and a decade lost to a commercial cult";
-        var localElectionsLength = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
-        var mlmSpotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
+        const string lastWeekYouTubeTitle =
+            "Civic turnout strategies for mid-cycle ballot measures";
+        const string thisWeekSpotifyTitle =
+            "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost";
+        var lastWeekYouTubeLength = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
+        var thisWeekSpotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
         var probe = _fixture.CreateEpisode(e =>
         {
-            e.Title = localElectionsTitle;
-            e.Length = localElectionsLength;
+            e.Title = lastWeekYouTubeTitle;
+            e.Length = lastWeekYouTubeLength;
             e.Release = new DateTime(2026, 7, 11, 3, 30, 46, DateTimeKind.Utc);
             e.YouTubeId = _fixture.CreateYouTubeId();
         });
         var catalogueItem = _fixture.CreateEpisode(e =>
         {
-            e.Title = mlmSpotifyTitle;
-            e.Length = mlmSpotifyLength;
+            e.Title = thisWeekSpotifyTitle;
+            e.Length = thisWeekSpotifyLength;
             e.Release = new DateTime(2026, 7, 13, 8, 30, 0, DateTimeKind.Utc);
             e.SpotifyId = _fixture.CreateSpotifyId();
         });

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -438,7 +438,8 @@ public class CatalogueMatchingRules
 
     [Fact(DisplayName =
         "For YouTube release authority podcasts with negative publishing delay, " +
-        "IsCatalogueMatch does not treat episodes as the same when titles share no fuzzy or substring relationship.")]
+        "IsCatalogueMatch does not treat episodes as the same when weak catalogue-day release alignment " +
+        "plus similar duration lack fuzzy or substring title confidence.")]
     public void is_catalogue_match_rejects_negative_delay_when_titles_clearly_differ()
     {
         // Arrange
@@ -452,7 +453,25 @@ public class CatalogueMatchingRules
         matches.Should().BeFalse();
     }
 
+    
     [Fact(DisplayName =
+        "For YouTube release authority podcasts with negative publishing delay, IsCatalogueMatch accepts " +
+        "delay-aligned Apple/Spotify catalogue rows for a YouTube-only stored episode even when marketing " +
+        "titles are wholly divergent — composite score meets the cross-platform threshold.")]
+    public void is_catalogue_match_accepts_negative_delay_aligned_divergent_titles()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (stored, discovered, _) = _fixture.CreateNegativeDelayAlignedDivergentTitlePair(podcast);
+
+        // Act
+        var matches = _matcher.IsCatalogueMatch(stored, discovered, podcast, episodeMatchRegex: null);
+
+        // Assert
+        matches.Should().BeTrue();
+    }
+
+[Fact(DisplayName =
         "For YouTube release authority podcasts with negative publishing delay, " +
         "IsCatalogueMatch accepts an aligned Spotify catalogue item for a YouTube-only stored episode.")]
     public void is_catalogue_match_accepts_negative_delay_aligned_spotify_catalogue()
@@ -615,6 +634,50 @@ public class CatalogueMatchingRules
             podcast,
             episodeMatchRegex: null,
             new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "When enriching a YouTube-discovered episode with both EnrichingYouTubeDiscoveredEpisode and " +
+        "AcceptUniqueDurationWithoutTitleMatch set (legacy Spotify finder combo), indexing must still " +
+        "refuse a wrong-week Spotify catalogue row within five minutes whose title is wholly disjoint.")]
+    public void youtube_enrichment_with_unique_duration_flag_still_rejects_hassan_wrong_week_spotify()
+    {
+        // Arrange — production Spotify finder previously set both flags true
+        const string localElectionsTitle =
+            "Can Local Elections Stop Authoritarianism? Defending Democracy One Vote at a Time";
+        const string mlmSpotifyTitle =
+            "She Spent $115K in a Wellness MLM with Brandie Hadfield: A new mom, an autistic baby, and a decade lost to a commercial cult";
+        var localElectionsLength = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
+        var mlmSpotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = localElectionsTitle;
+            e.Length = localElectionsLength;
+            e.Release = new DateTime(2026, 7, 11, 3, 30, 46, DateTimeKind.Utc);
+            e.YouTubeId = _fixture.CreateYouTubeId();
+        });
+        var catalogueItem = _fixture.CreateEpisode(e =>
+        {
+            e.Title = mlmSpotifyTitle;
+            e.Length = mlmSpotifyLength;
+            e.Release = new DateTime(2026, 7, 13, 8, 30, 0, DateTimeKind.Utc);
+            e.SpotifyId = _fixture.CreateSpotifyId();
+        });
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+
+        // Act
+        var result = _matcher.FindCatalogueMatchByLength(
+            probe,
+            [catalogueItem],
+            podcast,
+            episodeMatchRegex: null,
+            new CatalogueMatchByLengthOptions(
+                ReleaseAuthority: Service.YouTube,
+                AcceptUniqueDurationWithoutTitleMatch: true,
+                EnrichingYouTubeDiscoveredEpisode: true));
 
         // Assert
         result.Should().BeNull();

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchScorerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchScorerRules.cs
@@ -1,0 +1,221 @@
+using FluentAssertions;
+using RedditPodcastPoster.Episodes.Matching;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models;
+
+namespace RedditPodcastPoster.Episodes.Tests.BusinessRules.Matching;
+
+/// <summary>
+/// Unit coverage for <see cref="CrossPlatformMatchScorer"/> signal tiers and threshold 60.
+/// </summary>
+public class CrossPlatformMatchScorerRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "Delay-aligned release plus duration scores 70 and meets the match threshold without title confidence.")]
+    public void Delay_aligned_release_and_duration_meets_threshold_without_title()
+    {
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (youTube, audio) = CreateDelayAlignedDivergentPair(podcast);
+
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        score.Should().Be(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.DelayAlignedReleasePoints);
+        CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "Same-calendar-day release plus duration scores exactly 60 and meets the match threshold without title.")]
+    public void Same_calendar_day_release_and_duration_meets_threshold_at_boundary()
+    {
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-10, TimeSpan.FromHours(15));
+        var audioRelease = youTubeRelease.Date.Add(TimeSpan.FromHours(8));
+        var length = TimeSpan.FromMinutes(60);
+        var (youTube, audio) = CreateYouTubeAudioPair(
+            podcast,
+            youTubeRelease,
+            audioRelease,
+            length,
+            "Alpha market briefing on early catalogue drift signals",
+            "Omega wellness interview about unrelated guest journeys");
+
+        EpisodeReleaseTolerance.IsYouTubePublishDelayAligned(
+                audioRelease, youTubeRelease, podcast.YouTubePublishingDelay())
+            .Should().BeFalse("fixture must not accidentally delay-align");
+        EpisodeReleaseTolerance.AreCrossPlatformReleasesOnSameCalendarDay(audioRelease, youTubeRelease)
+            .Should().BeTrue();
+
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        score.Should().Be(CrossPlatformMatchScorer.MatchThreshold);
+        CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "Weak catalogue-day release plus duration scores 45 and stays below the match threshold without title.")]
+    public void Weak_catalogue_release_and_duration_stays_below_threshold()
+    {
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (youTube, audio) = _fixture.CreateNegativeDelayNonMatchingPair(podcast);
+
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        score.Should().Be(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.WeakCatalogueReleasePoints);
+        score.Should().BeLessThan(CrossPlatformMatchScorer.MatchThreshold);
+        CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "Weak catalogue-day release plus duration plus fuzzy title reaches 70 and meets the match threshold.")]
+    public void Weak_catalogue_release_with_fuzzy_title_meets_threshold()
+    {
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var delay = podcast.YouTubePublishingDelay();
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-40, TimeSpan.FromHours(15));
+        var audioRelease = (youTubeRelease - delay).Date.AddDays(3);
+        var length = TimeSpan.FromMinutes(55);
+        const string baseTitle = "Holy Disobedience Inside the Seventh-day Adventist Church";
+        var (youTube, audio) = CreateYouTubeAudioPair(
+            podcast,
+            youTubeRelease,
+            audioRelease,
+            length,
+            baseTitle,
+            baseTitle + " with Melissa Duge Spiers");
+
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        score.Should().Be(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.WeakCatalogueReleasePoints +
+            CrossPlatformMatchScorer.FuzzyTitlePoints);
+        CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "Weak catalogue-day release plus duration plus a substring/fuzzy title relationship reaches at least " +
+        "65 and meets the match threshold (title points push past the 45 weak-release floor).")]
+    public void Weak_catalogue_release_with_substring_title_meets_threshold()
+    {
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var delay = podcast.YouTubePublishingDelay();
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-40, TimeSpan.FromHours(15));
+        var audioRelease = (youTubeRelease - delay).Date.AddDays(3);
+        var length = TimeSpan.FromMinutes(55);
+        // Short core contained in a longer title: substring relationship; may also fuzzy-match.
+        const string core = "zkq-match-core-token";
+        var (youTube, audio) = CreateYouTubeAudioPair(
+            podcast,
+            youTubeRelease,
+            audioRelease,
+            length,
+            core,
+            "Broadcast archive " + core + " extended cut");
+
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+        var weakFloor =
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.WeakCatalogueReleasePoints;
+
+        score.Should().BeOneOf(
+            weakFloor + CrossPlatformMatchScorer.SubstringTitlePoints,
+            weakFloor + CrossPlatformMatchScorer.FuzzyTitlePoints);
+        score.Should().BeGreaterThanOrEqualTo(CrossPlatformMatchScorer.MatchThreshold);
+        CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "Delay-aligned release takes precedence over same-calendar-day: release tiers are mutually exclusive.")]
+    public void Delay_aligned_release_tier_does_not_stack_same_calendar_day_points()
+    {
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        podcast.YouTubePublicationOffset = TimeSpan.FromHours(-8).Ticks;
+        var audioRelease = new DateTime(2026, 7, 13, 8, 0, 0, DateTimeKind.Utc);
+        var youTubeRelease = audioRelease.Add(podcast.YouTubePublishingDelay());
+        youTubeRelease.Date.Should().Be(audioRelease.Date, "same calendar day while delay-aligned");
+        var length = TimeSpan.FromMinutes(62);
+        var (youTube, audio) = CreateYouTubeAudioPair(
+            podcast,
+            youTubeRelease,
+            audioRelease,
+            length,
+            "Alpha market briefing on early catalogue drift signals",
+            "Omega wellness interview about unrelated guest journeys");
+
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        score.Should().Be(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.DelayAlignedReleasePoints);
+        score.Should().NotBe(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.DelayAlignedReleasePoints +
+            CrossPlatformMatchScorer.SameCalendarDayReleasePoints);
+    }
+
+    [Fact(DisplayName =
+        "Fifty-nine is below threshold and sixty meets it — MeetsMatchThreshold uses inclusive comparison.")]
+    public void Match_threshold_is_inclusive_at_sixty()
+    {
+        CrossPlatformMatchScorer.MatchThreshold.Should().Be(60);
+        (CrossPlatformMatchScorer.DurationWithinBandPoints +
+         CrossPlatformMatchScorer.SameCalendarDayReleasePoints)
+            .Should().Be(60);
+        (CrossPlatformMatchScorer.DurationWithinBandPoints +
+         CrossPlatformMatchScorer.WeakCatalogueReleasePoints)
+            .Should().Be(45);
+        (45 + CrossPlatformMatchScorer.SubstringTitlePoints).Should().Be(65);
+        (45 + CrossPlatformMatchScorer.FuzzyTitlePoints).Should().Be(70);
+        // Document the 59-vs-60 boundary relative to composed constants.
+        (CrossPlatformMatchScorer.MatchThreshold - 1).Should().Be(59);
+    }
+
+    [Fact(DisplayName =
+        "Score is symmetric for YouTube-stored/audio-incoming and audio-stored/YouTube-incoming argument order.")]
+    public void Score_is_symmetric_for_youtube_and_audio_argument_order()
+    {
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (youTube, audio) = CreateDelayAlignedDivergentPair(podcast);
+
+        CrossPlatformMatchScorer.Score(youTube, audio, podcast)
+            .Should().Be(CrossPlatformMatchScorer.Score(audio, youTube, podcast));
+    }
+
+    private (Episode YouTube, Episode Audio) CreateDelayAlignedDivergentPair(Podcast podcast)
+    {
+        var delay = podcast.YouTubePublishingDelay();
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-40, TimeSpan.FromHours(14));
+        var audioRelease = youTubeRelease - delay;
+        var length = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(38);
+        return CreateYouTubeAudioPair(
+            podcast,
+            youTubeRelease,
+            audioRelease,
+            length,
+            "The Neighborhood Scheme: Shocking Truth About Wellness Influencer Networks",
+            "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost");
+    }
+
+    private (Episode YouTube, Episode Audio) CreateYouTubeAudioPair(
+        Podcast podcast,
+        DateTime youTubeRelease,
+        DateTime audioRelease,
+        TimeSpan length,
+        string youTubeTitle,
+        string audioTitle)
+    {
+        var youTube = _fixture.CreateStoredEpisodeWithYouTubeOnly(
+            podcast, youTubeRelease, length, youTubeTitle);
+        var audio = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithTitle(audioTitle)
+            .WithRelease(audioRelease)
+            .WithDuration(length));
+        return (youTube, audio);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchingRules.cs
@@ -84,9 +84,9 @@ public class CrossPlatformMatchingRules
     }
 
     [Fact(DisplayName =
-        "Hassan-shaped: after Apple has already merged onto the YouTube row, an incoming Spotify catalogue " +
-        "episode with delay-aligned release and duration within five minutes must still merge onto that " +
-        "YouTube+Apple target despite wholly divergent marketing titles.")]
+        "After Apple has already merged onto the YouTube row, an incoming Spotify catalogue episode with " +
+        "delay-aligned release and duration within five minutes must still merge onto that YouTube+Apple " +
+        "target despite wholly divergent marketing titles.")]
     public void Spotify_merges_onto_youtube_plus_apple_when_delay_aligned_despite_divergent_titles()
     {
         // Arrange
@@ -97,17 +97,18 @@ public class CrossPlatformMatchingRules
         var youTubeLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(37);
         var spotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
         var appleId = _fixture.CreateAppleId();
+        var youTubeId = _fixture.CreateYouTubeId();
         var stored = _fixture.BuildEpisode()
             .WithPodcast(podcast)
-            .WithTitle("The Cult Next Door: The Shocking Truth About MLM Schemes and Wellness Influencers")
+            .WithTitle("The Neighborhood Scheme: Shocking Truth About Wellness Influencer Networks")
             .WithRelease(youTubeRelease)
             .WithLength(youTubeLength)
-            .WithYouTube("JH_934xaeN0", _fixture.DefaultYouTubeUrl("JH_934xaeN0"))
+            .WithYouTube(youTubeId, _fixture.DefaultYouTubeUrl(youTubeId))
             .WithApple(appleId, _fixture.DefaultAppleUrl(appleId))
             .Create();
         var spotifyInput = _fixture.CreateSpotifyCatalogueInput(b => b
             .WithTitle(
-                "She Spent $115K in a Wellness MLM with Brandie Hadfield: A new mom, an autistic baby, and a decade lost to a commercial cult")
+                "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost")
             .WithRelease(audioRelease)
             .WithDuration(spotifyLength));
         var discovered = _fixture.CreateSpotifyCatalogueEpisode(b => b
@@ -131,36 +132,37 @@ public class CrossPlatformMatchingRules
     }
 
     [Fact(DisplayName =
-        "Hassan-shaped: Spotify for this week's MLM episode must not merge onto last week's YouTube episode " +
-        "even when catalogue-day tolerance (±5) and five-minute duration include that row — composite score " +
-        "stays below threshold without delay alignment or title confidence.")]
+        "Spotify for this week's episode must not merge onto last week's YouTube episode even when " +
+        "catalogue-day tolerance (±5) and five-minute duration include that row — composite score stays " +
+        "below threshold without delay alignment or title confidence.")]
     public void Spotify_does_not_merge_onto_wrong_week_youtube_under_weak_catalogue_day_alignment()
     {
         // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         podcast.YouTubePublicationOffset = TimeSpan.FromHours(-8.5).Ticks;
         var lastWeekYouTubeRelease = new DateTime(2026, 7, 10, 19, 0, 46, DateTimeKind.Utc);
-        var mlmSpotifyRelease = new DateTime(2026, 7, 13, 8, 30, 0, DateTimeKind.Utc);
+        var thisWeekSpotifyRelease = new DateTime(2026, 7, 13, 8, 30, 0, DateTimeKind.Utc);
         var lastWeekLength = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
-        var mlmSpotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
+        var thisWeekSpotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
+        var youTubeId = _fixture.CreateYouTubeId();
         var stored = _fixture.BuildEpisode()
             .WithPodcast(podcast)
-            .WithTitle("Can Local Elections Stop Authoritarianism? Defending Democracy One Vote at a Time")
+            .WithTitle("Civic turnout strategies for mid-cycle ballot measures")
             .WithRelease(lastWeekYouTubeRelease)
             .WithLength(lastWeekLength)
-            .WithYouTube("yN_wIF8zk4w", _fixture.DefaultYouTubeUrl("yN_wIF8zk4w"))
+            .WithYouTube(youTubeId, _fixture.DefaultYouTubeUrl(youTubeId))
             .Create();
         var spotifyInput = _fixture.CreateSpotifyCatalogueInput(b => b
             .WithTitle(
-                "She Spent $115K in a Wellness MLM with Brandie Hadfield: A new mom, an autistic baby, and a decade lost to a commercial cult")
-            .WithRelease(mlmSpotifyRelease)
-            .WithDuration(mlmSpotifyLength));
+                "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost")
+            .WithRelease(thisWeekSpotifyRelease)
+            .WithDuration(thisWeekSpotifyLength));
         var discovered = _fixture.CreateSpotifyCatalogueEpisode(b => b
             .WithSpotifyId(spotifyInput.SpotifyId)
             .WithTitle(spotifyInput.Title)
             .WithSpotifyUrl(spotifyInput.SpotifyUrl)
-            .WithRelease(mlmSpotifyRelease)
-            .WithDuration(mlmSpotifyLength));
+            .WithRelease(thisWeekSpotifyRelease)
+            .WithDuration(thisWeekSpotifyLength));
         var expected = EpisodeExpectation.From(stored);
 
         // Act
@@ -175,8 +177,8 @@ public class CrossPlatformMatchingRules
 
     
     [Fact(DisplayName =
-        "Hassan-shaped: a Spotify catalogue episode with delay-aligned release and duration within five minutes " +
-        "must merge onto a YouTube-only stored episode despite wholly divergent marketing titles.")]
+        "A Spotify catalogue episode with delay-aligned release and duration within five minutes must " +
+        "merge onto a YouTube-only stored episode despite wholly divergent marketing titles.")]
     public void Spotify_merges_onto_youtube_only_when_delay_aligned_despite_divergent_titles()
     {
         // Arrange

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchingRules.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Episodes.TestSupport;
 using RedditPodcastPoster.Episodes.TestSupport.Assertions;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
@@ -60,8 +61,273 @@ public class CrossPlatformMatchingRules
     }
 
     [Fact(DisplayName =
-        "For YouTube release authority podcasts with negative publishing delay, episodes must not merge on " +
-        "release-and-duration alone when titles share no fuzzy or substring relationship.")]
+        "For YouTube release authority podcasts with negative publishing delay, a YouTube-only stored episode " +
+        "and an Apple catalogue episode with delay-aligned releases and duration within five minutes must merge " +
+        "even when marketing titles are wholly disjoint — release+duration scores meet the cross-platform threshold.")]
+    public void Negative_delay_aligned_divergent_titles_merge_on_release_and_duration_score()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (stored, discovered, appleId) = _fixture.CreateNegativeDelayAlignedDivergentTitlePair(podcast);
+        var expected = EpisodeExpectation.From(stored)
+            .WithApple(appleId, _fixture.DefaultAppleUrl(appleId));
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.AddedEpisodes.Should().BeEmpty();
+        result.FailedEpisodes.Should().BeEmpty();
+        result.MergedEpisodes.Should().ContainSingle();
+        result.MergedEpisodes.Single().Existing.Id.Should().Be(stored.Id);
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    [Fact(DisplayName =
+        "Hassan-shaped: after Apple has already merged onto the YouTube row, an incoming Spotify catalogue " +
+        "episode with delay-aligned release and duration within five minutes must still merge onto that " +
+        "YouTube+Apple target despite wholly divergent marketing titles.")]
+    public void Spotify_merges_onto_youtube_plus_apple_when_delay_aligned_despite_divergent_titles()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        podcast.YouTubePublicationOffset = TimeSpan.FromHours(-8.5).Ticks;
+        var youTubeRelease = new DateTime(2026, 7, 13, 4, 0, 5, DateTimeKind.Utc);
+        var audioRelease = new DateTime(2026, 7, 13, 8, 30, 0, DateTimeKind.Utc);
+        var youTubeLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(37);
+        var spotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
+        var appleId = _fixture.CreateAppleId();
+        var stored = _fixture.BuildEpisode()
+            .WithPodcast(podcast)
+            .WithTitle("The Cult Next Door: The Shocking Truth About MLM Schemes and Wellness Influencers")
+            .WithRelease(youTubeRelease)
+            .WithLength(youTubeLength)
+            .WithYouTube("JH_934xaeN0", _fixture.DefaultYouTubeUrl("JH_934xaeN0"))
+            .WithApple(appleId, _fixture.DefaultAppleUrl(appleId))
+            .Create();
+        var spotifyInput = _fixture.CreateSpotifyCatalogueInput(b => b
+            .WithTitle(
+                "She Spent $115K in a Wellness MLM with Brandie Hadfield: A new mom, an autistic baby, and a decade lost to a commercial cult")
+            .WithRelease(audioRelease)
+            .WithDuration(spotifyLength));
+        var discovered = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithSpotifyId(spotifyInput.SpotifyId)
+            .WithTitle(spotifyInput.Title)
+            .WithSpotifyUrl(spotifyInput.SpotifyUrl)
+            .WithRelease(audioRelease)
+            .WithDuration(spotifyLength));
+        var expected = EpisodeExpectation.From(stored)
+            .WithSpotify(spotifyInput.SpotifyId, spotifyInput.SpotifyUrl);
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.AddedEpisodes.Should().BeEmpty();
+        result.FailedEpisodes.Should().BeEmpty();
+        result.MergedEpisodes.Should().ContainSingle();
+        result.MergedEpisodes.Single().Existing.Id.Should().Be(stored.Id);
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    [Fact(DisplayName =
+        "Hassan-shaped: Spotify for this week's MLM episode must not merge onto last week's YouTube episode " +
+        "even when catalogue-day tolerance (±5) and five-minute duration include that row — composite score " +
+        "stays below threshold without delay alignment or title confidence.")]
+    public void Spotify_does_not_merge_onto_wrong_week_youtube_under_weak_catalogue_day_alignment()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        podcast.YouTubePublicationOffset = TimeSpan.FromHours(-8.5).Ticks;
+        var lastWeekYouTubeRelease = new DateTime(2026, 7, 10, 19, 0, 46, DateTimeKind.Utc);
+        var mlmSpotifyRelease = new DateTime(2026, 7, 13, 8, 30, 0, DateTimeKind.Utc);
+        var lastWeekLength = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
+        var mlmSpotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
+        var stored = _fixture.BuildEpisode()
+            .WithPodcast(podcast)
+            .WithTitle("Can Local Elections Stop Authoritarianism? Defending Democracy One Vote at a Time")
+            .WithRelease(lastWeekYouTubeRelease)
+            .WithLength(lastWeekLength)
+            .WithYouTube("yN_wIF8zk4w", _fixture.DefaultYouTubeUrl("yN_wIF8zk4w"))
+            .Create();
+        var spotifyInput = _fixture.CreateSpotifyCatalogueInput(b => b
+            .WithTitle(
+                "She Spent $115K in a Wellness MLM with Brandie Hadfield: A new mom, an autistic baby, and a decade lost to a commercial cult")
+            .WithRelease(mlmSpotifyRelease)
+            .WithDuration(mlmSpotifyLength));
+        var discovered = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithSpotifyId(spotifyInput.SpotifyId)
+            .WithTitle(spotifyInput.Title)
+            .WithSpotifyUrl(spotifyInput.SpotifyUrl)
+            .WithRelease(mlmSpotifyRelease)
+            .WithDuration(mlmSpotifyLength));
+        var expected = EpisodeExpectation.From(stored);
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.MergedEpisodes.Should().BeEmpty();
+        result.FailedEpisodes.Should().BeEmpty();
+        result.AddedEpisodes.Should().ContainSingle();
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    
+    [Fact(DisplayName =
+        "Hassan-shaped: a Spotify catalogue episode with delay-aligned release and duration within five minutes " +
+        "must merge onto a YouTube-only stored episode despite wholly divergent marketing titles.")]
+    public void Spotify_merges_onto_youtube_only_when_delay_aligned_despite_divergent_titles()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (stored, discovered, spotifyId) = _fixture.CreateNegativeDelayAlignedDivergentTitleSpotifyPair(podcast);
+        var expected = EpisodeExpectation.From(stored)
+            .WithSpotify(spotifyId, _fixture.DefaultSpotifyUrl(spotifyId));
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.AddedEpisodes.Should().BeEmpty();
+        result.FailedEpisodes.Should().BeEmpty();
+        result.MergedEpisodes.Should().ContainSingle();
+        result.MergedEpisodes.Single().Existing.Id.Should().Be(stored.Id);
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    [Fact(DisplayName =
+        "When ExactReleaseMatchStrategy accepts same-calendar-day audio-stored and YouTube-incoming releases " +
+        "(not delay-aligned), duration within five minutes meets the cross-platform score threshold even when " +
+        "titles are disjoint.")]
+    public void Same_calendar_day_release_and_duration_merges_despite_divergent_titles()
+    {
+        // Arrange — positive delay expects YouTube next day; same calendar day is a separate ExactRelease signal.
+        var publishingDelay = TimeSpan.FromDays(3);
+        var audioRelease = DomainTestFixture.UtcAtTime(-2, TimeSpan.FromHours(10));
+        // Same calendar day as audio, but far from expected audio+delay (outside 1-day align window).
+        var youTubeRelease = audioRelease.Date.Add(TimeSpan.FromHours(18));
+        var length = TimeSpan.FromMinutes(70);
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.YouTubeChannelId = _fixture.CreateYouTubeChannelId();
+        podcast.YouTubePublicationOffset = publishingDelay.Ticks;
+        var spotifyId = _fixture.CreateSpotifyId();
+        var stored = _fixture.BuildEpisode()
+            .WithPodcast(podcast)
+            .WithTitle("Alpha market briefing on early catalogue drift signals")
+            .WithRelease(audioRelease)
+            .WithLength(length)
+            .WithSpotify(spotifyId, _fixture.DefaultSpotifyUrl(spotifyId))
+            .Create();
+        var youTubeInput = _fixture.CreateYouTubeCatalogueInput(b => b
+            .WithTitle("Omega wellness interview about unrelated guest journeys")
+            .WithRelease(youTubeRelease)
+            .WithDuration(length - TimeSpan.FromSeconds(2)));
+        var discovered = _fixture.CreateYouTubeCatalogueEpisode(b => b
+            .WithYouTubeId(youTubeInput.YouTubeId)
+            .WithTitle(youTubeInput.Title)
+            .WithRelease(youTubeInput.Release)
+            .WithDuration(youTubeInput.Duration));
+        var expected = EpisodeExpectation.From(stored)
+            .WithYouTube(youTubeInput.YouTubeId, youTubeInput.YouTubeUrl);
+
+        EpisodeReleaseTolerance.IsYouTubePublishDelayAligned(
+                audioRelease, youTubeRelease, publishingDelay)
+            .Should().BeFalse();
+        EpisodeReleaseTolerance.AreCrossPlatformReleasesOnSameCalendarDay(audioRelease, youTubeRelease)
+            .Should().BeTrue();
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.AddedEpisodes.Should().BeEmpty();
+        result.FailedEpisodes.Should().BeEmpty();
+        result.MergedEpisodes.Should().ContainSingle();
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    [Fact(DisplayName =
+        "Weak catalogue-day release alignment plus similar duration can still merge when a substring title " +
+        "relationship supplies enough score to reach the cross-platform threshold.")]
+    public void Weak_catalogue_day_alignment_merges_when_substring_title_pushes_score_over_threshold()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var delay = podcast.YouTubePublishingDelay();
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-40, TimeSpan.FromHours(15));
+        var audioRelease = (youTubeRelease - delay).Date.AddDays(3);
+        var length = TimeSpan.FromMinutes(55);
+        const string core = "Holy Disobedience: Inside Adventist Networks";
+        var stored = _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast, youTubeRelease, length, core);
+        var spotifyInput = _fixture.CreateSpotifyCatalogueInput(b => b
+            .WithTitle("Show Prefix - " + core)
+            .WithRelease(audioRelease)
+            .WithDuration(length));
+        var discovered = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithSpotifyId(spotifyInput.SpotifyId)
+            .WithTitle(spotifyInput.Title)
+            .WithSpotifyUrl(spotifyInput.SpotifyUrl)
+            .WithRelease(audioRelease)
+            .WithDuration(length));
+        var expected = EpisodeExpectation.From(stored)
+            .WithSpotify(spotifyInput.SpotifyId, spotifyInput.SpotifyUrl);
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.MergedEpisodes.Should().ContainSingle();
+        result.AddedEpisodes.Should().BeEmpty();
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    [Fact(DisplayName =
+        "For Spotify-first podcasts with positive YouTube publishing delay, delay-aligned release and duration " +
+        "within five minutes merge YouTube onto stored audio even when marketing titles are wholly disjoint.")]
+    public void Positive_delay_aligned_divergent_titles_merge_on_release_and_duration_score()
+    {
+        // Arrange
+        var publishingDelay = TimeSpan.FromDays(1);
+        var audioRelease = DomainTestFixture.UtcAtTime(-2, TimeSpan.FromHours(10));
+        var length = TimeSpan.FromMinutes(70);
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.YouTubeChannelId = _fixture.CreateYouTubeChannelId();
+        podcast.YouTubePublicationOffset = publishingDelay.Ticks;
+        var spotifyId = _fixture.CreateSpotifyId();
+        var stored = _fixture.BuildEpisode()
+            .WithPodcast(podcast)
+            .WithTitle("Alpha market briefing on early catalogue drift signals")
+            .WithRelease(audioRelease)
+            .WithLength(length)
+            .WithSpotify(spotifyId, _fixture.DefaultSpotifyUrl(spotifyId))
+            .Create();
+        var youTubeInput = _fixture.CreateYouTubeCatalogueInput(b => b
+            .WithTitle("Omega wellness interview about unrelated guest journeys")
+            .WithRelease(audioRelease.Add(publishingDelay))
+            .WithDuration(length - TimeSpan.FromSeconds(2)));
+        var discovered = _fixture.CreateYouTubeCatalogueEpisode(b => b
+            .WithYouTubeId(youTubeInput.YouTubeId)
+            .WithTitle(youTubeInput.Title)
+            .WithRelease(youTubeInput.Release)
+            .WithDuration(youTubeInput.Duration));
+        var expected = EpisodeExpectation.From(stored)
+            .WithYouTube(youTubeInput.YouTubeId, youTubeInput.YouTubeUrl);
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.AddedEpisodes.Should().BeEmpty();
+        result.FailedEpisodes.Should().BeEmpty();
+        result.MergedEpisodes.Should().ContainSingle();
+        stored.ShouldMatchExpectation(expected);
+    }
+
+[Fact(DisplayName =
+        "For YouTube release authority podcasts with negative publishing delay, weak catalogue-day release " +
+        "alignment (±5 days) plus similar duration must not merge when titles share no fuzzy or substring " +
+        "relationship — composite score stays below the cross-platform threshold.")]
     public void Negative_delay_does_not_merge_on_release_and_duration_when_titles_differ()
     {
         // Arrange

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/FuzzyTitleMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/FuzzyTitleMatchingRules.cs
@@ -129,8 +129,8 @@ public class FuzzyTitleMatchingRules
 
     // --------------------------------------------------------------------------------------------
     // Matrix: 4 variant strategies × YouTube release authority podcast with negative publishing delay.
-    // Negative delay requires fuzzy title match in BOTH the fuzzy-and-duration path AND the
-    // release-and-duration path (see EpisodePlatformMatcher.MatchesByReleaseAndDuration line 146).
+    // Fuzzy title still contributes score on the release-and-duration path; these cases also pass
+    // via MatchesByFuzzyTitleAndDuration when duration is within band.
     // --------------------------------------------------------------------------------------------
 
     [Theory(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
@@ -7,7 +7,7 @@ namespace RedditPodcastPoster.Episodes.Matching;
 /// <summary>
 /// Composite confidence score for YouTube↔audio cross-platform merges.
 /// Signals add; match when total ≥ <see cref="MatchThreshold"/>.
-/// Delay-aligned release + duration reaches threshold without title (Hassan-style).
+/// Delay-aligned release + duration reaches threshold without title confidence.
 /// Weak catalogue-day release + duration alone does not (#869 protection).
 /// </summary>
 public static class CrossPlatformMatchScorer

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
@@ -1,0 +1,131 @@
+using RedditPodcastPoster.Episodes.Extensions;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Text;
+
+namespace RedditPodcastPoster.Episodes.Matching;
+
+/// <summary>
+/// Composite confidence score for YouTube↔audio cross-platform merges.
+/// Signals add; match when total ≥ <see cref="MatchThreshold"/>.
+/// Delay-aligned release + duration reaches threshold without title (Hassan-style).
+/// Weak catalogue-day release + duration alone does not (#869 protection).
+/// </summary>
+public static class CrossPlatformMatchScorer
+{
+    public const int MatchThreshold = 60;
+
+    public const int DelayAlignedReleasePoints = 40;
+    public const int SameCalendarDayReleasePoints = 30;
+    public const int WeakCatalogueReleasePoints = 15;
+    public const int DurationWithinBandPoints = 30;
+    public const int FuzzyTitlePoints = 25;
+    public const int SubstringTitlePoints = 20;
+
+    private const int MinFuzzyTitleScore = 70;
+
+    /// <summary>
+    /// Scores a YouTube↔audio pair that already passed a release-strategy match and
+    /// duration-within-band checks. Title is supporting evidence, not a hard veto.
+    /// </summary>
+    public static int Score(
+        Episode existingEpisode,
+        Episode incomingEpisode,
+        Podcast podcast)
+    {
+        var score = DurationWithinBandPoints;
+        score += ScoreReleaseStrength(existingEpisode, incomingEpisode, podcast);
+        score += ScoreTitle(existingEpisode, incomingEpisode);
+        return score;
+    }
+
+    public static bool MeetsMatchThreshold(
+        Episode existingEpisode,
+        Episode incomingEpisode,
+        Podcast podcast) =>
+        Score(existingEpisode, incomingEpisode, podcast) >= MatchThreshold;
+
+    private static int ScoreReleaseStrength(
+        Episode existingEpisode,
+        Episode incomingEpisode,
+        Podcast podcast)
+    {
+        if (!TryGetYouTubeAndAudioSides(existingEpisode, incomingEpisode, out var youTubeSide, out var audioSide))
+        {
+            return WeakCatalogueReleasePoints;
+        }
+
+        var delay = podcast.YouTubePublishingDelay();
+        if (delay != TimeSpan.Zero &&
+            EpisodeReleaseTolerance.IsYouTubePublishDelayAligned(
+                audioSide.Release,
+                youTubeSide.Release,
+                delay))
+        {
+            return DelayAlignedReleasePoints;
+        }
+
+        if (EpisodeReleaseTolerance.AreCrossPlatformReleasesOnSameCalendarDay(
+                audioSide.Release,
+                youTubeSide.Release))
+        {
+            return SameCalendarDayReleasePoints;
+        }
+
+        return WeakCatalogueReleasePoints;
+    }
+
+    private static int ScoreTitle(Episode existingEpisode, Episode incomingEpisode)
+    {
+        if (FuzzyMatcher.IsMatch(
+                existingEpisode.Title,
+                incomingEpisode,
+                e => e.Title,
+                MinFuzzyTitleScore))
+        {
+            return FuzzyTitlePoints;
+        }
+
+        if (TitlesShareSubstringRelationship(existingEpisode.Title, incomingEpisode.Title))
+        {
+            return SubstringTitlePoints;
+        }
+
+        return 0;
+    }
+
+    private static bool TryGetYouTubeAndAudioSides(
+        Episode existingEpisode,
+        Episode incomingEpisode,
+        out Episode youTubeSide,
+        out Episode audioSide)
+    {
+        if (existingEpisode.HasYouTubeIdentity() && !incomingEpisode.HasYouTubeIdentity())
+        {
+            youTubeSide = existingEpisode;
+            audioSide = incomingEpisode;
+            return true;
+        }
+
+        if (incomingEpisode.HasYouTubeIdentity() && !existingEpisode.HasYouTubeIdentity())
+        {
+            youTubeSide = incomingEpisode;
+            audioSide = existingEpisode;
+            return true;
+        }
+
+        youTubeSide = existingEpisode;
+        audioSide = incomingEpisode;
+        return false;
+    }
+
+    private static bool TitlesShareSubstringRelationship(string left, string right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+        {
+            return false;
+        }
+
+        return left.Contains(right, StringComparison.OrdinalIgnoreCase) ||
+               right.Contains(left, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
@@ -72,7 +72,12 @@ public sealed partial class EpisodePlatformMatcher
             .Where(x => Math.Abs((x.Length - probe.Length).Ticks) < durationThreshold)
             .ToList();
 
-        if (sameLength.Count == 1 && options.AcceptUniqueDurationWithoutTitleMatch)
+        // YouTube-discovered enrichment already attempted title-confident matching above.
+        // Do not fall through to unique-duration acceptance — that snipes wrong-week audio
+        // when catalogue titles diverge (Hassan Local-Elections←MLM Spotify).
+        if (sameLength.Count == 1 &&
+            options.AcceptUniqueDurationWithoutTitleMatch &&
+            !options.EnrichingYouTubeDiscoveredEpisode)
         {
             return sameLength[0];
         }

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
@@ -74,7 +74,7 @@ public sealed partial class EpisodePlatformMatcher
 
         // YouTube-discovered enrichment already attempted title-confident matching above.
         // Do not fall through to unique-duration acceptance — that snipes wrong-week audio
-        // when catalogue titles diverge (Hassan Local-Elections←MLM Spotify).
+        // when catalogue titles diverge.
         if (sameLength.Count == 1 &&
             options.AcceptUniqueDurationWithoutTitleMatch &&
             !options.EnrichingYouTubeDiscoveredEpisode)

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.cs
@@ -141,41 +141,21 @@ public sealed partial class EpisodePlatformMatcher(IEnumerable<IReleaseMatchStra
             return false;
         }
 
+        // YouTube↔audio pairs: compose release/duration/title scores (same model for +/- delay).
+        if (HasCrossPlatformYouTubeAudioPair(existingEpisode, incomingEpisode))
+        {
+            return CrossPlatformMatchScorer.MeetsMatchThreshold(
+                existingEpisode,
+                incomingEpisode,
+                podcast);
+        }
+
         if (podcast.YouTubePublishingDelay().Ticks < 0)
         {
-            if (HasCrossPlatformYouTubeAudioPair(existingEpisode, incomingEpisode))
-            {
-                return HasCrossPlatformTitleConfidence(existingEpisode, incomingEpisode);
-            }
-
             return FuzzyMatcher.IsMatch(existingEpisode.Title, incomingEpisode, e => e.Title, MinFuzzyTitleScore);
         }
 
         return true;
-    }
-
-    private static bool HasCrossPlatformTitleConfidence(Episode existingEpisode, Episode incomingEpisode)
-    {
-        var existingTitle = existingEpisode.Title;
-        var incomingTitle = incomingEpisode.Title;
-
-        if (FuzzyMatcher.IsMatch(existingTitle, incomingEpisode, e => e.Title, MinFuzzyTitleScore))
-        {
-            return true;
-        }
-
-        return TitlesShareSubstringRelationship(existingTitle, incomingTitle);
-    }
-
-    private static bool TitlesShareSubstringRelationship(string left, string right)
-    {
-        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
-        {
-            return false;
-        }
-
-        return left.Contains(right, StringComparison.OrdinalIgnoreCase) ||
-               right.Contains(left, StringComparison.OrdinalIgnoreCase);
     }
 
     private bool EpisodesReleaseMatch(
@@ -218,22 +198,23 @@ public sealed partial class EpisodePlatformMatcher(IEnumerable<IReleaseMatchStra
 
     private static bool HasCrossPlatformYouTubeAudioPair(Episode existingEpisode, Episode incomingEpisode)
     {
-        return IsYouTubeOnlyToAudioOnlyPair(existingEpisode, incomingEpisode) ||
-               IsYouTubeOnlyToAudioOnlyPair(incomingEpisode, existingEpisode);
+        return IsYouTubeToMissingAudioPlatformPair(existingEpisode, incomingEpisode) ||
+               IsYouTubeToMissingAudioPlatformPair(incomingEpisode, existingEpisode);
     }
 
-    private static bool IsYouTubeOnlyToAudioOnlyPair(Episode youTubeSide, Episode audioSide)
+    /// <summary>
+    /// YouTube-authority side paired with an audio-only side that supplies a platform the YouTube
+    /// side still lacks. YouTube may already have Apple when Spotify arrives (or vice versa).
+    /// </summary>
+    private static bool IsYouTubeToMissingAudioPlatformPair(Episode youTubeSide, Episode audioSide)
     {
         if (!youTubeSide.HasYouTubeIdentity() || audioSide.HasYouTubeIdentity())
         {
             return false;
         }
 
-        if (youTubeSide.HasSpotifyIdentity() || youTubeSide.HasAppleIdentity())
-        {
-            return false;
-        }
-
-        return audioSide.HasSpotifyIdentity() || audioSide.HasAppleIdentity();
+        var bringsSpotify = audioSide.HasSpotifyIdentity() && !youTubeSide.HasSpotifyIdentity();
+        var bringsApple = audioSide.HasAppleIdentity() && !youTubeSide.HasAppleIdentity();
+        return bringsSpotify || bringsApple;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Finders/SearchResultFinderCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Finders/SearchResultFinderCatalogueWrapperRules.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using RedditPodcastPoster.Episodes.TestSupport;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models;
 using RedditPodcastPoster.PodcastServices.Spotify.Finders;
 using SpotifyAPI.Web;
 
@@ -84,38 +85,103 @@ public class SearchResultFinderCatalogueWrapperRules
     }
 
     [Fact(DisplayName =
-        "When the Spotify finder accepts a unique-duration match without title overlap, " +
-        "it maps the matched SimpleEpisode back to the platform API type.")]
-    public void find_by_length_maps_unique_duration_match_back_to_simple_episode()
+        "When enriching a YouTube-discovered episode via the Spotify finder, a sole catalogue row " +
+        "within five minutes of duration but with a disjoint title must not be selected.")]
+    public void find_by_length_youtube_enrichment_does_not_duration_snipe_disjoint_title()
     {
-        // Arrange
-        var episodeLength = _fixture.CreateDuration();
-        var otherLength = episodeLength + TimeSpan.FromMinutes(30);
+        // Arrange — Hassan shape: Local Elections YT (~59:40) must not claim MLM Spotify (~62:39)
+        const string youTubeTitle =
+            "Can Local Elections Stop Authoritarianism? Defending Democracy One Vote at a Time";
+        const string spotifyTitle =
+            "She Spent $115K in a Wellness MLM with Brandie Hadfield: A new mom, an autistic baby, and a decade lost to a commercial cult";
+        var youTubeLength = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
+        var spotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
         var matchingId = _fixture.CreateSpotifyId();
         var episodes = new List<SimpleEpisode>
         {
             new()
             {
                 Id = matchingId,
-                Name = _fixture.CreateTitle(),
-                DurationMs = (int)episodeLength.TotalMilliseconds,
-                ReleaseDate = DomainTestFixture.UtcDateDaysAgo(2).ToString("yyyy-MM-dd")
-            },
+                Name = spotifyTitle,
+                DurationMs = (int)spotifyLength.TotalMilliseconds,
+                ReleaseDate = "2026-07-13"
+            }
+        };
+
+        // Act
+        var result = _sut.FindMatchingEpisodeByLength(
+            youTubeTitle,
+            youTubeLength,
+            episodes,
+            releaseAuthority: Service.YouTube,
+            released: new DateTime(2026, 7, 11, 3, 30, 46, DateTimeKind.Utc),
+            enrichingYouTubeDiscoveredEpisode: true);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "The Spotify finder never enables AcceptUniqueDurationWithoutTitleMatch: a sole catalogue row " +
+        "with matching duration but a title below catalogue fuzzy thresholds is rejected.")]
+    public void find_by_length_never_accepts_unique_duration_without_title_match()
+    {
+        // Arrange — titles chosen so FuzzySharp stays below CatalogueSameLengthMinFuzzyScore (35)
+        const string probeTitle = "aaaaaaaa";
+        const string catalogueTitle = "zzzzzzzz";
+        var episodeLength = TimeSpan.FromMinutes(45);
+        var matchingId = _fixture.CreateSpotifyId();
+        var episodes = new List<SimpleEpisode>
+        {
             new()
             {
-                Id = _fixture.CreateSpotifyId(),
-                Name = _fixture.CreateTitle(),
-                DurationMs = (int)otherLength.TotalMilliseconds,
+                Id = matchingId,
+                Name = catalogueTitle,
+                DurationMs = (int)episodeLength.TotalMilliseconds,
                 ReleaseDate = DomainTestFixture.UtcDateDaysAgo(2).ToString("yyyy-MM-dd")
             }
         };
 
         // Act
         var result = _sut.FindMatchingEpisodeByLength(
-            _fixture.CreateTitle(),
+            probeTitle,
             episodeLength,
             episodes,
-            acceptUniqueDurationWithoutTitleMatch: true);
+            enrichingYouTubeDiscoveredEpisode: false);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "When enriching a YouTube-discovered episode via the Spotify finder, a catalogue row with " +
+        "title confidence and duration within five minutes is still selected.")]
+    public void find_by_length_youtube_enrichment_accepts_title_confident_duration_match()
+    {
+        // Arrange
+        const string title =
+            "Can Local Elections Stop Authoritarianism? Defending Democracy One Vote at a Time";
+        var length = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
+        var matchingId = _fixture.CreateSpotifyId();
+        var episodes = new List<SimpleEpisode>
+        {
+            new()
+            {
+                Id = matchingId,
+                Name = title,
+                DurationMs = (int)length.TotalMilliseconds,
+                ReleaseDate = "2026-07-11"
+            }
+        };
+
+        // Act
+        var result = _sut.FindMatchingEpisodeByLength(
+            title,
+            length,
+            episodes,
+            releaseAuthority: Service.YouTube,
+            released: new DateTime(2026, 7, 11, 3, 30, 46, DateTimeKind.Utc),
+            enrichingYouTubeDiscoveredEpisode: true);
 
         // Assert
         result.Should().NotBeNull();

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Finders/SearchResultFinderCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Finders/SearchResultFinderCatalogueWrapperRules.cs
@@ -89,11 +89,11 @@ public class SearchResultFinderCatalogueWrapperRules
         "within five minutes of duration but with a disjoint title must not be selected.")]
     public void find_by_length_youtube_enrichment_does_not_duration_snipe_disjoint_title()
     {
-        // Arrange — Hassan shape: Local Elections YT (~59:40) must not claim MLM Spotify (~62:39)
+        // Arrange — wrong-week YouTube (~59:40) must not claim this week's Spotify (~62:39) on duration alone
         const string youTubeTitle =
-            "Can Local Elections Stop Authoritarianism? Defending Democracy One Vote at a Time";
+            "Civic turnout strategies for mid-cycle ballot measures";
         const string spotifyTitle =
-            "She Spent $115K in a Wellness MLM with Brandie Hadfield: A new mom, an autistic baby, and a decade lost to a commercial cult";
+            "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost";
         var youTubeLength = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
         var spotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
         var matchingId = _fixture.CreateSpotifyId();
@@ -160,7 +160,7 @@ public class SearchResultFinderCatalogueWrapperRules
     {
         // Arrange
         const string title =
-            "Can Local Elections Stop Authoritarianism? Defending Democracy One Vote at a Time";
+            "Civic turnout strategies for mid-cycle ballot measures";
         var length = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
         var matchingId = _fixture.CreateSpotifyId();
         var episodes = new List<SimpleEpisode>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/ISpotifySearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/ISpotifySearchResultFinder.cs
@@ -21,5 +21,5 @@ public interface ISpotifySearchResultFinder
         Func<SimpleEpisode, bool>? reducer = null,
         Service? releaseAuthority = null,
         DateTime? released = null,
-        bool acceptUniqueDurationWithoutTitleMatch = false);
+        bool enrichingYouTubeDiscoveredEpisode = false);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/SpotifySearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/SpotifySearchResultFinder.cs
@@ -25,7 +25,7 @@ public class SpotifySearchResultFinder(IEpisodePlatformMatcher platformMatcher) 
         Func<SimpleEpisode, bool>? reducer = null,
         Service? releaseAuthority = null,
         DateTime? released = null,
-        bool acceptUniqueDurationWithoutTitleMatch = false)
+        bool enrichingYouTubeDiscoveredEpisode = false)
     {
         var probe = CreateProbeEpisode(episodeTitle, episodeLength, released);
         var candidates = episodes.Select(ToCatalogueEpisode).ToList();
@@ -37,15 +37,17 @@ public class SpotifySearchResultFinder(IEpisodePlatformMatcher platformMatcher) 
                 return source != null && reducer(source);
             };
 
+        // Match AppleEpisodeResolver: YouTube-discovered enrichment must not accept a sole
+        // duration match without title confidence (prevents wrong-week Spotify sniping).
         var match = platformMatcher.FindCatalogueMatchByLength(
             probe,
             candidates,
             CreateLookupPodcast(releaseAuthority),
             episodeMatchRegex: null,
             new CatalogueMatchByLengthOptions(
-                releaseAuthority,
-                acceptUniqueDurationWithoutTitleMatch,
-                acceptUniqueDurationWithoutTitleMatch),
+                ReleaseAuthority: releaseAuthority,
+                AcceptUniqueDurationWithoutTitleMatch: false,
+                EnrichingYouTubeDiscoveredEpisode: enrichingYouTubeDiscoveredEpisode),
             episodeReducer);
 
         return match == null ? null : FindSourceEpisode(episodes, match);


### PR DESCRIPTION
## Summary
- Replace absolute negative-delay title gates with `CrossPlatformMatchScorer` (threshold 60) so delay-aligned release + duration can merge divergent marketing titles (Apple→YT, Spotify→YT, Spotify→YT+Apple), including when YouTube already has Apple.
- Keep #869 protection: weak ±5-day catalogue alignment + duration without title stays below threshold; Spotify enrichment no longer accepts unique-duration-without-title (catalogue defense when enriching YouTube).
- Add dedicated scorer unit tests plus expanded matching/Spotify business-rule coverage for happy paths and edge cases (wrong-week duration snipes, same-calendar-day ExactRelease path, title points pushing weak release over threshold, positive-delay divergent titles, duration >5 min veto).

## Test plan
- [x] `dotnet test` Episodes.Tests `FullyQualifiedName~BusinessRules.Matching` — 188 passed
- [x] `dotnet test` Spotify.Tests `FullyQualifiedName~SearchResultFinder` — 5 passed
- [ ] Spot-check delay-aligned divergent marketing titles merge onto the correct YouTube row; wrong-week YouTube not claimed by similar-duration Spotify
- [ ] Spot-check positive-delay Spotify-first show still merges YouTube on release+duration scoring

Made with [Cursor](https://cursor.com)