### PR TITLE
Accept early-within-delay audio for negative YouTube offsets

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
@@ -672,11 +672,12 @@ public sealed class DomainTestFixture
   }
 
   /// <summary>
-  /// Cults to Consciousness production shape: configured YouTube delay −31.5d, YouTube-first publish,
-  /// Spotify/Apple arrive ~13 days later (early within delay), durations within five minutes.
-  /// Titles may be divergent (pre-rename) or matched (post-rename); descriptions match either way.
+  /// YouTube-authority podcast with a large negative publication offset (~31.5d): YouTube publishes
+  /// first; Spotify/Apple arrive early within that configured delay (~13d later) with durations in
+  /// the cross-platform band. Titles may diverge (pre-rename) or match (post-rename); descriptions
+  /// are shared either way for description-confidence scoring.
   /// </summary>
-  public (Episode Stored, Episode Incoming, string SpotifyId) CreateCultsToConsciousnessEarlyAudioPair(
+  public (Episode Stored, Episode Incoming, string SpotifyId) CreateYouTubeAuthorityNegativeOffsetEarlyAudioPair(
     Podcast podcast,
     bool matchingTitles)
   {
@@ -686,10 +687,12 @@ public sealed class DomainTestFixture
     var youTubeLength = TimeSpan.FromMinutes(81) + TimeSpan.FromSeconds(50);
     var audioLength = TimeSpan.FromMinutes(85) + TimeSpan.FromSeconds(10);
     const string youTubeTitlePreRename =
-      "When Evil Infiltrates Campus Church (and gets away with it)";
-    const string audioTitle = "I Was Recruited on Campus Into a Cult";
+      "The Neighborhood Scheme: Shocking Truth About Wellness Influencer Networks";
+    const string audioTitle =
+      "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost";
     const string sharedDescription =
-      "Sarah entered college with almost no religious background, hoping to find community and deepen her newfound Christian faith, only to be drawn into a highly controlling branch of Assemblies of God known as Chi Alpha at Murray State.";
+      "A long-form interview covering recruitment into a high-control group, isolation from family, " +
+      "and the lasting impact of coercive spiritual authority after leaving the community.";
 
     var stored = CreateStoredEpisodeWithYouTubeOnly(
       podcast,

--- a/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
@@ -659,12 +659,58 @@ public sealed class DomainTestFixture
       youTubeRelease,
       storedLength,
       "Alpha market briefing on early catalogue drift signals");
+    stored.Description =
+      "Alpha-only show notes about market briefing mechanics and catalogue drift telemetry.";
     var incoming = CreateSpotifyCatalogueEpisode(b => b
       .WithTitle("Omega wellness interview about unrelated guest journeys")
+      .WithDescription(
+        "Omega-only wellness interview notes about guest journeys with no shared phrasing.")
       .WithRelease(incomingRelease)
       .WithDuration(incomingLength));
 
     return (stored, incoming);
+  }
+
+  /// <summary>
+  /// Cults to Consciousness production shape: configured YouTube delay −31.5d, YouTube-first publish,
+  /// Spotify/Apple arrive ~13 days later (early within delay), durations within five minutes.
+  /// Titles may be divergent (pre-rename) or matched (post-rename); descriptions match either way.
+  /// </summary>
+  public (Episode Stored, Episode Incoming, string SpotifyId) CreateCultsToConsciousnessEarlyAudioPair(
+    Podcast podcast,
+    bool matchingTitles)
+  {
+    podcast.YouTubePublicationOffset = TimeSpan.FromDays(-31).Add(TimeSpan.FromHours(-12)).Ticks;
+    var youTubeRelease = new DateTime(2026, 7, 1, 15, 21, 27, DateTimeKind.Utc);
+    var audioRelease = new DateTime(2026, 7, 14, 13, 0, 0, DateTimeKind.Utc);
+    var youTubeLength = TimeSpan.FromMinutes(81) + TimeSpan.FromSeconds(50);
+    var audioLength = TimeSpan.FromMinutes(85) + TimeSpan.FromSeconds(10);
+    const string youTubeTitlePreRename =
+      "When Evil Infiltrates Campus Church (and gets away with it)";
+    const string audioTitle = "I Was Recruited on Campus Into a Cult";
+    const string sharedDescription =
+      "Sarah entered college with almost no religious background, hoping to find community and deepen her newfound Christian faith, only to be drawn into a highly controlling branch of Assemblies of God known as Chi Alpha at Murray State.";
+
+    var stored = CreateStoredEpisodeWithYouTubeOnly(
+      podcast,
+      youTubeRelease,
+      youTubeLength,
+      matchingTitles ? audioTitle : youTubeTitlePreRename);
+    stored.Description = sharedDescription;
+    var spotifyInput = CreateSpotifyCatalogueInput(b => b
+      .WithTitle(audioTitle)
+      .WithDescription(sharedDescription)
+      .WithRelease(audioRelease)
+      .WithDuration(audioLength));
+    var incoming = CreateSpotifyCatalogueEpisode(b => b
+      .WithSpotifyId(spotifyInput.SpotifyId)
+      .WithTitle(audioTitle)
+      .WithDescription(sharedDescription)
+      .WithSpotifyUrl(spotifyInput.SpotifyUrl)
+      .WithRelease(audioRelease)
+      .WithDuration(audioLength));
+
+    return (stored, incoming, spotifyInput.SpotifyId);
   }
 
   /// <summary>

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/AppleCatalogueReleaseMatchStrategyRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/AppleCatalogueReleaseMatchStrategyRules.cs
@@ -115,9 +115,8 @@ public class AppleCatalogueReleaseMatchStrategyRules
         var stored = _fixture.CreateStoredEpisodeWithYouTubeOnly(
             podcast,
             release: youTubeRelease);
-        var delay = podcast.YouTubePublishingDelay();
-        var expectedAudioRelease = youTubeRelease.Subtract(delay);
-        var farOffAppleRelease = expectedAudioRelease.AddDays(-30);
+        // Before YouTube day — outside ±5 of expected and outside early-within-delay window.
+        var farOffAppleRelease = youTubeRelease.AddDays(-5);
         var incoming = _fixture.CreateAppleCatalogueEpisode(b => b
             .WithRelease(farOffAppleRelease));
         var context = new ReleaseMatchContext(podcast, stored, incoming);

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -604,7 +604,7 @@ public class CatalogueMatchingRules
         "a catalogue row whose title shares no fuzzy or substring relationship with the stored episode.")]
     public void youtube_discovered_enrichment_does_not_duration_snipe_disjoint_titles()
     {
-        // Arrange — Cults to Consciousness shape: release window aligns but titles refer to different interviews
+        // Arrange — YouTube-authority enrichment: release window aligns but titles refer to different interviews
         const string storedTitle = "My Buddhist Guru Convinced Me Her Ab*se Was Enlightenment";
         const string catalogueTitle =
             "Growing Up On SISTER WIVES: The Dark Side of Parenting No One Talks About (ft. Mykelti Brown)";

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -204,8 +204,8 @@ public class CatalogueMatchingRules
     }
 
     [Fact(DisplayName =
-        "When a catalogue item's release falls outside the Spotify catalogue tolerance window, " +
-        "CatalogueReleaseMatches rejects it for platform lookup filtering.")]
+        "When a catalogue item's release falls before the inferred YouTube day for a negative-delay " +
+        "podcast, CatalogueReleaseMatches rejects it for platform lookup filtering.")]
     public void catalogue_release_filter_rejects_release_outside_tolerance()
     {
         // Arrange
@@ -218,7 +218,7 @@ public class CatalogueMatchingRules
             e.Length = _fixture.CreateDuration();
             e.Release = lookupRelease;
         });
