### PR TITLE
fix: correct Bluesky mentions and language metadata

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Bluesky/BlueskyPoster.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/BlueskyPoster.cs
@@ -21,6 +21,9 @@ public class BlueskyPoster(
         var embedPost = await embedCardPostFactory.Create(podcastEpisode, shortUrl);
         BlueskySendStatus sendStatus;
         var embedCardRequest = await embedCardRequestFactory.CreateEmbedCardRequest(podcastEpisode, embedPost);
+        var language = string.IsNullOrWhiteSpace(podcastEpisode.Episode.Language)
+            ? "en"
+            : podcastEpisode.Episode.Language.Trim();
         try
         {
             if (embedCardRequest != null)
@@ -28,13 +31,13 @@ public class BlueskyPoster(
                 logger.LogInformation(
                     "Non-Null {nameofEmbedCardRequest} for episode with id '{podcastEpisodeId}'.",
                     nameof(EmbedCardRequest), podcastEpisode.Episode.Id);
-                await blueSkyClient.Post(embedPost.Text, embedCardRequest);
+                await blueSkyClient.Post(embedPost.Text, embedCardRequest, language);
             }
             else
             {
                 logger.LogError("Null {nameofEmbedCardRequest} for episode with id '{podcastEpisodeId}'.",
                     nameof(EmbedCardRequest), podcastEpisode.Episode.Id);
-                await blueSkyClient.Post($"{embedPost.Text}{Environment.NewLine}{embedPost.Url}");
+                await blueSkyClient.Post($"{embedPost.Text}{Environment.NewLine}{embedPost.Url}", language);
             }
 
             sendStatus = BlueskySendStatus.Success;

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Client/EmbedCardBlueskyClient.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Client/EmbedCardBlueskyClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http.Headers;
 using System.Security.Authentication;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -12,6 +13,13 @@ namespace RedditPodcastPoster.Bluesky.Client;
 
 public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
 {
+    // X.Bluesky's FacetBuilder mention-regex (@\w+(\.\w+)*) does not permit dashes, so handles such as
+    // @morningjoe-msnow.bsky.social are truncated and then fail DID resolution. This regex follows the
+    // atproto handle spec: dot-separated segments of alphanumerics/dashes that must not start/end with a dash.
+    private static readonly Regex MentionRegex = new(
+        @"(?<![\w@.-])@[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)+",
+        RegexOptions.Compiled);
+
     private readonly IAuthorizationClient _authorizationClient;
     private readonly BlueskyClient _blueskyClient;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -61,9 +69,18 @@ public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
         await Post(session, post);
     }
 
-    public Task Post(string text)
+    public async Task Post(string text)
     {
-        return _blueskyClient.Post(text);
+        var session = await _authorizationClient.GetSession();
+
+        if (session == null)
+        {
+            throw new AuthenticationException();
+        }
+
+        var (_, post) = await CreatePostAndFacets(text);
+
+        await Post(session, post);
     }
 
     public Task Post(string text, Uri uri)
@@ -92,19 +109,40 @@ public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
         var now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
         var facetBuilder = new FacetBuilder();
 
-        var facets = facetBuilder.GetFacets(text);
+        var facets = new List<Facet>();
 
-        foreach (var facet in facets)
+        foreach (var match in facetBuilder.GetFeatureLinkMatches(text))
         {
-            foreach (var facetFeature in facet.Features)
-            {
-                if (facetFeature is FacetFeatureMention facetFeatureMention)
-                {
-                    var resolveDid = await _mentionResolver.ResolveMention(facetFeatureMention.Did);
+            facets.Add(facetBuilder.CreateFacet(
+                GetUtf8BytePosition(text, match.Index),
+                GetUtf8BytePosition(text, match.Index + match.Length),
+                new FacetFeatureLink {Uri = new Uri(match.Value)}));
+        }
 
-                    facetFeatureMention.ResolveDid(resolveDid);
-                }
+        foreach (var match in facetBuilder.GetFeatureTagMatches(text))
+        {
+            facets.Add(facetBuilder.CreateFacet(
+                GetUtf8BytePosition(text, match.Index),
+                GetUtf8BytePosition(text, match.Index + match.Length),
+                new FacetFeatureTag {Tag = match.Value.Replace("#", string.Empty)}));
+        }
+
+        foreach (Match match in MentionRegex.Matches(text))
+        {
+            var resolvedDid = await _mentionResolver.ResolveMention(match.Value);
+
+            if (string.IsNullOrWhiteSpace(resolvedDid))
+            {
+                _logger.LogWarning(
+                    "Unable to resolve bluesky-mention '{mention}' to a DID. Posting without a mention-facet for it.",
+                    match.Value);
+                continue;
             }
+
+            facets.Add(facetBuilder.CreateFacet(
+                GetUtf8BytePosition(text, match.Index),
+                GetUtf8BytePosition(text, match.Index + match.Length),
+                new FacetFeatureMention {Did = resolvedDid}));
         }
 
         // Required fields for the post
@@ -114,9 +152,14 @@ public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
             Text = text,
             CreatedAt = now,
             Langs = _languages.ToList(),
-            Facets = facets.ToList()
+            Facets = facets
         };
         return (facets, post);
+    }
+
+    private static int GetUtf8BytePosition(string text, int index)
+    {
+        return Encoding.UTF8.GetByteCount(text[..index]);
     }
 
     private async Task Post(Session session, Post post)

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Client/EmbedCardBlueskyClient.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Client/EmbedCardBlueskyClient.cs
@@ -48,7 +48,17 @@ public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
         _authorizationClient = new AuthorizationClient(httpClientFactory, identifier, password, reuseSession, uri);
     }
 