-        var farOffRelease = lookupRelease.AddDays(-30);
+        var farOffRelease = youTubeRelease.AddDays(-5);
         var catalogueItem = _fixture.CreateEpisode(e =>
         {
             e.Title = _fixture.CreateTitle();

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchScorerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchScorerRules.cs
@@ -78,7 +78,7 @@ public class CrossPlatformMatchScorerRules
     {
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var (youTube, audio, _) =
-            _fixture.CreateCultsToConsciousnessEarlyAudioPair(podcast, matchingTitles: false);
+            _fixture.CreateYouTubeAuthorityNegativeOffsetEarlyAudioPair(podcast, matchingTitles: false);
 
         var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
 

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchScorerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchScorerRules.cs
@@ -72,6 +72,24 @@ public class CrossPlatformMatchScorerRules
     }
 
     [Fact(DisplayName =
+        "Early-within-negative-delay release plus duration plus matching descriptions reaches 70 and " +
+        "meets the threshold even when marketing titles are wholly disjoint.")]
+    public void Early_within_delay_with_matching_descriptions_meets_threshold()
+    {
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (youTube, audio, _) =
+            _fixture.CreateCultsToConsciousnessEarlyAudioPair(podcast, matchingTitles: false);
+
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        score.Should().Be(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.WeakCatalogueReleasePoints +
+            CrossPlatformMatchScorer.FuzzyDescriptionPoints);
+        CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
         "Weak catalogue-day release plus duration plus fuzzy title reaches 70 and meets the match threshold.")]
     public void Weak_catalogue_release_with_fuzzy_title_meets_threshold()
     {

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchingRules.cs
@@ -561,6 +561,90 @@ public class CrossPlatformMatchingRules
     }
 
     [Fact(DisplayName =
+        "Cults to Consciousness shape: when audio arrives early within the configured negative delay " +
+        "(YouTube first, Spotify ~13d later vs −31.5d expectation) and titles still diverge, matching " +
+        "descriptions plus duration must merge onto the YouTube row.")]
+    public void Early_within_negative_delay_divergent_titles_merge_when_descriptions_match()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (stored, discovered, spotifyId) =
+            _fixture.CreateCultsToConsciousnessEarlyAudioPair(podcast, matchingTitles: false);
+        var expected = EpisodeExpectation.From(stored)
+            .WithSpotify(spotifyId, _fixture.DefaultSpotifyUrl(spotifyId));
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.AddedEpisodes.Should().BeEmpty();
+        result.FailedEpisodes.Should().BeEmpty();
+        result.MergedEpisodes.Should().ContainSingle();
+        result.MergedEpisodes.Single().Existing.Id.Should().Be(stored.Id);
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    [Fact(DisplayName =
+        "Cults to Consciousness shape: when YouTube has already been renamed to match Spotify/Apple, " +
+        "early-within-negative-delay audio must merge even without relying on description confidence.")]
+    public void Early_within_negative_delay_renamed_titles_merge()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (stored, discovered, spotifyId) =
+            _fixture.CreateCultsToConsciousnessEarlyAudioPair(podcast, matchingTitles: true);
+        stored.Description = "YouTube teaser copy that no longer matches the Spotify show notes.";
+        discovered.Description = "Spotify-only RSS description with wholly different wording.";
+        var expected = EpisodeExpectation.From(stored)
+            .WithSpotify(spotifyId, _fixture.DefaultSpotifyUrl(spotifyId));
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.AddedEpisodes.Should().BeEmpty();
+        result.FailedEpisodes.Should().BeEmpty();
+        result.MergedEpisodes.Should().ContainSingle();
+        result.MergedEpisodes.Single().Existing.Id.Should().Be(stored.Id);
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    [Fact(DisplayName =
+        "Early-within-negative-delay release plus similar duration must not merge when titles and " +
+        "descriptions are both divergent — keep #869 protection across the widened delay window.")]
+    public void Early_within_negative_delay_does_not_merge_without_title_or_description_confidence()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        podcast.YouTubePublicationOffset = TimeSpan.FromDays(-31).Add(TimeSpan.FromHours(-12)).Ticks;
+        var youTubeRelease = new DateTime(2026, 7, 1, 15, 21, 27, DateTimeKind.Utc);
+        var audioRelease = new DateTime(2026, 7, 14, 13, 0, 0, DateTimeKind.Utc);
+        var length = TimeSpan.FromMinutes(80);
+        var stored = _fixture.CreateStoredEpisodeWithYouTubeOnly(
+            podcast,
+            youTubeRelease,
+            length,
+            "Civic turnout strategies for mid-cycle ballot measures");
+        stored.Description = "Ballot-measure strategy notes with no overlap to the audio episode.";
+        var discovered = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithTitle(
+                "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost")
+            .WithDescription("Wellness-scheme interview notes with no shared ballot wording.")
+            .WithRelease(audioRelease)
+            .WithDuration(length));
+        var expected = EpisodeExpectation.From(stored);
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.MergedEpisodes.Should().BeEmpty();
+        result.FailedEpisodes.Should().BeEmpty();
+        result.AddedEpisodes.Should().ContainSingle();
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    [Fact(DisplayName =
         "For cross-platform YouTube-to-audio-stored pairs, duration tolerance is five minutes (strict less-than); " +
         "differences beyond that must not merge on release alignment alone.")]
     public void Cross_platform_duration_beyond_five_minutes_does_not_merge_on_release_alignment()

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchingRules.cs
@@ -561,7 +561,7 @@ public class CrossPlatformMatchingRules
     }
 
     [Fact(DisplayName =
-        "Cults to Consciousness shape: when audio arrives early within the configured negative delay " +
+        "When audio arrives early within a large negative YouTube publication offset " +
         "(YouTube first, Spotify ~13d later vs −31.5d expectation) and titles still diverge, matching " +
         "descriptions plus duration must merge onto the YouTube row.")]
     public void Early_within_negative_delay_divergent_titles_merge_when_descriptions_match()
@@ -569,7 +569,7 @@ public class CrossPlatformMatchingRules
         // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var (stored, discovered, spotifyId) =
-            _fixture.CreateCultsToConsciousnessEarlyAudioPair(podcast, matchingTitles: false);
+            _fixture.CreateYouTubeAuthorityNegativeOffsetEarlyAudioPair(podcast, matchingTitles: false);
         var expected = EpisodeExpectation.From(stored)
             .WithSpotify(spotifyId, _fixture.DefaultSpotifyUrl(spotifyId));
 
@@ -585,14 +585,14 @@ public class CrossPlatformMatchingRules
     }
 
     [Fact(DisplayName =
-        "Cults to Consciousness shape: when YouTube has already been renamed to match Spotify/Apple, " +
-        "early-within-negative-delay audio must merge even without relying on description confidence.")]
+        "When YouTube has already been renamed to match Spotify/Apple, early-within-negative-delay " +
+        "audio must merge even without relying on description confidence.")]
     public void Early_within_negative_delay_renamed_titles_merge()
     {
         // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var (stored, discovered, spotifyId) =
-            _fixture.CreateCultsToConsciousnessEarlyAudioPair(podcast, matchingTitles: true);
+            _fixture.CreateYouTubeAuthorityNegativeOffsetEarlyAudioPair(podcast, matchingTitles: true);
         stored.Description = "YouTube teaser copy that no longer matches the Spotify show notes.";
         discovered.Description = "Spotify-only RSS description with wholly different wording.";
         var expected = EpisodeExpectation.From(stored)

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/EpisodeReleaseToleranceRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/EpisodeReleaseToleranceRules.cs
@@ -220,11 +220,12 @@ public class EpisodeReleaseToleranceRules
     }
 
     [Fact(DisplayName =
-        "For Cults to Consciousness-shaped delays (−31.5d configured, audio ~13d after YouTube), " +
-        "SpotifyCatalogueReleaseMatches accepts the early audio date against expected audio = YouTube − delay.")]
+        "For a YouTube-authority podcast with a large negative publication offset (−31.5d) when audio " +
+        "arrives ~13d after YouTube, SpotifyCatalogueReleaseMatches accepts that early date against " +
+        "expected audio = YouTube − delay.")]
     public void spotify_catalogue_accepts_early_audio_within_configured_negative_delay()
     {
-        // Arrange — production C2C offset and the Jul 2026 campus episode pair
+        // Arrange — large negative offset; actual audio early within the configured delay window
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         podcast.YouTubePublicationOffset = TimeSpan.FromDays(-31).Add(TimeSpan.FromHours(-12)).Ticks;
         var youTubeRelease = new DateTime(2026, 7, 1, 15, 21, 27, DateTimeKind.Utc);

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/EpisodeReleaseToleranceRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/EpisodeReleaseToleranceRules.cs
@@ -64,27 +64,37 @@ public class EpisodeReleaseToleranceRules
 
     [Fact(DisplayName =
         "When YouTube is release authority with negative delay, Spotify catalogue day tolerance " +
-        "is five days and SpotifyCatalogueReleaseMatches accepts releases within that window.")]
+        "is five days around expected audio, and audio earlier than that but still after the inferred " +
+        "YouTube day is accepted (early-within-configured-delay). Audio before YouTube is rejected.")]
     public void spotify_catalogue_day_tolerance_for_negative_delay_youtube_authority()
     {
         // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var expectedRelease = DomainTestFixture.UtcAtTime(-10, _fixture.CreateNonMidnightTimeOfDay());
+        var delay = podcast.YouTubePublishingDelay();
+        var youTubeRelease = expectedRelease.Add(delay);
         var toleranceTicks = EpisodeReleaseTolerance.GetToleranceTicks(podcast, _fixture.CreateDuration());
         var withinFiveDays = expectedRelease.AddDays(-4);
-        var beyondFiveDays = expectedRelease.AddDays(-6);
+        var earlyWithinDelayWindow = youTubeRelease.AddDays(5);
+        var beforeYouTube = youTubeRelease.AddDays(-2);
 
         // Act
         var dayTolerance = EpisodeReleaseTolerance.GetSpotifyCatalogueDayTolerance(podcast);
         var withinMatches = EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
             withinFiveDays, expectedRelease, toleranceTicks, podcast);