-    public async Task Post(string text, EmbedCardRequest embedCard)
+    public Task Post(string text, EmbedCardRequest embedCard)
+    {
+        return Post(text, embedCard, _languages);
+    }
+
+    public Task Post(string text, EmbedCardRequest embedCard, string language)
+    {
+        return Post(text, embedCard, [language]);
+    }
+
+    private async Task Post(string text, EmbedCardRequest embedCard, IEnumerable<string> languages)
     {
         var session = await _authorizationClient.GetSession();
 
@@ -57,7 +67,7 @@ public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
             throw new AuthenticationException();
         }
 
-        var (_, post) = await CreatePostAndFacets(text);
+        var (_, post) = await CreatePostAndFacets(text, languages);
 
         var embedCardBuilder = new EmbedCardBuilder(_httpClientFactory, session, _logger);
 
@@ -69,7 +79,17 @@ public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
         await Post(session, post);
     }
 
-    public async Task Post(string text)
+    public Task Post(string text)
+    {
+        return Post(text, _languages);
+    }
+
+    public Task Post(string text, string language)
+    {
+        return Post(text, [language]);
+    }
+
+    private async Task Post(string text, IEnumerable<string> languages)
     {
         var session = await _authorizationClient.GetSession();
 
@@ -78,7 +98,7 @@ public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
             throw new AuthenticationException();
         }
 
-        var (_, post) = await CreatePostAndFacets(text);
+        var (_, post) = await CreatePostAndFacets(text, languages);
 
         await Post(session, post);
     }
@@ -103,7 +123,9 @@ public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
         return _blueskyClient.Post(text, url, images);
     }
 
-    private async Task<(IReadOnlyCollection<Facet> facets, Post post)> CreatePostAndFacets(string text)
+    private async Task<(IReadOnlyCollection<Facet> facets, Post post)> CreatePostAndFacets(
+        string text,
+        IEnumerable<string> languages)
     {
         // Fetch the current time in ISO 8601 format, with "Z" to denote UTC
         var now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
@@ -151,7 +173,7 @@ public class EmbedCardBlueskyClient : IEmbedCardBlueskyClient
             Type = "app.bsky.feed.post",
             Text = text,
             CreatedAt = now,
-            Langs = _languages.ToList(),
+            Langs = languages.ToList(),
             Facets = facets
         };
         return (facets, post);

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Client/IEmbedCardBlueskyClient.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Client/IEmbedCardBlueskyClient.cs
@@ -5,4 +5,6 @@ namespace RedditPodcastPoster.Bluesky.Client;
 public interface IEmbedCardBlueskyClient : IBlueskyClient
 {
     Task Post(string text, EmbedCardRequest embedCard);
+    Task Post(string text, EmbedCardRequest embedCard, string language);
+    Task Post(string text, string language);
 }


### PR DESCRIPTION
## Summary

Fix Bluesky post failures when a mentioned handle contains a dash, such as `@morningjoe-msnow.bsky.social`. Also set each episode post's `langs` metadata from `Episode.Language`, defaulting to `en` when the value is missing or blank.

## Changes

- Detect atproto handles with dash-aware mention matching
- Build mention facets with UTF-8 byte offsets and resolved DIDs
- Skip unresolved mention facets with a warning instead of failing the whole post
- Route plain-text posts through the same corrected facet builder
- Set Bluesky `langs` from the episode language for both embed-card and fallback posts
- Default missing or whitespace-only episode languages to `en`

## Test Plan

- [x] Build `RedditPodcastPoster.Bluesky.csproj`
- [x] Post a live embed-card test mentioning `@morningjoe-msnow.bsky.social`
- [x] Verify the stored facet resolves to `did:plc:46wlih636qari72j67turcia`
- [x] Delete the test Bluesky post
- [x] Verify both episode-posting paths pass the selected language into post serialization