-        var beyondMatches = EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
-            beyondFiveDays, expectedRelease, toleranceTicks, podcast);
+        var earlyMatches = EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
+            earlyWithinDelayWindow, expectedRelease, toleranceTicks, podcast);
+        var beforeYouTubeMatches = EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
+            beforeYouTube, expectedRelease, toleranceTicks, podcast);
 
         // Assert
         dayTolerance.Should().Be(5);
         withinMatches.Should().BeTrue();
-        beyondMatches.Should().BeFalse();
+        earlyMatches.Should().BeTrue();
+        beforeYouTubeMatches.Should().BeFalse();
+        EpisodeReleaseTolerance.IsAudioWithinNegativeDelayYouTubeToExpectedWindow(
+                earlyWithinDelayWindow, expectedRelease, podcast)
+            .Should().BeTrue();
     }
 
     [Fact(DisplayName =
@@ -187,13 +197,15 @@ public class EpisodeReleaseToleranceRules
     }
 
     [Fact(DisplayName =
-        "SpotifyCatalogueReleaseMatches rejects far-off Spotify catalogue dates.")]
+        "SpotifyCatalogueReleaseMatches rejects Spotify catalogue dates before the inferred YouTube " +
+        "publish day for negative-delay YouTube-authority podcasts.")]
     public void spotify_catalogue_release_matches_outside_tolerance()
     {
         // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var expectedRelease = DomainTestFixture.UtcAtTime(-10, _fixture.CreateNonMidnightTimeOfDay());
-        var farOffSpotifyRelease = expectedRelease.AddDays(-30);
+        var youTubeRelease = expectedRelease.Add(podcast.YouTubePublishingDelay());
+        var farOffSpotifyRelease = youTubeRelease.AddDays(-5);
         var toleranceTicks = EpisodeReleaseTolerance.GetToleranceTicks(podcast, _fixture.CreateDuration());
 
         // Act
@@ -205,6 +217,35 @@ public class EpisodeReleaseToleranceRules
 
         // Assert
         matches.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "For Cults to Consciousness-shaped delays (−31.5d configured, audio ~13d after YouTube), " +
+        "SpotifyCatalogueReleaseMatches accepts the early audio date against expected audio = YouTube − delay.")]
+    public void spotify_catalogue_accepts_early_audio_within_configured_negative_delay()
+    {
+        // Arrange — production C2C offset and the Jul 2026 campus episode pair
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        podcast.YouTubePublicationOffset = TimeSpan.FromDays(-31).Add(TimeSpan.FromHours(-12)).Ticks;
+        var youTubeRelease = new DateTime(2026, 7, 1, 15, 21, 27, DateTimeKind.Utc);
+        var audioRelease = new DateTime(2026, 7, 14, 13, 0, 0, DateTimeKind.Utc);
+        var expectedAudioRelease = EpisodeReleaseTolerance.GetAudioReleaseForPlatformLookup(
+            podcast,
+            youTubeRelease,
+            episodeHasYouTubeIdentity: true);
+        var toleranceTicks = EpisodeReleaseTolerance.GetToleranceTicks(podcast, TimeSpan.FromMinutes(80));
+
+        // Act
+        var matches = EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
+            audioRelease,
+            expectedAudioRelease,
+            toleranceTicks,
+            podcast);
+
+        // Assert
+        expectedAudioRelease.Date.Should().Be(new DateTime(2026, 8, 2));
+        Math.Abs((audioRelease - youTubeRelease).TotalDays).Should().BeApproximately(12.9, 0.1);
+        matches.Should().BeTrue();
     }
 
     private Podcast CreateSpotifyPrimaryWithPositiveDelay()

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/SpotifyCatalogueReleaseMatchStrategyRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/SpotifyCatalogueReleaseMatchStrategyRules.cs
@@ -115,9 +115,8 @@ public class SpotifyCatalogueReleaseMatchStrategyRules
         var stored = _fixture.CreateStoredEpisodeWithYouTubeOnly(
             podcast,
             release: youTubeRelease);
-        var delay = podcast.YouTubePublishingDelay();
-        var expectedAudioRelease = youTubeRelease.Subtract(delay);
-        var farOffSpotifyRelease = expectedAudioRelease.AddDays(-30);
+        // Before YouTube day — outside ±5 of expected and outside early-within-delay window.
+        var farOffSpotifyRelease = youTubeRelease.AddDays(-5);
         var incoming = _fixture.CreateSpotifyCatalogueEpisode(b => b
             .WithRelease(farOffSpotifyRelease));
         var context = new ReleaseMatchContext(podcast, stored, incoming);

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/YouTubePublishDelayMatchStrategyRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/YouTubePublishDelayMatchStrategyRules.cs
@@ -82,9 +82,7 @@ public class YouTubePublishDelayMatchStrategyRules
         var stored = _fixture.CreateStoredEpisodeWithYouTubeOnly(
             podcast,
             release: youTubeRelease);
-        var delay = podcast.YouTubePublishingDelay();
-        var expectedAudioRelease = youTubeRelease.Subtract(delay);
-        var farOffSpotifyRelease = expectedAudioRelease.AddDays(-30);
+        var farOffSpotifyRelease = youTubeRelease.AddDays(-5);
         var incoming = _fixture.CreateSpotifyCatalogueEpisode(b => b
             .WithRelease(farOffSpotifyRelease));
         var context = new ReleaseMatchContext(podcast, stored, incoming);

--- a/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeReleaseTolerance.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeReleaseTolerance.cs
@@ -126,7 +126,50 @@ public static class EpisodeReleaseTolerance
             return true;
         }
 
+        // Negative delay = YouTube first, audio later at ~|delay|. Audio often lands early
+        // (between YouTube publish and the configured expectation). Accept that band so
+        // catalogue/merge do not miss real pairs when |actual delay| < |configured delay|.
+        if (IsAudioWithinNegativeDelayYouTubeToExpectedWindow(
+                spotifyCatalogueRelease,
+                expectedRelease,
+                podcast,
+                dayTolerance))
+        {
+            return true;
+        }
+
         return Math.Abs((spotifyCatalogueRelease - expectedRelease).Ticks) < toleranceTicks;
+    }
+
+    /// <summary>
+    /// For YouTube-authority podcasts with negative publishing delay, <paramref name="expectedRelease"/>
+    /// is audio ≈ YouTube − delay. Accept catalogue audio from the inferred YouTube day through
+    /// expected audio + day tolerance (early-within-configured-delay).
+    /// </summary>
+    public static bool IsAudioWithinNegativeDelayYouTubeToExpectedWindow(
+        DateTime audioCatalogueRelease,
+        DateTime expectedAudioRelease,
+        Podcast? podcast,
+        int? dayTolerance = null)
+    {
+        if (podcast is not { ReleaseAuthority: Service.YouTube })
+        {
+            return false;
+        }
+
+        var delay = podcast.YouTubePublishingDelay();
+        if (delay.Ticks >= 0)
+        {
+            return false;
+        }
+
+        var tol = dayTolerance ?? GetSpotifyCatalogueDayTolerance(podcast);
+        // expected = youtube - delay ⇒ youtube = expected + delay (delay &lt; 0).
+        var youTubeDate = DateOnly.FromDateTime(expectedAudioRelease.Add(delay));
+        var audioDate = DateOnly.FromDateTime(audioCatalogueRelease);
+        var expectedDate = DateOnly.FromDateTime(expectedAudioRelease);
+        return audioDate >= youTubeDate &&
+               audioDate.DayNumber <= expectedDate.DayNumber + tol;
     }
 
     /// <summary>
@@ -184,7 +227,9 @@ public static class EpisodeReleaseTolerance
         }
 
         var expectedAudioRelease = GetAudioReleaseForPlatformLookup(podcast, episode);
-        var windowStart = expectedAudioRelease.AddDays(-YouTubeReleaseAuthoritySpotifyCatalogueDayTolerance);
+        // Start from the YouTube release (not only near expected audio): audio frequently arrives
+        // early within the configured |delay| window (Cults to Consciousness shape).
+        var windowStart = episode.Release.AddDays(-YouTubeReleaseAuthoritySpotifyCatalogueDayTolerance);
         var windowEnd = expectedAudioRelease.Add(YouTubeReleaseAuthorityEnrichmentLookahead);
         var now = DateTime.UtcNow;
         return now >= windowStart && now <= windowEnd;

--- a/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeReleaseTolerance.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeReleaseTolerance.cs
@@ -228,7 +228,7 @@ public static class EpisodeReleaseTolerance
 
         var expectedAudioRelease = GetAudioReleaseForPlatformLookup(podcast, episode);
         // Start from the YouTube release (not only near expected audio): audio frequently arrives
-        // early within the configured |delay| window (Cults to Consciousness shape).
+        // early within the configured |delay| window on YouTube-authority negative-offset podcasts.
         var windowStart = episode.Release.AddDays(-YouTubeReleaseAuthoritySpotifyCatalogueDayTolerance);
         var windowEnd = expectedAudioRelease.Add(YouTubeReleaseAuthorityEnrichmentLookahead);
         var now = DateTime.UtcNow;

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
@@ -97,7 +97,7 @@ public static class CrossPlatformMatchScorer
         if (DescriptionsFuzzyMatch(existingEpisode.Description, incomingEpisode.Description))
         {
             // Same weight as fuzzy title: marketing titles often diverge while show notes match
-            // (Cults to Consciousness YouTube teasers renamed later to match Spotify/Apple).
+            // (YouTube teasers later renamed to match Spotify/Apple catalogue titles).
             return FuzzyDescriptionPoints;
         }
 

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
@@ -8,7 +8,8 @@ namespace RedditPodcastPoster.Episodes.Matching;
 /// Composite confidence score for YouTube↔audio cross-platform merges.
 /// Signals add; match when total ≥ <see cref="MatchThreshold"/>.
 /// Delay-aligned release + duration reaches threshold without title confidence.
-/// Weak catalogue-day release + duration alone does not (#869 protection).
+/// Weak catalogue-day (or early-within-negative-delay) release + duration alone does not
+/// (#869 protection). Matching episode descriptions supply the same confidence as a fuzzy title.
 /// </summary>
 public static class CrossPlatformMatchScorer
 {
@@ -20,8 +21,11 @@ public static class CrossPlatformMatchScorer
     public const int DurationWithinBandPoints = 30;
     public const int FuzzyTitlePoints = 25;
     public const int SubstringTitlePoints = 20;
+    public const int FuzzyDescriptionPoints = FuzzyTitlePoints;
 
     private const int MinFuzzyTitleScore = 70;
+    private const int MinFuzzyDescriptionScore = 70;
+    private const int DescriptionCompareMaxChars = 500;
 
     /// <summary>
     /// Scores a YouTube↔audio pair that already passed a release-strategy match and
@@ -90,7 +94,34 @@ public static class CrossPlatformMatchScorer
             return SubstringTitlePoints;
         }
 
+        if (DescriptionsFuzzyMatch(existingEpisode.Description, incomingEpisode.Description))
+        {
+            // Same weight as fuzzy title: marketing titles often diverge while show notes match
+            // (Cults to Consciousness YouTube teasers renamed later to match Spotify/Apple).
+            return FuzzyDescriptionPoints;
+        }
+
         return 0;
+    }
+
+    private static bool DescriptionsFuzzyMatch(string left, string right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+        {
+            return false;
+        }
+
+        var leftSample = TruncateForFuzzyCompare(left);
+        var rightSample = TruncateForFuzzyCompare(right);
+        return FuzzyMatcher.IsMatch(leftSample, rightSample, s => s, MinFuzzyDescriptionScore);
+    }
+
+    private static string TruncateForFuzzyCompare(string value)
+    {
+        var trimmed = value.Trim();
+        return trimmed.Length <= DescriptionCompareMaxChars
+            ? trimmed
+            : trimmed[..DescriptionCompareMaxChars];
     }
 
     private static bool TryGetYouTubeAndAudioSides(


### PR DESCRIPTION
## Summary
- Widen catalogue/merge release matching for YouTube-authority podcasts with a large negative publication offset so Spotify/Apple that land early (between YouTube publish and expected audio = YouTube − delay) still count as release-aligned — e.g. configured delay −31.5d with audio only ~13d after YouTube falls outside the old ±5d band around expected audio but inside the configured delay window.
- Treat matching episode descriptions as a fuzzy-title-strength signal in `CrossPlatformMatchScorer` so divergent pre-rename YouTube teaser titles can still merge with duration when show notes match; keep early-window release at weak strength so duration alone does not merge (#869).
- Add regression coverage for early-within-configured-delay audio with renamed and non-renamed titles, plus refuse without title/description confidence. Live duplicate-episode cleanup from the incident that motivated this fix is out of scope and was not applied.

## Test plan
- [x] `dotnet test Class-Libraries/RedditPodcastPoster.Episodes.Tests --filter FullyQualifiedName~BusinessRules.Matching` — 193 passed
- [ ] Deploy indexer (blob script) after merge — not part of this PR
- [ ] After deploy: re-index affected YouTube-authority negative-offset podcasts and confirm new Spotify/Apple rows merge onto YouTube-first episodes when audio arrives early within `|YouTubePublicationOffset|`
- [ ] One-time prod cleanup of the motivating duplicate pair (separate, explicit approval): merge Spotify/Apple onto the YouTube-only row, remove/ignore the duplicate, refresh YouTube title from live video