### PR TITLE
feat(search): slim indexed episode documents

### DIFF
--- a/.cursor/rules/language-list-sync.mdc
+++ b/.cursor/rules/language-list-sync.mdc
@@ -1,0 +1,20 @@
+---
+description: Require a synchronized website build whenever the authoritative backend language list changes
+globs: "Class-Libraries/RedditPodcastPoster.ContentPublisher/LanguagesPublisher.cs"
+alwaysApply: false
+---
+
+# Backend and website language-list sync
+
+`Class-Libraries/RedditPodcastPoster.ContentPublisher/LanguagesPublisher.cs` (`LanguageNames`) is authoritative. `Console-Apps/R2Publisher` publishes it to the R2 object `languages`, which the API Worker exposes to curators at `GET /languages`.
+
+The public website does **not** read that endpoint at runtime. Its language lookup is baked into the webapp at sibling repository `website/cultpodcasts/src/app/languages.ts` and used by `website/cultpodcasts/src/app/subject-language-filter.ts`.
+
+Whenever `LanguageNames` adds, removes, or renames a language:
+
+- [ ] Update `website/cultpodcasts/src/app/languages.ts` with matching codes, English names, and local/endonym names.
+- [ ] Keep `website/cultpodcasts/src/app/subject-language-filter.spec.ts` green.
+- [ ] Bump the webapp version in `website/cultpodcasts/package.json` and `website/cultpodcasts/package-lock.json`.
+- [ ] Merge the website change to its production branch and verify the Cloudflare Pages Git-integration build deploys successfully.
+
+Publishing the R2 object alone is insufficient. Missing the website update leaves new languages displayed as raw ISO-code fallbacks on public subject pages.

--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Extensions/PodcastEpisodeExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Extensions/PodcastEpisodeExtensions.cs
@@ -9,34 +9,64 @@ public static class PodcastEpisodeExtensions
     {
         var image = podcastEpisode.Episode.Images?.YouTube ?? podcastEpisode.Episode.Images?.Spotify ??
             podcastEpisode.Episode.Images?.Apple ?? podcastEpisode.Episode.Images?.Other;
+        var youtubeImageVariant = GetYoutubeImageVariant(image, podcastEpisode.Episode.YouTubeId);
+        if (youtubeImageVariant != null)
+        {
+            image = null;
+        }
+
         var podcastEpisodeDescription = podcastEpisode.Episode.Description.Trim();
+        var duration = podcastEpisode.Episode.Length.ToString();
         return new EpisodeSearchRecord
         {
-            Apple = podcastEpisode.Episode.Urls.Apple != null
-                ? podcastEpisode.Episode.Urls.Apple.ToString()
-                : string.Empty,
+            AppleId = podcastEpisode.Episode.AppleId?.ToString(),
             BBC = podcastEpisode.Episode.Urls.BBC != null ? podcastEpisode.Episode.Urls.BBC.ToString() : string.Empty,
-            Duration = podcastEpisode.Episode.Length.ToString(),
+            Duration = duration.EndsWith(".0000000", StringComparison.Ordinal) ? duration[..^8] : duration,
             EpisodeDescription = podcastEpisodeDescription.Substring(0,
                 Math.Min(Constants.DescriptionSize, podcastEpisodeDescription.Length)),
             EpisodeSearchTerms = podcastEpisode.Episode.SearchTerms ?? string.Empty,
             EpisodeTitle = podcastEpisode.Episode.Title.Trim(),
-            Explicit = podcastEpisode.Episode.Explicit,
             Id = podcastEpisode.Episode.Id.ToString(),
-            Image = image != null ? image.ToString() : string.Empty,
+            Image = image?.ToString(),
             InternetArchive = podcastEpisode.Episode.Urls.InternetArchive != null
                 ? podcastEpisode.Episode.Urls.InternetArchive.ToString()
                 : string.Empty,
+            Lang = podcastEpisode.Episode.Language ?? podcastEpisode.Podcast.Language,
+            PodcastAppleId = podcastEpisode.Podcast.AppleId?.ToString(),
             PodcastName = podcastEpisode.Podcast.Name.Trim(),
             PodcastSearchTerms = podcastEpisode.Podcast.SearchTerms ?? string.Empty,
             Release = podcastEpisode.Episode.Release,
-            Spotify = podcastEpisode.Episode.Urls.Spotify != null
-                ? podcastEpisode.Episode.Urls.Spotify.ToString()
-                : string.Empty,
+            SpotifyId = NullIfWhiteSpace(podcastEpisode.Episode.SpotifyId),
             Subjects = podcastEpisode.Episode.Subjects.ToArray(),
-            Youtube = podcastEpisode.Episode.Urls.YouTube != null
-                ? podcastEpisode.Episode.Urls.YouTube.ToString()
-                : string.Empty
+            YoutubeId = NullIfWhiteSpace(podcastEpisode.Episode.YouTubeId),
+            YoutubeImageVariant = youtubeImageVariant
         };
     }
+
+    private static string? GetYoutubeImageVariant(Uri? image, string youtubeId)
+    {
+        if (image == null ||
+            string.IsNullOrWhiteSpace(youtubeId) ||
+            !image.Host.Equals("i.ytimg.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var expectedPrefix = $"/vi/{youtubeId}/";
+        if (!image.AbsolutePath.StartsWith(expectedPrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return image.AbsolutePath[expectedPrefix.Length..] switch
+        {
+            "maxresdefault.jpg" => "maxres",
+            "sddefault.jpg" => "sd",
+            "hqdefault.jpg" => "hq",
+            _ => null
+        };
+    }
+
+    private static string? NullIfWhiteSpace(string value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
 }

--- a/Class-Libraries/RedditPodcastPoster.Search/EpisodeSearchRecord.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/EpisodeSearchRecord.cs
@@ -26,17 +26,17 @@ public class EpisodeSearchRecord
     [SimpleField(IsSortable = false, IsFacetable = false, IsFilterable = false)]
     public required string Duration { get; set; }
 
-    [SimpleField(IsFilterable = false, IsSortable = false, IsFacetable = false)]
-    public required bool Explicit { get; set; }
+    [SimpleField(IsSortable = false, IsFilterable = false, IsFacetable = false)]
+    public string? SpotifyId { get; set; }
 
     [SimpleField(IsSortable = false, IsFilterable = false, IsFacetable = false)]
-    public required string Spotify { get; set; }
+    public string? AppleId { get; set; }
 
     [SimpleField(IsSortable = false, IsFilterable = false, IsFacetable = false)]
-    public required string Apple { get; set; }
+    public string? PodcastAppleId { get; set; }
 
     [SimpleField(IsSortable = false, IsFilterable = false, IsFacetable = false)]
-    public required string Youtube { get; set; }
+    public string? YoutubeId { get; set; }
 
     [SimpleField(IsSortable = false, IsFilterable = false, IsFacetable = false)]
     public required string BBC { get; set; }
@@ -56,8 +56,11 @@ public class EpisodeSearchRecord
     public required string EpisodeSearchTerms { get; set; }
 
     [SimpleField(IsSortable = false, IsFacetable = false, IsFilterable = false)]
-    public required string Image { get; set; }
+    public string? Image { get; set; }
 
-    [SimpleField(IsFilterable = true, IsFacetable = true)]
+    [SimpleField(IsSortable = false, IsFacetable = false, IsFilterable = false)]
+    public string? YoutubeImageVariant { get; set; }
+
+    [SimpleField(IsFilterable = true, IsFacetable = true, IsHidden = true)]
     public string? Lang { get; set; }
 }

--- a/Class-Libraries/RedditPodcastPoster.Search/SearchDocument.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/SearchDocument.cs
@@ -26,17 +26,17 @@ public class SearchDocument
     [JsonPropertyName("release")]
     public DateTime? Release { get; set; }
 
-    [JsonPropertyName("explicit")]
-    public bool? Explicit { get; set; }
+    [JsonPropertyName("spotifyId")]
+    public string? SpotifyId { get; set; }
 
-    [JsonPropertyName("apple")]
-    public Uri? Apple { get; set; }
+    [JsonPropertyName("youtubeId")]
+    public string? YoutubeId { get; set; }
 
-    [JsonPropertyName("youtube")]
-    public Uri? YouTube { get; set; }
+    [JsonPropertyName("appleId")]
+    public string? AppleId { get; set; }
 
-    [JsonPropertyName("spotify")]
-    public Uri? Spotify { get; set; }
+    [JsonPropertyName("podcastAppleId")]
+    public string? PodcastAppleId { get; set; }
 
     public Episode ToEpisodeModel()
     {
@@ -49,13 +49,9 @@ public class SearchDocument
             Subjects = Subjects.ToList(),
             Length = length,
             Release = Release ?? DateTime.MinValue,
-            Urls = new ServiceUrls
-            {
-                Apple = Apple,
-                Spotify = Spotify,
-                YouTube = YouTube
-            },
-            Explicit = Explicit ?? false
+            SpotifyId = SpotifyId ?? string.Empty,
+            YouTubeId = YoutubeId ?? string.Empty,
+            AppleId = long.TryParse(AppleId, out var appleId) ? appleId : null
         };
     }
 }

--- a/Cloud/Unit-Tests/Indexer.Tests/Indexer.Tests.csproj
+++ b/Cloud/Unit-Tests/Indexer.Tests/Indexer.Tests.csproj
@@ -24,6 +24,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Indexer\Indexer.csproj" />
+    <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.EntitySearchIndexer\RedditPodcastPoster.EntitySearchIndexer.csproj" />
+    <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.Search\RedditPodcastPoster.Search.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Cloud/Unit-Tests/Indexer.Tests/PodcastEpisodeExtensionsTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/PodcastEpisodeExtensionsTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using Azure.Core.Serialization;
+using Azure.Search.Documents.Indexes;
+using FluentAssertions;
+using RedditPodcastPoster.EntitySearchIndexer.Extensions;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Search;
+using Xunit;
+
+namespace Indexer.Tests;
+
+public class PodcastEpisodeExtensionsTests
+{
+    [Fact]
+    public void Maps_compact_service_ids_language_and_derivable_youtube_image()
+    {
+        var episode = CreateEpisode();
+        episode.Images = new EpisodeImages
+        {
+            YouTube = new Uri($"https://i.ytimg.com/vi/{episode.YouTubeId}/maxresdefault.jpg"),
+            Spotify = new Uri("https://i.scdn.co/image/opaque")
+        };
+        episode.Language = null;
+        var podcast = new Podcast
+        {
+            Name = " Podcast ",
+            AppleId = 1234567890,
+            Language = "es",
+            SearchTerms = "podcast terms"
+        };
+
+        var result = new PodcastEpisode(podcast, episode).ToEpisodeSearchRecord();
+
+        result.SpotifyId.Should().Be("spotify-episode-id");
+        result.YoutubeId.Should().Be("youtube-id");
+        result.AppleId.Should().Be("987654321");
+        result.PodcastAppleId.Should().Be("1234567890");
+        result.Lang.Should().Be("es");
+        result.Image.Should().BeNull();
+        result.YoutubeImageVariant.Should().Be("maxres");
+        result.Duration.Should().Be("00:02:03");
+    }
+
+    [Fact]
+    public void Keeps_opaque_image_and_omits_empty_ids()
+    {
+        var episode = CreateEpisode();
+        episode.SpotifyId = " ";
+        episode.YouTubeId = string.Empty;
+        episode.AppleId = null;
+        episode.Images = new EpisodeImages
+        {
+            Spotify = new Uri("https://i.scdn.co/image/opaque")
+        };
+
+        var result = new PodcastEpisode(new Podcast { Name = "Podcast" }, episode)
+            .ToEpisodeSearchRecord();
+
+        result.SpotifyId.Should().BeNull();
+        result.YoutubeId.Should().BeNull();
+        result.AppleId.Should().BeNull();
+        result.Image.Should().Be("https://i.scdn.co/image/opaque");
+        result.YoutubeImageVariant.Should().BeNull();
+    }
+
+    [Fact]
+    public void Slim_schema_drops_explicit_and_hides_language()
+    {
+        var fields = new FieldBuilder
+        {
+            Serializer = new JsonObjectSerializer(new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            })
+        }.Build(typeof(EpisodeSearchRecord));
+
+        fields.Should().NotContain(field => field.Name == "explicit");
+        fields.Should().Contain(field => field.Name == "spotifyId");
+        fields.Should().Contain(field => field.Name == "youtubeId");
+        fields.Should().Contain(field => field.Name == "appleId");
+        fields.Should().Contain(field => field.Name == "podcastAppleId");
+        fields.Should().Contain(field => field.Name == "youtubeImageVariant");
+
+        var language = fields.Single(field => field.Name == "lang");
+        language.IsFilterable.Should().BeTrue();
+        language.IsFacetable.Should().BeTrue();
+        language.IsHidden.Should().BeTrue();
+    }
+
+    private static Episode CreateEpisode() => new()
+    {
+        Id = Guid.NewGuid(),
+        Title = " Episode ",
+        Description = "Description",
+        Release = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc),
+        Length = TimeSpan.FromSeconds(123),
+        SpotifyId = "spotify-episode-id",
+        YouTubeId = "youtube-id",
+        AppleId = 987654321,
+        Subjects = ["subject"],
+        SearchTerms = "episode terms"
+    };
+}

--- a/Console-Apps/CreateSearchIndex/CreateSearchIndexProcessor.cs
+++ b/Console-Apps/CreateSearchIndex/CreateSearchIndexProcessor.cs
@@ -384,17 +384,33 @@ public partial class CreateSearchIndexProcessor(
                             e.podcastName as podcastName,
                             SUBSTRING (e.description, 0, {Constants.DescriptionSize}) as episodeDescription,
                             e.release,
-                            e.duration,
-                            e.explicit,
-                            e.urls.spotify,
-                            e.urls.apple,
-                            e.urls.youtube,
+                            IIF(ENDSWITH(e.duration, "".0000000""), SUBSTRING(e.duration, 0, LENGTH(e.duration) - 8), e.duration) as duration,
+                            IIF(IS_DEFINED(e.spotifyId) AND e.spotifyId != """", e.spotifyId, null) as spotifyId,
+                            IIF(IS_DEFINED(e.appleId), ToString(e.appleId), null) as appleId,
+                            IIF(IS_DEFINED(e.urls.apple) AND CONTAINS(e.urls.apple, ""/id"") AND CONTAINS(e.urls.apple, ""?i=""),
+                                SUBSTRING(e.urls.apple,
+                                    INDEX_OF(e.urls.apple, ""/id"") + 3,
+                                    INDEX_OF(e.urls.apple, ""?i="") - INDEX_OF(e.urls.apple, ""/id"") - 3),
+                                null) as podcastAppleId,
+                            IIF(IS_DEFINED(e.youTubeId) AND e.youTubeId != """", e.youTubeId, null) as youtubeId,
                             e.urls.bbc,
                             e.urls.internetArchive,
                             e.subjects as subjects,
                             e.podcastSearchTerms as podcastSearchTerms,
                             e.searchTerms as episodeSearchTerms,
-                            e.images.youtube ?? e.images.spotify ?? e.images.apple ?? e.images.other as image,
+                            IIF(IS_DEFINED(e.images.youtube)
+                                    AND STARTSWITH(e.images.youtube, CONCAT(""https://i.ytimg.com/vi/"", e.youTubeId, ""/""))
+                                    AND (ENDSWITH(e.images.youtube, ""/maxresdefault.jpg"")
+                                        OR ENDSWITH(e.images.youtube, ""/sddefault.jpg"")
+                                        OR ENDSWITH(e.images.youtube, ""/hqdefault.jpg"")),
+                                null,
+                                e.images.youtube ?? e.images.spotify ?? e.images.apple ?? e.images.other) as image,
+                            IIF(IS_DEFINED(e.images.youtube)
+                                    AND STARTSWITH(e.images.youtube, CONCAT(""https://i.ytimg.com/vi/"", e.youTubeId, ""/"")),
+                                IIF(ENDSWITH(e.images.youtube, ""/maxresdefault.jpg""), ""maxres"",
+                                    IIF(ENDSWITH(e.images.youtube, ""/sddefault.jpg""), ""sd"",
+                                        IIF(ENDSWITH(e.images.youtube, ""/hqdefault.jpg""), ""hq"", null))),
+                                null) as youtubeImageVariant,
                             e.lang ?? e.podcastLanguage as lang,
                             e._ts
                             FROM episodes e

--- a/docs/search-index-slimming-plan.md
+++ b/docs/search-index-slimming-plan.md
@@ -1,0 +1,663 @@
+# Search index slimming plan
+
+Planning deliverable only. No production writes, deploys, or source-code changes beyond this document.
+
+Related prior notes (descoped then revived): `docs/migration/concrete-migration-plan-and-cutover-strategy.md` (`CompactSearchRecord`), `docs/migration/implementation-checklist-mapped-to-repo.md` Phase 4, `docs/migration/sequenced-pr-plan.md` PR2/PR3.
+
+---
+
+## 1. Hard scope boundary
+
+**In scope — only Azure Search document / search-result JSON shapes**
+
+| Layer | Artifact |
+|-------|----------|
+| Index schema + push model | `Class-Libraries/RedditPodcastPoster.Search/EpisodeSearchRecord.cs` |
+| Cosmos → Search projection | `Console-Apps/CreateSearchIndex/CreateSearchIndexProcessor.cs` (`CreateDataSource` SELECT aliases) |
+| Incremental document upload | `Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Extensions/PodcastEpisodeExtensions.cs` (`ToEpisodeSearchRecord`) |
+| Description length constant | `Class-Libraries/RedditPodcastPoster.Search/Constants.cs` (`DescriptionSize = 230`) |
+| Public search HTTP | Cloudflare Worker `POST /search` → Azure Search docs API (`Api/src/search.ts`, `c.env.apihost`) |
+| Worker search consumers | `Api/src/getPageDetails.ts` (OData filter + field reads on search hit), leech stub in `search.ts`, search-log field sniffing in `searchLogCollector.ts` |
+| Angular search contracts | `SearchResult` / shared search-shaped fields on `HomepageEpisode` **only where fed by `/search`**, OData query builders, search templates |
+
+**Explicitly out of scope — do not rename or reshape**
+
+| Contract | Why |
+|----------|-----|
+| Cosmos `Episode` / `Podcast` documents | Canonical store; keep `urls.*`, `spotifyId`, `youTubeId`, `appleId`, etc. |
+| Domain models / non-search API DTOs | Episode CRUD, podcast APIs, discovery, people, social posting |
+| Homepage publish JSON (`HomepagePublisher` / R2 homepage) | Separate pipeline; keep human-readable keys |
+| Discovery result JSON | Not Azure Search |
+| Bookmarks / curator episode lists from Functions API | Not Azure Search documents |
+| KV shortener metadata shape (`ShortnerRecord`) | Not the search index (Worker may still *read* search hits as a fallback in `getPageDetails`) |
+
+Canonical platform URLs remain on Cosmos/domain/non-search APIs. URL omission and client/server reconstruction apply **only** to search documents and search-result JSON.
+
+---
+
+## 2. Current search document shape
+
+Schema source: `EpisodeSearchRecord` (FieldBuilder + camelCase). Datasource SQL projects the same camelCase names. Push path: `ToEpisodeSearchRecord`.
+
+| Field (JSON) | .NET type | Searchable | Filterable | Sortable | Facetable | Retrievable | Notes |
+|--------------|-----------|------------|------------|----------|-----------|-------------|-------|
+| `id` | string (key) | | ✓ | | | ✓ | Episode GUID |
+| `episodeTitle` | string | ✓ (en.lucene) | | | | ✓ | |
+| `podcastName` | string | ✓ | ✓ | | ✓ | ✓ | Facet + filter |
+| `episodeDescription` | string | ✓ | | | | ✓ | Truncated to **230** chars |
+| `release` | DateTimeOffset | | | ✓ | | ✓ | `orderby` |
+| `duration` | string | | | | | ✓ | `TimeSpan.ToString()` |
+| `explicit` | bool | | | | | ✓ | **Confirmed removal:** no search consumer reads it |
+| `spotify` | string | | | | | ✓ | Full URL or `""` |
+| `apple` | string | | | | | ✓ | Full URL or `""` |
+| `youtube` | string | | | | | ✓ | Full URL or `""` |
+| `bbc` | string | | | | | ✓ | Full URL or `""` — **not ID-derivable** |
+| `internetArchive` | string | | | | | ✓ | Full URL or `""` — **not ID-derivable** |
+| `subjects` | string[] | ✓ | ✓ | | ✓ | ✓ | Facet + filter |
+| `podcastSearchTerms` | string | ✓ | | | | **hidden** | Inverted index only |
+| `episodeSearchTerms` | string | ✓ | | | | **hidden** | Inverted index only |
+| `image` | string | | | | | ✓ | Prefer YT → Spotify → Apple → other |
+| `lang` | string? | | ✓ | | ✓ | ✓ | Subject page defaults to `lang eq null` (= English/unset; see §3D) |
+
+No vector fields today.
+
+**Description truncation:** `Constants.DescriptionSize = 230` in both datasource `SUBSTRING(..., 0, 230)` and `ToEpisodeSearchRecord`.
+
+**Config:** `searchIndex:IndexName` = `cultpodcasts`, `IndexerName` = `cultpodcasts-indexer` (bicep `Infrastructure/functions.bicep`). Worker `apihost` points at the Azure Search **docs search URL for that index**.
+
+---
+
+## 3. What actually counts toward the 50 MB quota
+
+### 3.1 Authoritative behavior (Azure AI Search)
+
+Sources:
+
+- [Search indexes — physical structure and size](https://learn.microsoft.com/azure/search/search-what-is-an-index#physical-structure-and-size)
+- [Create an index — field attributes](https://learn.microsoft.com/azure/search/search-how-to-create-search-index#configure-field-definitions)
+- [Estimate capacity](https://learn.microsoft.com/azure/search/search-capacity-planning)
+- [Troubleshoot storage metrics](https://learn.microsoft.com/azure/search/troubleshoot-storage-metrics)
+- [Serverless cost optimization — schema tips](https://learn.microsoft.com/azure/search/serverless-cost-optimization#reduce-compute-costs-through-optimization)
+- [Performance tips — attributes and index size](https://learn.microsoft.com/azure/search/search-performance-tips#index-size-and-schema)
+
+Findings:
+
+1. **Reported `storageSize` is the on-disk footprint of internal index structures**, not the byte length of HTTP JSON upload/query payloads. Microsoft: physical structure is an internal implementation; size depends on document quantity/composition, field attributes, and index configuration (analyzers/suggesters/vectors).
+
+2. **Pretty-printed JSON whitespace, indentation, braces, commas, and repeated property-name characters in the request body do not become persistent index storage.** They affect only network/request size and client/SDK serialization cost. After ingest, content is tokenized / copied into Lucene-like structures keyed by schema fields.
+
+3. **Shortening JSON field names is not a primary lever for `storageSize`.** Field names live mainly in the **schema** (once per index), not as repeated JSON keys on disk per document. Microsoft never lists “shorter property names” as a capacity technique. Do **not** treat “chars saved in key names × document count” as quota savings.
+
+4. **Value content and attributes drive storage:**
+   - **Searchable** → inverted index / tokenized structures (extra space).
+   - **Filterable / sortable / facetable** → additional storage for non-tokenized values (can multiply cost; MS: filtering/sorting/faceting can roughly quadruple storage vs minimal attribution).
+   - **Retrievable / stored return values** → needed to return display fields; MS notes toggling retrievable alone is nuanced (`retrievable=true` “doesn’t cause increase” in create-index docs, while serverless guidance says `retrievable=false` on filter/sort-only fields can reduce on-disk storage). For URL-only display fields, **removing or shrinking the string value** is what frees quota.
+   - **Hidden searchable fields** (`podcastSearchTerms`, `episodeSearchTerms`) still consume inverted-index space even though clients never see them.
+   - **Vectors** — none in this index.
+   - **Dual indexes** on one service **both** count toward the same service storage quota.
+
+5. **Capacity planning guidance:** there are no solid heuristics; measure by building a sample index and extrapolating ([capacity planning](https://learn.microsoft.com/azure/search/search-capacity-planning)).
+
+### 3.2 How this codebase serializes uploads
+
+| Path | Serialization |
+|------|----------------|
+| `SearchClient.MergeOrUploadDocumentsAsync` (`EpisodeSearchIndexerService`) | Azure.Search.Documents SDK; default compact JSON (**no** `WriteIndented`) |
+| Index FieldBuilder (`CreateSearchIndexProcessor.CreateIndex`) | `JsonObjectSerializer` with `PropertyNamingPolicy = CamelCase` only — **not** indented |
+| Cosmos DB indexer | Service-side projection from Cosmos SQL → Search; not our pretty-printed JSON files |
+
+Indentation is **not** enabled on search uploads. Even if it were, it would be transport-only relative to `storageSize`.
+
+### 3.3 Corrected savings model (do not use wire-JSON bytes as quota)
+
+| Change | Effect on **wire/JSON** | Effect on **reported index storage** | Priority for 50 MB |
+|--------|-------------------------|--------------------------------------|--------------------|
+| Remove/replace long URL **values** with short IDs | Large | **High** — fewer/shorter stored string values + less inverted content if ever searchable (they are not) | **Primary** |
+| Keep/tighten description at 230 (or lower) | Medium | **High** — searchable field; tokens + stored text scale with length | **Primary** (already done) |
+| Omit empty platform strings / unused fields | Small–medium | **Medium** — fewer stored values | Secondary |
+| Shorten key names (`episodeTitle` → `t`) | Small per doc on wire | **Negligible / unproven for quota** | Optional DX/contract; not the quota fix |
+| Disable unnecessary filterable/facetable/searchable | n/a | **High** if over-attributed | No removable query attributes found; `lang` facetability is required for planned subject-search facets |
+| Dual live indexes during migration | n/a | **Critical risk** — sum of both `storageSize`s | See §8 |
+
+**Rough value-side estimates (illustrative only — verify with index statistics after a sample rebuild):**
+
+Assuming ~N documents and typical presence of Spotify/YouTube/Apple URLs:
+
+| Value change | Approx. chars removed per doc (when present) | Nature |
+|--------------|-----------------------------------------------|--------|
+| Spotify URL → `spotifyId` value (~22 chars) | ~25–35 | Retrievable string shrink |
+| YouTube URL → `youtubeId` value (~11 chars) | ~30–40 | Retrievable string shrink |
+| Apple URL → `appleId` + `podcastAppleId` values | ~40–90 vs full URL | Retrievable string shrink |
+| Empty `""` URLs omitted | few bytes each | Avoid storing empties |
+
+These are **value** reductions. Multiplying by N gives an *upper-bound intuition* for stored content, not a guarantee equal to Δ`storageSize` (inverted indexes, attribute overhead, and merge lag make size nondeterministic).
+
+**Key renaming is dropped.** Keep the existing descriptive field names; shorter keys have no meaningful persistent-storage benefit and would create avoidable consumer migration work.
+
+---
+
+## 3A. Measured savings for existing episodes (LIVE DATA)
+
+Measured **2026-07-17** against the production Free-tier service `cultpodcasts` (uksouth, RG `Cultpodcasts`), index `cultpodcasts`, via read-only Search REST (`/stats`, `/docs/search`). No writes.
+
+### Current index (authoritative, Get Index Statistics)
+
+| Metric | Value |
+|--------|-------|
+| `documentCount` | **82,252** |
+| `storageSize` | **51,462,953 bytes ≈ 49.08 MB** |
+| `vectorIndexSize` | 0 |
+| Tier | **Free (~50 MB hard cap)** |
+
+**The index is essentially at the cap** (~98% of 50 MB). Slimming is not optional headroom work — it is required to keep indexing.
+
+### URL field population + stored value size (FULL scan, all 82,252 docs)
+
+| Field | Docs populated | % of docs | Total chars (≈bytes) | Avg len |
+|-------|----------------|-----------|----------------------|---------|
+| `spotify` (URL) | 29,536 | 35.9% | 1,624,810 | 55 |
+| `apple` (URL) | 28,972 | 35.2% | 3,074,899 | 106.1 |
+| `youtube` (URL) | 67,685 | 82.3% | 2,910,500 | 43 |
+| `bbc` (keep) | 268 | 0.3% | 14,979 | 55.9 |
+| `internetArchive` (keep) | 171 | 0.2% | 12,923 | 75.6 |
+
+**Gross Spotify+Apple+YouTube URL value bytes = 7,610,209 ≈ 7.26 MB (~14.8% of storageSize).**
+
+### ID components (do URLs need new fields? YES)
+
+`spotifyId` / `youTubeId` / `appleId` are **not** in the search index today (only in Cosmos). Dropping URLs therefore requires **adding** compact id fields → net savings = URL bytes − new id bytes.
+
+Component lengths (1,000-doc sample, highly consistent):
+
+| Platform | Stored URL avg | Reconstruct from | New id chars/doc | Net save/doc |
+|----------|----------------|------------------|------------------|--------------|
+| Spotify | 55 | `spotifyId` (22) | 22 | **33** |
+| YouTube | 43 | `youtubeId` (11) | 11 | **32** |
+| Apple | 106.1 | `appleId`(13) + `podcastAppleId`(9.97≈10) | 23 | **~83** |
+
+Apple URLs are 523/525 slugged, 2/525 slugless. Slug is **droppable** — `https://podcasts.apple.com/podcast/id{podcastAppleId}?i={appleId}` resolves via Apple redirect.
+
+### Net storage savings (value-content, index-wide)
+
+| Change | Gross bytes removed | New id bytes added | **Net bytes saved** | Net MB | % of storageSize |
+|--------|--------------------|--------------------|---------------------|--------|------------------|
+| Spotify URL → `spotifyId` | 1,624,810 | 649,792 | 975,018 | 0.93 | 1.9% |
+| YouTube URL → `youtubeId` | 2,910,500 | 744,535 | 2,165,965 | 2.07 | 4.2% |
+| Apple URL → `appleId`+`podcastAppleId` | 3,074,899 | 666,356 | 2,408,543 | 2.30 | 4.7% |
+| **Total** | **7,610,209** | **2,060,683** | **5,549,526** | **≈5.29 MB** | **≈10.3%** |
+
+Keep `bbc` (0.014 MB) and `internetArchive` (0.012 MB) — not id-derivable, negligible.
+
+### Confidence & method
+
+- **Value-byte measurement: HIGH.** Full scan of 100% of documents for population + total chars; id lengths from a consistent 1,000-doc sample (spotify=22, youtube=11, apple i=13/id≈10 with near-zero variance).
+- **Translation to actual `storageSize` delta: MEDIUM.** These URL fields are **retrievable-only** (not searchable/filterable/facetable), so their footprint is ≈ stored value bytes plus modest per-field encoding overhead. Azure AI Search may compress stored values and reports size nondeterministically (merge lag 24–72h), so the realized `storageSize` drop could be **somewhat less** than the raw ~5.29 MB. Treat ~5.3 MB as a solid working estimate / near-upper-bound for the retrievable-value portion.
+- **Recommended verification:** build a v2 sample/side index (see §8) and compare `storageSize` empirically before decommissioning the old index.
+
+### Bottom line for existing episodes
+
+- Removing the three derivable URL sets and adding compact ids nets **≈5.3 MB (~10% of the index)** — moving from ~49.1 MB to roughly **~43.8 MB**, buying real headroom under the 50 MB cap.
+- **YouTube is the single biggest win** (82% populated → ~2.07 MB net), then Apple (~2.30 MB), then Spotify (~0.93 MB).
+- **JSON indentation:** does **not** affect persistent index size — uploads here are compact anyway, and whitespace is transport-only ([evidence in §3.1](#31-authoritative-behavior-azure-ai-search)).
+- **Key renaming:** dropped; it has negligible persistent-storage value compared with URL/value reduction.
+
+---
+
+## 3B. Unused / removable data audit (LIVE DATA, full scan)
+
+Measured **2026-07-17**, full read-only scan of all **82,252** documents (same method as §3A). Consumer audit covers Angular webapp, Cloudflare Worker, Azure Functions API, and console tools that *query* the index.
+
+### Stored-value inventory (context)
+
+| Field | Docs populated | Total chars (≈bytes) | Avg len |
+|-------|----------------|----------------------|---------|
+| `episodeDescription` | 76,770 | **16,359,422 (~15.6 MB)** | 213.1 |
+| `episodeTitle` | 82,252 | 4,951,811 (~4.7 MB) | 60.2 |
+| `image` | 80,482 | 4,412,240 (~4.2 MB) | ~55 |
+| `subjects` | 73,640 (96,580 elems) | 1,701,362 (~1.6 MB) | — |
+| `podcastName` | 82,252 | 1,612,061 (~1.5 MB) | 19.6 |
+| `duration` | 82,252 | 824,720 (~0.79 MB) | 10 |
+| `lang` | 5,715 | 11,432 | 2 |
+| `explicit` | true on 6,476 | bool | — |
+| URLs (§3A) | — | 7,610,209 (~7.26 MB) | — |
+
+Retrievable values ≈ 37.5 MB of the 49.1 MB `storageSize`; the rest is inverted-index / filter / facet structures and overhead.
+
+### Per-field verdicts
+
+| Field | Attributes | Consumers found | Verdict | Est. saved |
+|-------|------------|-----------------|---------|-----------|
+| `id` | key, filterable | Webapp routing/links; `episode.service.ts` + Worker `getPageDetails.ts` filters `id eq`; Functions `DeleteDocumentsAsync("id", …)` (`EpisodeHandler`, `PodcastHandler`) | **Keep** | — |
+| `episodeTitle` | searchable | Search/podcast/subject templates; `episode-links.component.ts` share; Worker `getPageDetails`/`searchLogCollector`; console `AddSubjectToSearchMatches` select | **Keep** | — |
+| `podcastName` | searchable+filterable+facetable | Facets/filters in all 3 list pages; `search.in(podcastName…)`; templates; Worker logs | **Keep** (all attributes used) | — |
+| `episodeDescription` | searchable | Displayed on search/podcast/subject cards; console select | **Keep** — biggest single field (~15.6 MB, ~32% of index). Optional: cut `DescriptionSize` 230→180 ≈ **~2.4 MB** further (user decision; UX trade-off) | (optional ~2.4 MB) |
+| `release` | sortable | `orderby: release asc/desc` everywhere; card dates; Worker page details | **Keep** | — |
+| `duration` | retrievable-only | Cards display it — but every consumer strips the fractional tail (`duration.split(".")[0]`, `episode-links`, Worker `ShortnerRecord`) | **Trim value**: emit without `.0000000` suffix | **166,704 B ≈ 0.16 MB** |
+| `explicit` | retrievable-only | **No search consumer.** Webapp reads `explicit` only via non-search episode API (edit/add dialogs). `SearchResult.explicit` declared but never read; Worker `ISearchResult.explicit` optional, only leech stub writes it | **Unused — drop from index** | ~small (bool ×82k, <0.1 MB) + simpler contract |
+| `spotify`/`apple`/`youtube` | retrievable-only | Card link icons (via reconstruction post-change) | **Replace with ids** (§3A) | **≈5.29 MB net** |
+| `bbc`, `internetArchive` | retrievable-only | `episode-links` / `episode-image` on search cards | **Keep** (not derivable; 0.027 MB combined) | — |
+| `subjects` | searchable+filterable+facetable | Facets, `subjects/any(…)` filters, `app-subjects` display | **Keep** (all attributes used) | — |
+| `podcastSearchTerms` | searchable, **hidden** | Search ranking only (by design) | **Keep** — already retrievable=false, cost is inverted-index only (not measurable via docs API) | — |
+| `episodeSearchTerms` | searchable, **hidden** | Same | **Keep** | — |
+| `image` | retrievable-only | `episode-image.component` | **Derive YouTube thumbnails** (below) | **≈3.18 MB net** |
+| `lang` | filterable+facetable | Current filter: `subject-api` `lang eq null`; **faceting is confirmed planned/intended for subject searches**. Never displayed as a document property | **Keep filterable=true + facetable=true; set retrievable=false.** Facet values/counts come from `@search.facets`, so document retrieval is not required | Small stored-value saving only |
+
+### Surprise find: `image` is mostly derivable
+
+**There is exactly ONE image field in the index: `image`** (retrievable-only `Edm.String`), confirmed in the live schema, `EpisodeSearchRecord.Image`, and the Angular `HomepageEpisode.image`. It holds a single best-choice episode artwork URL selected at index time with preference YouTube → Spotify → Apple → other (`ToEpisodeSearchRecord` / datasource `e.images.youtube ?? e.images.spotify ?? e.images.apple ?? e.images.other`). There are **no** hidden/duplicate podcast-artwork, thumbnail, or social-image fields.
+
+Full scan of `image` vs `youtube`:
+
+- **64,412 / 80,482 images (80%)** are exactly `https://i.ytimg.com/vi/{videoId}/{variant}.jpg`
+- **64,406 (99.99%)** of those have `{videoId}` equal to the doc's own YouTube id → derivable from `youtubeId` alone
+- Variants: `maxresdefault` 53,882 · `sddefault` 7,098 · `hqdefault` 3,432
+- YT-thumb chars stored: **3,307,304 (~3.15 MB)**; non-YT images: 16,070 docs, 1,104,936 chars (keep as URL)
+
+Host/origin breakdown (rescanned later same day — live index drifts ~1% between scans as hourly indexing runs):
+
+| Host | Docs | Chars | Origin |
+|------|------|-------|--------|
+| `i.ytimg.com` | 66,381 | 3,413,113 | YouTube thumbnail — **derivable from `youtubeId`** |
+| `i.scdn.co` | 12,708 | 813,312 | Spotify CDN — opaque hash, **not derivable** from `spotifyId` |
+| `is1-ssl.mzstatic.com` | 641 | 93,101 | Apple artwork — not derivable |
+| `archive.org` | 101 | 18,154 | IA — keep |
+| `ichef.bbci.co.uk` | 91 | 5,155 | BBC — keep |
+
+Proposal: keep `image` only for non-YT images; for YT thumbs store a small `youtubeImageVariant` value (`maxresdefault` / `sddefault` / `hqdefault`, or a compact enum value) or adopt client-side fallback (`maxresdefault` → `hqdefault`). Net saving remains approximately **3.18 MB**. The webapp already inspects `i.ytimg.com` hosts for crop handling (`episode-image.component.ts`), so the reconstruction pattern is established.
+
+### Audit totals (beyond §3A's ~5.29 MB URL savings)
+
+| Item | Net saved |
+|------|-----------|
+| YT-thumbnail `image` derivation | **~3.18 MB** |
+| `duration` fractional-tail trim | **~0.16 MB** |
+| Drop `explicit` | <0.1 MB |
+| `lang` retrievable=false (filterable+facetable retained) | Small; likely KB-scale |
+| **Audit total** | **≈3.4 MB** |
+| **Combined with URL removal (§3A)** | **≈8.7 MB ≈ 17–18% of the 49.1 MB index → ~40.4 MB** |
+| Optional description 230→180 | +~2.4 MB more (~38 MB total) |
+
+---
+
+## 3C. Attribute-level audit (live schema × every consumer)
+
+Live schema flags pulled read-only from `GET /indexes/cultpodcasts` (2026-07-17). Consumers cross-referenced: Angular (`search-api`, `podcast-api`, `subject-api`, `episode.service.ts`), Cloudflare Worker (`search.ts`, `getPageDetails.ts`, `searchLogCollector.ts`), Azure Functions API (`EpisodeHandler`/`PodcastHandler` — write/delete only, no queries), console tools (`AddSubjectToSearchMatches`).
+
+Observed query surface (exhaustive):
+
+- **$orderby:** `release asc` / `release desc` only.
+- **Facets currently observed:** `podcastName,count:…` and `subjects,count:…`. **Planned/intended:** `lang` facets for subject searches.
+- **$filter:** `podcastName eq` · `search.in(podcastName,…)` · `subjects/any(s: s eq …)` · `subjects/any(s: search.in(…))` · `id eq` · `lang eq null`.
+- **search:** simple queryType, no `searchFields` restriction → all searchable fields participate.
+- No suggesters, no scoring profiles, no vector fields (index config confirms).
+
+| Field | searchable | filterable | sortable | facetable | retrievable | Verdict |
+|-------|-----------|-----------|----------|-----------|-------------|---------|
+| `id` | — | ✓ **used** (`id eq`: episode.service, Worker getPageDetails) | — | — | ✓ used (routing/links, delete-by-key) | Keep as is |
+| `episodeTitle` | ✓ **used** (free-text) | — | — | — | ✓ used (cards, share, Worker) | Keep as is |
+| `podcastName` | ✓ used | ✓ **used** (eq + search.in) | — | ✓ **used** (facet) | ✓ used | Keep as is — fully utilised |
+| `episodeDescription` | ✓ used | — | — | — | ✓ used (cards) | Keep; only lever is shorter text (inverted index scales with the 15.6 MB of text, not with attributes) |
+| `release` | — | — | ✓ **used** (every orderby) | — | ✓ used (card dates) | Keep as is |
+| `duration` | — | — | — | — | ✓ used | Keep; trim value tail (§3B) |
+| `explicit` | — | — | — | — | ✗ **never read** | **Drop field** (§3B) |
+| `spotify`/`apple`/`youtube` | — | — | — | — | ✓ (via reconstruction) | **Replace with ids** (§3A) |
+| `bbc`, `internetArchive` | — | — | — | — | ✓ used | Keep |
+| `subjects` | ✓ used | ✓ **used** (`subjects/any`) | — | ✓ **used** (facet) | ✓ used (chips) | Keep as is — fully utilised |
+| `podcastSearchTerms` | ✓ used (ranking) | — | — | — | already `false` | Keep as is |
+| `episodeSearchTerms` | ✓ used (ranking) | — | — | — | already `false` | Keep as is |
+| `image` | — | — | — | — | ✓ used | Derive YT thumbs (§3B) |
+| `lang` | — | ✓ **used** (`lang eq null`) | — | ✓ **required** (planned subject-search facet) | ✗ **never displayed from a document** | **Keep filterable=true + facetable=true; set retrievable=false** |
+
+### Attribute changes available
+
+No filterable, sortable, facetable, or searchable flag should be removed. The only attribute-level change is **`lang.retrievable=false`**: it must remain filterable and facetable, but facet values/counts are returned in `@search.facets` independently of document retrieval. Field-level changes remain: drop `explicit`, replace derivable service URLs with IDs, derive YouTube thumbnails, and trim the duration tail.
+
+Notable non-findings (schema is already tight):
+
+- No field is sortable except `release`, which every page orderby uses.
+- No facetable flags beyond `podcastName`, `subjects` (currently used) and `lang` (required for planned subject-search facets).
+- All searchable fields are intended free-text targets (standard `en.lucene`, no ngram/edgeNgram analyzers, no suggesters — so no analyzer bloat to remove).
+- The .NET SDK FieldBuilder defaults meant unset attributes are already `false`, so there is no accidental "everything filterable" REST-default bloat.
+
+### Honest quantification caveat
+
+Disabling `facetable`/`filterable` would remove internal forward/facet structures, but none can be disabled because all are current or confirmed intended requirements. Their size is **not observable via the docs API**. Setting `lang.retrievable=false` may save its small stored-value representation (2-char codes on 5,715 / 82,252 docs), likely only KB-scale; retain its facet structures. The material, quantified savings remain URLs (~5.29 MB net, §3A), YouTube-thumbnail derivation (~3.18 MB, §3B), duration tail (~0.16 MB), and optionally shorter descriptions (~2.4 MB per 50-char reduction). Key renaming is **dropped** (no storage benefit, §3.3).
+
+---
+
+## 3D. Subject-search language facet (implementation requirement)
+
+**Scope:** Angular subject search OData query/UI only (`subject-api.component.ts` + its template). No Cosmos, API DTO, homepage, discovery, or non-search contract changes.
+
+### Current behavior (code + live index, 2026-07-17)
+
+Subject page (`website/cultpodcasts/src/app/subject-api/subject-api.component.ts`):
+
+- Hard-coded `langFilter = ' and lang eq null'` always appended to the subject filter.
+- Facets requested today: `podcastName` and `subjects` only — **no language selector**.
+- Effect: subject results are restricted to documents with **no `lang` value**.
+
+Live index distribution (`@search.facets` on `lang` + count filters):
+
+| Bucket | Docs | Notes |
+|--------|------|-------|
+| `lang eq null` | **76,569** (~93%) | Dominant bucket |
+| Non-null `lang` | **5,683** | ISO-ish codes only |
+| `lang eq ''` | **0** | Empty string unused |
+| `lang eq 'en'` / `en-GB` / `en-US` | **0** | Explicit English codes are **not stored** |
+
+Top non-null values: `es` 3948, `pt` 581, `fr` 478, `cs` 324, `de` 140, `it` 58, … (no English variants).
+
+**Semantics:** In this product, English/default is represented by **`lang` absent (`null`)**, not by `en`. Curator UI reinforces this: podcast language options exclude `en` (`PODCAST_DEFAULT_LANGUAGE_EXCLUDED_CODES`), and episode dialogs use `unset` → `"No Language"`. Datasource projects `e.lang ?? e.podcastLanguage as lang`. Push mapper (`ToEpisodeSearchRecord`) currently **omits `Lang` entirely** — fix that in the slim-index implementation so incremental uploads match the indexer (`episode.Language ?? podcast.Language`).
+
+Therefore today's `lang eq null` clause is **already the English-only default**, by convention: it keeps unset/default-English docs and excludes explicit non-English codes. It does **not** mean “unknown language” as a separate concept in live data.
+
+### Required default English-only filter
+
+Exact OData fragment (matches current production behavior and live values):
+
+```text
+ and lang eq null
+```
+
+Full subject English-default example:
+
+```text
+subjects/any(s: s eq 'SUBJECT') and lang eq null
+```
+
+Do **not** use `lang eq 'en'` — that matches **zero** documents today.
+
+### Null / empty / unknown treatment (recommended + open UX choice)
+
+| Value | Live presence | Recommended treatment |
+|-------|---------------|----------------------|
+| `null` (missing) | 76,569 | Treat as **English (default)** — default selected facet |
+| `''` empty | 0 | Treat same as null if it ever appears: include in English filter via `(lang eq null or lang eq '')` only if empty starts appearing |
+| Explicit `en` / `en-*` | 0 | Not used today. **Open UX choice:** if curators later store explicit English codes, expand English filter to `(lang eq null or lang eq 'en' or search.in(lang, 'en-GB,en-US', ','))` — defer until needed |
+| Other codes (`es`, `pt`, …) | 5,683 | Distinct language options in the selector |
+
+Recommended label for the null bucket in the UI: **“English”** (not “Unknown”), matching product convention. Flag for product confirmation: whether null-only should forever mean English, or whether an eventual explicit-`en` migration is desired (out of scope for index slimming storage work).
+
+### Facet request, selector, and `$filter` updates
+
+Add `lang` to the subject page facet list (same style as podcast chips):
+
+```text
+facets: [
+  "podcastName,count:1000,sort:count",
+  "subjects,count:10,sort:count",
+  "lang,count:50,sort:count"
+]
+```
+
+**Important Azure Search nuance:** `@search.facets.lang` returns **only non-null values**. English (`null`) will **not** appear as a facet bucket. The UI must synthesize an English option:
+
+1. Always show **English** first; selected by default; count = subject-scoped total with `lang eq null` (separate count, or `subjectTotal − Σ(non-null lang facet counts)` when no other lang filter is applied).
+2. Show remaining options from `@search.facets.lang` (value + count), using display names from the existing `/languages` map where available.
+3. Optional third control: **All languages** (clear `langFilter`).
+
+When selection changes, rebuild `langFilter` only (subject + podcast filters unchanged):
+
+| Selection | `langFilter` |
+|-----------|--------------|
+| English (default) | ` and lang eq null` |
+| Single non-English code `es` | ` and lang eq 'es'` |
+| Multiple non-English codes | ` and search.in(lang, 'es,fr', ',')` (pick a delimiter consistent with podcast chips) |
+| English + one or more codes | ` and (lang eq null or search.in(lang, 'es,fr', ','))` |
+| All languages | `` (empty) |
+
+Reset page to 1 and re-run search (same pattern as `podcastsChange`).
+
+### Retrievable?
+
+**Keep `retrievable=false`.** Facet buckets supply codes and counts; the selector does not need per-document `lang` on each hit. Only flip to `retrievable=true` if a future UI shows language on each result card (not required now).
+
+### Confined to search query/result behavior
+
+| In scope | Out of scope |
+|----------|--------------|
+| Subject-page OData `$filter` / `facets` | Cosmos `Episode.lang` / `Podcast.lang` semantics |
+| Search index field attributes for `lang` | Episode/podcast edit dialogs (already use API DTOs) |
+| Search-result TypeScript shape only if needed for facet state | Homepage JSON, discovery, Worker non-search routes |
+
+---
+
+## 4. Proposed slim search schema (existing keys retained)
+
+**No key renames.** Existing descriptive keys remain unchanged unless the value itself changes from a URL to an ID.
+
+| Field | Type / attributes | Purpose / decision |
+|-------|-------------------|--------------------|
+| `id` | string key, filterable, retrievable | Unchanged |
+| `episodeTitle` | searchable, retrievable | Unchanged |
+| `podcastName` | searchable, filterable, facetable, retrievable | Unchanged |
+| `episodeDescription` | searchable, retrievable | Keep 230 chars initially |
+| `release` | sortable, retrievable | Unchanged |
+| `duration` | retrievable string | Emit without fractional `.0000000` tail |
+| `explicit` | — | **Drop (confirmed)** |
+| `subjects` | searchable, filterable, facetable, retrievable | Unchanged |
+| `lang` | filterable=true, facetable=true, retrievable=false | Keep filtering and planned subject-search facets; document value need not be returned |
+| `spotifyId` | retrievable string | Replaces full `spotify` URL |
+| `youtubeId` | retrievable string | Replaces full `youtube` URL |
+| `appleId` + `podcastAppleId` | retrievable strings | Replace full `apple` URL; slug omitted |
+| `bbc` | retrievable string | Keep full URL; not derivable |
+| `internetArchive` | retrievable string | Keep full URL; not derivable |
+| `image` | retrievable string? | Store only non-YouTube image URLs; omit for derivable YT thumbnails |
+| `youtubeImageVariant` (optional) | retrievable string/enum | Preserve YT thumbnail variant only if fallback behavior is insufficient |
+| `podcastSearchTerms` | searchable, retrievable=false | Unchanged |
+| `episodeSearchTerms` | searchable, retrievable=false | Unchanged |
+
+Prefer omitting null/empty IDs and `image` rather than writing `""`.
+
+### 4.1 URL derivability (search reconstruction only)
+
+| Platform | Cosmos IDs | Canonical reconstruction | Edge cases |
+|----------|------------|--------------------------|------------|
+| Spotify | `Episode.SpotifyId` | `https://open.spotify.com/episode/{spotifyId}` | Matches codebase (`SpotifySearcher`, fixtures). |
+| YouTube | `Episode.YouTubeId` | `https://www.youtube.com/watch?v={youtubeId}` | Code uses watch URLs (`SearchResultExtensions.ToYouTubeUrl`). Shorts/`youtu.be` may exist in Cosmos URLs; watch URL is acceptable for links. |
+| Apple | `Episode.AppleId` + podcast Apple id | `https://podcasts.apple.com/podcast/id{podcastAppleId}?i={appleId}` | Slug/`/us/` optional; Apple redirects. **Podcast Apple id is on `Podcast.AppleId`, not denormalized on Episode today.** Indexer push path can read podcast; Cosmos datasource SQL needs it extracted from `urls.apple` at index time (no Cosmos model change). |
+| BBC / IA | No compact ids | Keep full URLs in search doc | Client uses them on search cards. |
+| Image | — | Keep non-YT URL; derive YT thumbnail from `youtubeId` (plus optional variant) | Spotify/Apple CDN URLs are not derivable. |
+
+Do **not** strip `urls` from Cosmos.
+
+### 4.2 Datasource / push changes (search only)
+
+- `CreateDataSource` SELECT: project `e.spotifyId as spotifyId`, `e.youTubeId as youtubeId`, `e.appleId as appleId`, plus `podcastAppleId`; stop projecting `e.urls.spotify|apple|youtube`.
+- Keep `e.urls.bbc` / `e.urls.internetArchive` under their existing field names.
+- `ToEpisodeSearchRecord`: map IDs from episode (+ podcast Apple id); do not copy Spotify/YouTube/Apple URL strings into the search document.
+
+---
+
+## 5. Client / query strategy (locked decision)
+
+### 5.1 Recommendation: retain existing OData field names
+
+**Do not rename keys and do not build an OData field-name translation layer.** Existing filters, orderings, facets, and displayed properties retain their descriptive names. Only the service-link representation changes from full URLs to ID properties, `explicit` disappears, and YouTube `image` values become derivable.
+
+| Option | Verdict |
+|--------|---------|
+| **(A) Retain descriptive field names** | **Chosen.** No persistent-storage benefit justifies key renaming. |
+| **(B) Rename keys and update consumers** | **Rejected.** Adds contract churn for negligible quota benefit. |
+| **(C) API translates long ↔ short** | **Rejected.** Unnecessary and fragile across filters, lambdas, ordering, facets, Worker page details, and logs. |
+
+Worker `POST /search` remains a **pass-through** to Azure Search (plus logging / leech stub). Existing OData field strings remain unchanged.
+
+### 5.2 In-scope Angular / Worker touch list
+
+**OData query sites (keep existing names; verify unchanged):**
+
+| File | Today |
+|------|--------|
+| `website/cultpodcasts/src/app/search-api/search-api.component.ts` | `release`, `podcastName`, `subjects` facets/filters |
+| `website/cultpodcasts/src/app/podcast-api/podcast-api.component.ts` | `podcastName eq`, `release`, `subjects` |
+| `website/cultpodcasts/src/app/subject-api/subject-api.component.ts` | `subjects/any`, default `lang eq null`, add `lang` facet + selector (§3D), `podcastName` facet/filter, `release` |
+| `website/cultpodcasts/src/app/episode.service.ts` | `podcastName` + `id` filter, `release desc` |
+
+**Search-result models / templates (search path only):**
+
+| File | Notes |
+|------|--------|
+| `search-result.interface.ts` | Drop `explicit`; replace URL properties with `spotifyId`, `youtubeId`, `appleId`, `podcastAppleId`; `image` becomes optional |
+| Prefer **splitting** `SearchResult` from `HomepageEpisode` | Homepage JSON keeps full URLs; search results use IDs without changing unrelated contracts |
+| `search-results-facets.interface.ts` | Keep existing `podcastName` / `subjects`; add `lang` support when the planned subject-search facet ships |
+| `search-api` / `podcast-api` / `subject-api` `*.html` | Existing descriptive result keys remain unchanged |
+| `episode-image` / `episode-links` when given **search** results | Reconstruct Spotify/YouTube/Apple URLs from IDs; derive YT thumbnail from `youtubeId`; keep `bbc`, `internetArchive`, and non-YT `image` |
+| `podcast-episode` / `podcast` components that load via `/search` | Search-shaped fields only |
+
+**Worker (search-shaped only):**
+
+| File | Change |
+|------|--------|
+| `Api/src/getPageDetails.ts` | No field-name changes (`podcastName`, `id`, `episodeTitle`, `release`, `duration` stay) |
+| `Api/src/search.ts` leech stub | Remove `explicit`; align any service-link fields with ID shape |
+| `Api/src/searchLogCollector.ts` | No field-name renames; tolerate ID-shaped service links if logged |
+| `Api/src/ISearchResult.ts` | Drop `explicit`; align service-link/image properties with the slim search JSON |
+
+**Out of scope:** edit/add episode dialogs, `api-episode.interface`, discovery UI, homepage templates fed by homepage API, and curator episode APIs that are not Azure Search.
+
+### 5.3 URL reconstruction location (search results)
+
+Reconstruct in the **webapp**. Prefer a single helper, e.g. `searchResultLinks(spotifyId, youtubeId, appleId, podcastAppleId)`.
+
+---
+
+## 6. Backend implementation notes (search-only code)
+
+1. Slim `EpisodeSearchRecord` while retaining descriptive names: drop `Explicit`, replace service URL properties with ID properties, make `Image` optional/non-YT only, trim `Duration`, and make `Lang` non-retrievable while retaining filtering+faceting.
+2. Update `CreateDataSource` projection + `ToEpisodeSearchRecord`.
+3. Populate `podcastAppleId` only in the search projection: parse it from `urls.apple` for the Cosmos datasource, and map it from the podcast in the push path. **Do not add it to the Episode/Cosmos model.**
+4. Console tools selecting existing names (for example `episodeDescription`) require no rename changes; verify they tolerate the dropped/replaced fields.
+5. `SearchDocument.cs` (older helper) — update or leave unused; do not ripple into non-search models.
+
+Azure Functions **do not** proxy public search; they write the index (`EpisodeSearchIndexerService`) and run the indexer (`SearchIndexHandler`). Public queries: Worker → Azure Search.
+
+---
+
+## 7. Reindexing mechanics (this repo)
+
+| Mechanism | Role |
+|-----------|------|
+| `Console-Apps/CreateSearchIndex` | Create/teardown index, datasource, indexer; run indexer with retries; Cosmos episode counts / duplicate fingerprint |
+| Azure Search indexer + Cosmos datasource | High-watermark on `e._ts`; filter active episodes |
+| `EpisodeSearchIndexerService` | `MergeOrUploadDocumentsAsync` after episode mutations |
+| `searchIndex:*` app settings | `Url`, `Key`, `IndexName`, `IndexerName` |
+| Worker `apihost` | Full Azure Search search URL including **index name** |
+
+The field removals/additions and `lang.retrievable` change require a **new index** (several field definitions are immutable). Pattern: create new index + new datasource/indexer names → populate → flip config → delete old.
+
+---
+
+## 8. Deployment plan (minimal interruption)
+
+### 8.1 Dual-index storage risk (critical)
+
+Service `storageSize` is **summed across all indexes**. Free/Basic ~50 MB is shared.
+
+If current index is already near the cap, **creating a second full copy will fail or force eviction**. Measure first:
+
+- Portal: Search service → Usage / Indexes size  
+- Or `GET .../servicestats` / index statistics (`storageSize`)
+
+| Situation | Strategy |
+|-----------|----------|
+| `current + estimatedNew < quota` (with headroom for merge overhead) | Blue/green: build new alongside old |
+| Not enough headroom | Temporary SKU bump for migration, **or** delete-old-then-rebuild (downtime = reindex duration) |
+| Near cap even for one slim index | Value reduction is mandatory; key renaming will not save the tier |
+
+Rebuilds temporarily inflate size (delete+insert until merges finish, often 24–72h) — [storage metrics](https://learn.microsoft.com/azure/search/troubleshoot-storage-metrics).
+
+### 8.2 Dual-read / dual-write feasibility
+
+| Pattern | Feasible today? |
+|---------|-----------------|
+| Dual-write to two indexes | **No** without new code (single `SearchClient` / `IndexName`) |
+| Dual-read in webapp (old+new schemas) | Possible but unnecessary; keep descriptive field names and cut over atomically |
+| Feature flag on index name | Yes via `searchIndex__IndexName` + Worker `apihost` |
+| Index alias | Azure Search supports aliases; optional cutover aid — not used in repo today |
+
+**Recommended:** blue/green with **atomic cutover** of writers + readers + webapp; no long dual-compat window.
+
+### 8.3 Ordered rollout (preferred when dual-index fits)
+
+1. **Measure** current `storageSize` and document count; estimate slim size (sample index on a non-prod service if possible).
+2. **Ship code** that can build/populate the slim schema (console + libraries), without flipping prod `IndexName` yet.
+3. **Create** `cultpodcasts-v2` (name TBD) + datasource + indexer **without** tearing down `cultpodcasts` (`CreateSearchIndex` without `--teardown-index`).
+4. **Populate** via `--run-indexer` on the **new** indexer until doc counts match filter expectations.
+5. **Prepare packages:** api-infra + indexer-infra with slim `EpisodeSearchRecord` (IDs not URLs, no `explicit`, trimmed duration, non-YT `image`, `lang` non-retrievable); webapp with URL/image reconstruction helpers + subject language facet (§3D); Worker search consumers updated for ID fields / dropped `explicit`.
+6. **Cutover window (seconds–minutes):**
+   1. Set function app `searchIndex__IndexName` (and `IndexerName`) to v2 (bicep/app settings — not local deploy scripts).
+   2. Deploy api-infra + indexer-infra packages that emit slim docs.
+   3. Point Worker `apihost` at the v2 index search URL.
+   4. Deploy Angular PWA (`wrangler pages deploy`).
+   5. Trigger indexer once on v2 to catch `_ts` delta since step 4.
+7. **Verify:** search, podcast, subject (English-default `lang eq null` + language facet selector), episode deep link / `pagedetails`, podcast facets, platform link icons, BBC/IA when present. Confirm non-search APIs unchanged.
+8. **Soak**, then **delete** old index + old indexer/datasource to reclaim quota.
+9. **Rollback:** keep old index until soak passes; revert `apihost` + `IndexName` + previous function packages + previous Pages deploy.
+
+**Outage estimate:** with dual-index headroom, user-visible cutover can be **near-zero to ~1–2 minutes** (config + deploys). Without headroom, outage ≈ **full reindex time** after deleting the old index (plus deploy), unless SKU is temporarily raised.
+
+### 8.4 Deploy order across repos
+
+| Order | Component | Action |
+|-------|-----------|--------|
+| 0 | Azure Search | Create+fill v2 (console), old still serving |
+| 1 | `api-infra` + `indexer-infra` | Slim schema writers + IndexName=v2 |
+| 2 | Cloudflare Worker `Api` | `apihost` → v2; align search hit fields (IDs, drop `explicit`) |
+| 3 | `website/cultpodcasts` | URL/image reconstruction + subject language facet |
+| 4 | Azure Search | Delete old index when stable |
+
+Homepage / discovery / episode CRUD deploys are **unrelated** and must not change contracts for this work.
+
+### 8.5 Compatibility shim?
+
+**Not recommended.** Blue/green via **new index name + coordinated webapp/Worker** is enough. Field names stay descriptive; only value shapes change (URLs→IDs, drop `explicit`, derive YT images).
+
+---
+
+## 9. Phased implementation sequence
+
+| Phase | Work |
+|-------|------|
+| P0 | Measure prod `storageSize`; decide dual-index vs SKU bump vs downtime rebuild |
+| P1 | Slim `EpisodeSearchRecord` + datasource SQL + `ToEpisodeSearchRecord` (map `Lang`); URL→ID; drop `explicit`; trim duration; derive YT images; `lang` retrievable=false |
+| P2 | Angular search-result models: ID reconstruction helpers; subject language facet/selector (§3D); keep existing OData field names |
+| P3 | Worker search consumers (`getPageDetails`, logs, leech) — drop `explicit`, accept IDs |
+| P4 | Create/populate v2 index; cutover; verify; decommission old |
+| P5 | Optional: further description trim — measure again |
+
+---
+
+## 10. Open questions for the user
+
+1. Current Azure Search SKU and **exact `storageSize` / quota** (dual-index possible?). *(Measured Free ~49.08 MB / 50 MB — still need dual-index headroom decision.)*
+2. Approve temporary **SKU bump** for blue/green if under 50 MB headroom fails?
+3. **`podcastAppleId`:** confirm parse-from-`urls.apple` at index time only (no Cosmos Episode field)?
+4. Keep optional Apple slug in reconstruction, or omit (recommended: omit)?
+5. ~~Keep `explicit`?~~ **Resolved: drop.**
+6. New index name (`cultpodcasts-v2`?) and whether to use an **index alias** for cutover.
+7. Target description length: stay at **230** or reduce further after URL value wins?
+8. Confirm homepage / discovery / Cosmos URL fields remain untouched (assumed yes per scope).
+9. **Language UX (§3D):** label null as **“English”** (recommended)? If explicit `en`/`en-*` codes are introduced later, expand the English filter accordingly?
+10. Subject language selector: single-select only, or multi-select (English + other codes)?
+
+---
+
+## 11. Summary — final recommended changes (locked)
+
+| Change | Decision |
+|--------|----------|
+| Drop `explicit` | **Yes (confirmed)** |
+| Derive Spotify / YouTube / Apple URLs from IDs | **Yes** — store `spotifyId`, `youtubeId`, `appleId`, `podcastAppleId` |
+| Derive YouTube-thumbnail `image` | **Yes** — keep non-YT image URLs only |
+| Trim `duration` fractional `.0000000` tail | **Yes** |
+| `lang` attributes | **filterable=true, facetable=true, retrievable=false** |
+| Subject language facet | **Yes** — default English = `lang eq null` (§3D) |
+| Key renaming / short keys | **No** — dropped (no storage benefit) |
+| API OData translation layer | **No** |
+| Non-search contracts | **Unchanged** |
+
+- **Biggest quota wins:** platform URL→ID (~5.29 MB), YT image derivation (~3.18 MB), duration trim (~0.16 MB); `explicit` drop and `lang.retrievable=false` are small.
+- **Queries:** keep descriptive OData field names; update webapp for ID reconstruction + subject language selector; Worker pass-through only.
+- **Cutover:** new index → populate → flip `IndexName` + `apihost` + webapp together → delete old; **watch dual-index quota**.

--- a/docs/search-platform-alternatives.md
+++ b/docs/search-platform-alternatives.md
@@ -1,0 +1,302 @@
+# Search platform alternatives (strategic)
+
+**Status:** Proposal only — no production or code changes.  
+**Date:** 2026-07-17  
+**Related:** [search-index-slimming-plan.md](./search-index-slimming-plan.md) (tactical stay-on-Azure-Free), [migration/README.md](./migration/README.md) (Cosmos split; assumes Azure AI Search).
+
+---
+
+## Recommendation (read this first)
+
+| Rank | Path | Verdict |
+|------|------|---------|
+| **1 — Best free long-term** | **Cloudflare Worker + D1 (SQLite FTS5)** | Best fit for “stay free” with the existing Worker edge. 5 GB free D1 storage easily holds an 82k+ episode projection; implement search/filter/facet/sort in the Worker. |
+| **2 — Only plausible managed $0 candidate** | **Aiven OpenSearch Free** | Verified 2026-07-17 at **4 GB RAM / 20 GB storage** (not the conflicting 30 GB shown on Aiven's generic pricing page). It holds the corpus, but Aiven labels it learning/prototyping/evaluation, powers it off after 24 hours with no indexing or queries, and gives it no SLA. |
+| **3 — Best low-cost self-managed** | **Self-hosted Meilisearch** (small VPS / container) | Excellent feature fit, but it is not a managed free tier: the software is free and the infrastructure/operations are yours. |
+| **Bridge (not free)** | **Azure AI Search Basic (~$74/SU-month list)** | Lowest migration risk: keep OData, indexer, Angular contracts. Use if Free-tier storage pain returns after slimming and you will not invest in a Worker rewrite. |
+| **Near-term** | **Stay on Azure Free + index slimming** | Correct tactical move while evaluating alternatives ([search-index-slimming-plan.md](./search-index-slimming-plan.md)). Does not solve long-term growth past ~50 MB. |
+
+**Honest free ceiling:** A public podcast site with ~82k growing documents, multi-field keyword search, `search.in` / collection filters, date sort, relevance ranking, facet counts up to 1000, and pagination **can** stay free where storage is multi‑GB and you own the query layer (D1/FTS5 or self-hosted Meilisearch/OpenSearch). As of 2026-07-17, **there is no managed, ongoing $0 tier that is both a comfortable functional fit and a reliable production offering**. Aiven is the closest, but explicitly has no SLA and is positioned for evaluation; Algolia and Upstash impose low request ceilings; Atlas M0 is shared and storage-constrained.
+
+**Migration docs alignment:** The multi-container Cosmos migration docs treat **Azure AI Search as the search projection** (datasource on `Episodes`, `EpisodeSearchIndexerService`). They do **not** discuss platform alternatives. This document is the strategic counterpart; Cosmo migration work stays valid whatever search backend is chosen (episodes remain source of truth).
+
+---
+
+## Current usage (verified from codebase)
+
+### Architecture
+
+```
+Angular PWA  --POST /search-->  Cloudflare Worker (pass-through + cache)  -->  Azure AI Search
+.NET indexer / CreateSearchIndex  --push/pull-->  Azure AI Search
+Homepage  --GET /homepage-->  Worker / Functions  (NOT Azure Search)
+```
+
+- Index: Free tier `cultpodcasts` (uksouth), ~82k docs, ~49 MB / **50 MB hard cap**.
+- Public reads: Worker `Api/src/search.ts` → `c.env.apihost` (Azure Search docs API).
+- Writes: `EpisodeSearchIndexerService` + Cosmos pull indexer (`CreateSearchIndex`).
+- Azure Functions API does **not** proxy public search.
+
+### Features actually used
+
+| Capability | Used? | Evidence |
+|------------|-------|----------|
+| Full-text (simple query) | **Yes** | `queryType: 'simple'`, `searchMode: 'any'` over title/description/subjects/hidden search-terms |
+| OData `$filter` | **Yes** | `podcastName eq`, `search.in(podcastName,…)`, `subjects/any(s: s eq …)`, `subjects/any(s: search.in(…))`, `lang eq null`, `id eq` |
+| `$orderby` | **Yes** | `release asc` / `release desc`; empty orderby → relevance (`@search.score`) |
+| Facets | **Yes** | `podcastName,count:1000` and `subjects,count:1000` (subject page: subjects count 10) |
+| `$count` + skip/top | **Yes** | Infinite scroll / paging |
+| Highlighting | **No** | Not requested |
+| Suggestions / autocomplete | **No** | Not used |
+| Geo | **No** | — |
+| Vectors / semantic rank | **No** | No vector fields; Free tier lacks semantic ranking |
+| Scoring profiles | **Implicit only** | Default BM25-style score when not sorting by date |
+
+### Document shape (search projection)
+
+See `EpisodeSearchRecord` / [search-index-slimming-plan.md](./search-index-slimming-plan.md) §2. Roughly: id, titles, truncated description (230 chars), podcastName, release, duration, explicit, platform URLs, subjects[], hidden search-terms, image, lang. Retrievable card fields dominate storage; filterable/facetable attributes multiply footprint.
+
+### Non-negotiables for any replacement
+
+1. Keyword search over episode + podcast text (incl. curator search-terms).
+2. Filter by podcast name(s), subject(s), lang null, episode id.
+3. Sort by release **or** relevance.
+4. Facet counts for podcasts and subjects (UI chip filters).
+5. Stable pagination + total count.
+6. Sub‑hundreds-of-ms typical latency for a public site (Worker already CF-caches search 600s).
+7. Incremental upsert/delete from the .NET indexing path (or a dual-write Worker job).
+
+---
+
+## Comparison table
+
+Limits below are as of mid‑2026 research; re-check vendor pages before committing.
+
+| Candidate | Free / cheap limits | Filters / sort / FTS / facets | Fit to current UX | Migration effort | Ops burden | Stays free as corpus grows? | Latency / UX |
+|-----------|---------------------|-------------------------------|-------------------|------------------|------------|-----------------------------|--------------|
+| **Stay Azure Free + slim** | 50 MB, 3 indexes, shared HW | Full OData parity | Perfect | Low (schema only) | Low (managed) | **No** — hard 50 MB | Good today |
+| **Azure Basic** | ~$74/SU‑mo, 15 GB | Full parity | Perfect | **Lowest** | Low | Paid forever | Excellent |
+| **CF Worker + D1 FTS5** | Free: **5 GB** storage, 5M rows read/day; Paid Workers: same 5 GB included then $0.75/GB‑mo | FTS5 + SQL filters/sort; facets via SQL `GROUP BY` (you build) | High if Worker API mirrors today’s JSON | **High** (rewrite query + write path) | Low–med (SQL schema, FTS config) | **Yes** into multi‑GB; may need Workers Paid if read volume high | Edge-local; good with cache |
+| **Self-host Meilisearch** | OSS free; host ~$5–20/mo VPS | Filters, sort, facets, typo tolerance native | High | Med (SDK + replace OData) | Med (updates, backups, TLS) | Yes if you pay the box | Excellent (&lt;50 ms typical) |
+| **Meilisearch Cloud** | 14‑day trial; then ~$20+/mo | Same as OSS | High | Med | Low | **No** (paid) | Excellent |
+| **Self-host Typesense** | OSS free; same VPS story | Filters, facets, sort | High | Med | Med | Yes (box cost) | Excellent |
+| **Typesense Cloud** | One-time 720 cluster hours + 10 GB BW — **not recurring** | Same | High | Med | Low | **No** | Excellent |
+| **Aiven OpenSearch Free** | **$0** ongoing: 4 GB RAM, **20 GB** storage, 2 shards, 50 connections; powers off after 24h with no indexing/querying | ES-like query DSL; facets/aggs | High | Med–high | Low (managed) | Comfortable capacity; not production-backed | Good while running; manual wake after idle shutdown |
+| **Elastic Cloud** | 14‑day trial only | Overkill feature set | High | High | Low when paid | **No** free long-term | Excellent |
+| **Algolia Build** | 1M records, **10k searches/mo**, 1 GB app | Filters/facets excellent | High | Med | Low | **No** — 10k searches kills a public site | Excellent |
+| **Algolia Grow free allotment** | 10k searches + 100k records then $ | Same | High | Med | Low | **No** at traffic | Excellent |
+| **Neon / Supabase PG FTS** | **0.5 GB** DB free | `tsvector` + SQL; facets DIY | Med–high | High | Low–med | **Tight** at 0.5 GB; growth → paid | Neon scales-to-zero → cold latency |
+| **CF Hyperdrive → Postgres** | Needs paid PG usually | Same as PG | Med–high | High | Med | Only if PG paid | Better than raw Neon from Worker |
+| **CF AI Search** | Free beta: 100k files, **20k queries/mo**, **5 metadata fields** | RAG/hybrid; weak structured facets | **Poor** for podcast browse UX | High | Low | Query + metadata caps | RAG-oriented, not catalog search |
+| **CF Vectorize alone** | Vectors only | No lexical FTS replacement | **Poor** | High | Low | N/A as sole engine | Semantic ≠ keyword |
+| **Cosmos full-text / vector** | Uses existing RU $; FTS preview | FTS + rank; facets weak vs Search | Med | Med–high | Low (same DB) | Not free; RU spike risk | Variable; costly |
+| **Azure SQL FTS** | No meaningful free SKU for always-on | FTS + SQL | Med | High | Med | Paid | OK |
+| **Client MiniSearch / Lunr** | Browser download | Local only | Poor at 82k | Med | None | Feasible only if tiny index | First load huge; bad mobile |
+
+---
+
+## Candidate notes
+
+### 1. Cloudflare Worker + D1 / FTS5 (recommended free path)
+
+**Why it fits:** You already terminate search at the Worker. Replacing the Azure pass-through with D1 queries keeps the public surface (`POST /search`) and CF cache. Free D1 storage (5 GB) is ~100× the Azure Free cap.
+
+**Query model sketch:**
+
+- Table `episodes` + `episodes_fts` (FTS5) on title, description, podcast name, subjects, search-terms.
+- Filters: `WHERE podcast_name IN (…)`, `EXISTS` subject junction or JSON/`LIKE` normalized subjects, `lang IS NULL`, `id = ?`.
+- Sort: `ORDER BY release DESC` or `ORDER BY rank` (FTS5 `bm25` / `rank`).
+- Facets: separate aggregated queries (or cached facet snapshots in KV refreshed on write).
+- Response: shape today’s OData-ish JSON (`value`, `@odata.count`, `@search.facets`) so Angular changes stay small.
+
+**Gaps to engineer:** Azure `search.in` / `subjects/any` → SQL; facet `count:1000`; typo tolerance weaker than Meilisearch unless you add trigram/spell logic; write path from .NET must upsert D1 (HTTP to Worker admin route, or queue).
+
+**Growth:** Comfortable past 82k with compact rows (align with slimming: short keys, platform ids not URLs). Workers Free row-read quota (5M/day) may force **Workers Paid** under heavy uncached traffic — still far cheaper than Azure Search Basic if storage stays in the included 5 GB.
+
+### 2. Meilisearch / Typesense (self-host = free software; cloud ≠ free)
+
+**Feature fit:** Excellent — filters, facets, sort, typo-tolerant search map cleanly onto podcast/subject pages.
+
+**Cloud:** Meilisearch Cloud is trial then paid (~$20+/mo). Typesense Cloud free hours are **lifetime one-shot**, then billed. Neither is a long-term $0 managed plan for production.
+
+**Self-host:** Real “free search engine”; you pay only for a small VM/container (~1 GB RAM likely enough for this corpus). Fits Azure+.NET write path via REST from `EpisodeSearchIndexerService`.
+
+### 3. OpenSearch / Elasticsearch
+
+- **Aiven OpenSearch Free:** Closest candidate for “managed + $0” with 4 GB RAM / 20 GB storage. It has no SLA, one node, two shards, one disaster-recovery backup (product page says up to three days' snapshot retention), and powers off after 24 hours with no indexing or queries. Treat it as an evaluation tier, not a production guarantee. The generic Aiven pricing page currently says 30 GB; the product-specific free-tier page says 20 GB, so this document uses the conservative product-specific limit.
+- **Elastic Cloud:** Trial only → paid.
+- **Self-host ES/OS:** Overkill ops for this feature set vs Meilisearch.
+
+### 4. Algolia
+
+Records capacity is fine; **10k search requests/month** on free Build/Grow allotments is not viable for cultpodcasts.com (homepage is separate, but search/podcast/subject/SSR page-details fallbacks still generate searches). Treat as paid product or reject.
+
+### 5. PostgreSQL FTS (Neon / Supabase) ± Hyperdrive
+
+Technically solid (GIN/`tsvector`, filters, DIY facets). Free **0.5 GB** is the problem: a denormalized search table with FTS indexes may fit initially if aggressively slimmed, but leaves little headroom vs D1’s 5 GB. Neon scale-to-zero hurts public TTFB unless always-warm (paid) or cached heavily at the Worker.
+
+### 6. Staying on Azure (Free / Basic / Cosmos / SQL)
+
+| Option | Role |
+|--------|------|
+| **Free + slim** | Buy time; dual-index room for cutover of compact schema |
+| **Basic** | Escape hatch with near-zero UX rewrite (~$74/mo list) |
+| **Cosmos FTS** | Avoids a second store but burns RU on already-costly Episodes path; facet UX and Free-tier story worse |
+| **Azure SQL FTS** | New paid database; poor free story |
+
+### 7. Cloudflare AI Search / Vectorize
+
+Wrong product shape: RAG/file/metadata limits (5 custom metadata fields, 20k queries/mo on Free Workers) cannot replace podcast/subject facet browse. Vectorize alone does not replace lexical search.
+
+### 8. Static / client-side search
+
+~82k documents × (title + 230-char description + subjects + ids) is typically several–tens of MB compressed. Unacceptable as a PWA primary download; only plausible for a tiny “podcast names only” index, which does not meet current UX.
+
+---
+
+## Migration sketches (top options)
+
+### A. Worker + D1 (best free path)
+
+1. **Define** compact search table matching slimmed `EpisodeSearchRecord` (ids not URLs).
+2. **Bulk load** once from Cosmos or Azure Search export into D1 (offline script / wrangler).
+3. **Implement** `POST /search` in Worker: parse existing Angular body (`search`, `filter`, `orderby`, `facets`, `skip`, `top`, `count`) → SQL/FTS; return compatible JSON.
+4. **Dual-write:** extend indexing to upsert/delete D1 via authenticated Worker route (or Azure → queue → Worker). Keep Azure Search until parity.
+5. **Cut over** `apihost` / Worker to D1-only; retire Azure Search when stable.
+6. **Angular:** prefer zero change if Worker preserves contract; otherwise replace OData filter strings with a small structured query DTO (cleaner long-term).
+
+**Effort:** roughly 1–2 focused weeks for an engineer who knows the Worker + indexing paths; facets and filter parser are the hard parts.
+
+### B. Self-hosted Meilisearch (best free-enough search UX)
+
+1. Deploy Meilisearch (Docker on cheap VPS or Azure Container Instance).
+2. Create index settings: searchable/filterable/facetable attributes aligned to current fields; primary key `id`.
+3. Bulk import documents; point `EpisodeSearchIndexerService` at Meilisearch documents API (replace `SearchClient`).
+4. Worker: either proxy Meilisearch search API or translate OData → Meilisearch filter syntax (`podcastName = "…"`, arrays for subjects).
+5. Validate facet chip UX, date sort, relevance, `getPageDetails` fallback.
+6. Decommission Azure Search.
+
+**Effort:** often less than D1 for search quality; more ongoing ops (patching, backups, monitoring).
+
+### C. Azure Basic (lowest effort paid)
+
+1. Provision Basic in uksouth; recreate index (optionally slimmed schema).
+2. Repoint indexer + Worker `apihost`.
+3. No Angular change if field names unchanged.
+
+---
+
+## Decision guide
+
+```text
+Need zero rewrite and can spend ~$75/mo?
+  → Azure AI Search Basic
+
+Need $0 long-term and already on Cloudflare?
+  → Worker + D1 FTS5 (accept building facets/filters)
+
+Need best search UX on a shoestring and OK with a small server?
+  → Self-host Meilisearch (or Typesense)
+
+Want managed $0 without writing SQL search?
+  → No production-reliable option; evaluate Aiven OpenSearch Free only if no SLA
+    and manual recovery from idle shutdown are acceptable
+
+Still on Free and only need months of headroom?
+  → Execute search-index-slimming-plan.md first
+```
+
+---
+
+## What “free won’t work” means here
+
+These are **not** viable as permanent $0 production search for Cult Podcasts:
+
+- **Algolia free search quotas** (10k searches/mo).
+- **Meilisearch / Typesense / Elastic managed free trials** (time- or hour-boxed).
+- **Neon/Supabase free 0.5 GB** as a growing primary search store.
+- **Azure AI Search Free** beyond aggressive slimming (~50 MB wall).
+- **Client-side full corpus search** at 82k+ rich documents.
+- **Cloudflare AI Search** as a drop-in catalog/facet engine.
+
+“Free” that **does** work long-term is almost always **open-source search (or SQLite FTS) on infrastructure you already pay for or that has multi‑GB free storage** — not a second SaaS with a marketing free tier.
+
+---
+
+## Managed free-tier verification (2026-07-17)
+
+This section is the live-pricing follow-up to the earlier strategic comparison. “Ongoing” means a recurring or indefinite $0 managed plan, not a trial, signup credit, student offer, or self-hosted software. Published limits are quoted exactly where possible; “not published” is used instead of inferring RAM, storage, backup, or SLA terms.
+
+### Bottom line and ranked ongoing $0 options
+
+Only the following are genuinely managed and ongoing at $0 **and** expose more than Azure AI Search Free's 50 MB of storage/capacity. The ranking is for this 82,252-document podcast workload, not for general product quality.
+
+| Rank | Managed ongoing $0 offer | Exact published free limits | Corpus and growth fit | Idle / retention / reliability | UK/EU and card |
+|------|---------------------------|-----------------------------|-----------------------|--------------------------------|----------------|
+| **1** | **Aiven for OpenSearch Free** | 1 node, 1 CPU, **4 GB RAM, 20 GB storage**, 2 shards (20 max/node), 50 concurrent connections, one service/org. No document or query quota published. | **Comfortable capacity and full feature fit.** Even allowing substantial Lucene overhead over the current ~49 MB Azure index, 20 GB is ample. Two shards are enough for this corpus. | Powers off after **24h with no indexing or querying**; console power-on required. No SLA, fixed maintenance, no operator-routed alerts. One DR backup; product page says snapshot retention up to **3 days**. Aiven may change free configuration/regions. | No card. User selects a region **group**, not an exact cloud/region; an EU group can be selected if offered in the console, but the exact UK/EU location is not guaranteed or migratable. |
+| **2** | **Algolia Build** | **1,000,000 records**, **10,000 search requests/month**, 10,000 recommendation requests and 10,000 crawls/month. Storage and RAM are not published because quota is record/request based. | **Documents fit (~12.2× current count), traffic probably does not.** Excellent filters, facets, relevance and sorting, but 10k searches/month is only ~333/day. Suitable only if Cloudflare caching keeps origin searches below that hard ceiling. | No sleep behavior published. Build is a developer/test plan with no support/SLA published; backup/restore terms are not specified for Build. | No card. Pricing advertises US, UK and EU-West locations. |
+| **3** | **Upstash Search Free** | **200,000 records**, **20,000 monthly queries/requests**, up to 10 free databases, 10,000 indexes/database, `topK` max 1,000, **1,500 characters/document**; free migration/upsert limit **10,000 documents/day**. RAM and a free-tier byte quota are not published (service FAQ gives a 50 GB database ceiling, while Free is record-limited). | **Raw count fits only to ~2.43× current size. Functional fit is poor:** filtering exists, but no independent date sort, facet counts, total-count paging, or stable search offset is documented. Search and document updates both consume requests. | Serverless; no idle deletion documented. **Preview/Early Access; no uptime SLA.** Backup/retention terms are not published. | Card is required only to upgrade to PAYG, so not for Free. Console offers region choice, but the Search-specific public docs do not enumerate regions; do not assume Redis's London/Frankfurt list applies to Search. |
+| **4** | **MongoDB Atlas Free (M0) with Atlas Search** | **512 MB database quota** for uncompressed BSON plus database indexes; separate Lucene Search-index bytes are not published. Shared RAM/vCPU, up to **100 ops/s**, 500 connections, **10 GB in + 10 GB out per rolling 7 days**, 3 Search indexes, one free cluster/project. | **Possible but not comfortable.** 82k compact documents may fit, and Atlas Search supports text, filters, facets, counts, relevance/date sort. However, its accounting differs from Azure's 49 MB search index, Search shares M0 resources, and growth/reindex headroom is uncertain. Benchmark the full projection before considering it. | Automatically pauses after **30 days with zero connections**. No Atlas backups on Free (manual `mongodump` only). No SLA; 99.995% applies to M10+. | No card for M0. Free clusters exist only in a subset of regions; Atlas lists Azure UK South plus EU regions in its region catalog, but Free availability must be confirmed in the create-cluster UI. |
+| **5** | **Bonsai Sandbox (Heroku add-on)** | **119 MB capacity, 125 MB RAM, 35,000 documents, 10,000 requests/day**, 2 shards, 1 concurrent search, 1 concurrent indexing operation, 159 MB outgoing/day. | **Does not fit:** 35k documents is only 43% of the current corpus, regardless of its storage being above 50 MB. | Three-node multitenant service. Heroku listing says hourly backups, but Bonsai's snapshot doc says automatic snapshots cover **paid clusters**; therefore free backup/retention is contradictory and must not be relied on. No free-plan SLA published. | Heroku Common Runtime Europe available (exact region controlled by Heroku; Private Space London is not listed as available). Card requirement is not stated by Bonsai; Heroku may require account/payment verification to install add-ons. |
+
+**Verdict:** Aiven is the only free managed tier with comfortable capacity and native search semantics, but its official terms make it unsuitable as a dependable production promise. Therefore **none of the verified ongoing $0 managed offers is a reliable long-term production recommendation**. Aiven can be benchmarked as a no-cost experiment; D1/FTS5 or paid/self-managed infrastructure remains the defensible long-term path.
+
+### Aiven discrepancy resolved
+
+The earlier 4 GB / 20 GB claim is substantially correct, but “permanent production free tier” was too strong:
+
+- The product-specific [Aiven for OpenSearch free-tier page](https://aiven.io/docs/products/opensearch/concepts/opensearch-free-tier) says **4 GB RAM and 20 GB storage**, explicitly describes the plan as learning/prototyping/evaluation, and documents no SLA plus idle shutdown.
+- Aiven's generic [service-pricing page](https://aiven.io/docs/platform/concepts/service-pricing) currently says the OpenSearch Developer tier has **30 GB storage** and is “always-on.” That conflicts with the product-specific page and its 24-hour idle-shutdown rules.
+- Until Aiven makes those pages consistent or the console contract shows otherwise, use **20 GB and possible idle shutdown** for planning. No heartbeat workaround should be treated as a contractual entitlement.
+- Creation details and region-group restriction: [Create a free-tier OpenSearch service](https://aiven.io/docs/products/opensearch/howto/create-free-tier-opensearch). Backup details: [Aiven service backups](https://aiven.io/docs/platform/concepts/service_backups).
+
+### Ongoing free offers that fail the >50 MB or corpus test
+
+| Provider | Verified offer | Why it is not a candidate | Operations / region / card |
+|----------|----------------|---------------------------|----------------------------|
+| **Searchly** | Starter is ongoing free: **20 MB, 2 indexes**; no card. | Below Azure's 50 MB and below the existing ~49 MB index before growth. | AWS US East or EU West. Daily backups are advertised for **paid** plans; no free SLA/backup promise published. [Pricing](https://www.searchly.com/pricing), [architecture/regions](https://docs.searchly.com/article/14-introduction). |
+| **Bonsai direct/Heroku** | The verifiable free plan is the 119 MB / 35k-doc Heroku Sandbox above. | Storage exceeds 50 MB but document cap fails immediately. Bonsai's direct public pricing page starts with paid Staging and does not publish a separate direct Hobby quota. | [Heroku plan table](https://elements.heroku.com/addons/bonsai), [Bonsai architecture](https://bonsai.io/docs/platform/bonsai-architecture/), [snapshots](https://bonsai.io/docs/platform/snapshots/). |
+| **Skryx** (credible new EU alternative) | Site says a forever free plan and no card, but does **not publish exact free document/query/storage limits** on the public pricing material found. | Cannot verify that it exceeds 50 MB or 82k docs; its public proof point is stores at 25k+ products, not this corpus. Not ranked without exact authoritative limits. | Frankfurt/EU-hosted; no public free SLA/backup terms found. [Product](https://skryx.io/), [API docs](https://skryx.io/docs/index). |
+
+### Trials, credits, paid-only services, and self-hosting (not ranked)
+
+| Provider | Current verified status — not an ongoing managed free tier | UK/EU, resilience, and payment notes |
+|----------|-------------------------------------------------------------|--------------------------------------|
+| **Elastic Cloud** | **14-day trial** only; no card. Trial allows one hosted deployment, up to 8 GB RAM and approximately 360 GB storage (Elastic's pricing FAQ separately says 240 GB, another reason not to treat trial sizing as a plan). Then paid. | AWS/GCP/Azure regions include Europe; exact region selectable. Trial has no production SLA commitment. [Trial](https://www.elastic.co/cloud/cloud-trial-overview), [trial limits](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/create-an-organization). |
+| **AWS OpenSearch Service** | The often-quoted **750 t2/t3.small hours/month + 10 GB EBS** was **12 months free**, not ongoing, for pre-2025-07-15 accounts. New accounts receive signup credits/free-account access for at most six months; OpenSearch is not established as an Always Free service. | London, Ireland and Frankfurt service regions exist. Managed domains retain automated snapshots **14 days**. AWS signup/account normally includes a payment method; overages bill automatically on paid plans. [Current Free Tier model](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/free-tier.html), [offer classification](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/tracking-free-tier-usage.html), [OpenSearch pricing/snapshots](https://aws.amazon.com/opensearch-service/pricing/). |
+| **Instaclustr OpenSearch** | Free **trial** only; ongoing service is paid/contact-sales. | Multi-cloud AWS/Azure/GCP, including European deployments. The advertised 99.999% SLA, automated backups and support are paid-service attributes. Card requirement for trial is not stated in the public pages reviewed. [Managed OpenSearch](https://www.instaclustr.com/platform/managed-opensearch/), [pricing](https://www.instaclustr.com/pricing/). |
+| **Scaleway Cloud Essentials for OpenSearch** | Paid only. Smallest published shared node is **2 vCPU / 8 GB RAM at €0.099/hour**, plus block storage at €0.000136/GB/hour. | European cloud; no UK location established in the OpenSearch docs reviewed. Managed HA is available on paid configurations. Account/payment verification applies. [Pricing](https://www.scaleway.com/en/pricing/managed-databases/), [FAQ](https://www.scaleway.com/en/docs/opensearch/faq/). |
+| **IBM Cloud Databases for Elasticsearch** | Paid only, hourly by members, vCPU, RAM, disk and backup; no Lite/free plan. | IBM has UK/EU cloud regions, but deployment availability must be checked in catalog. HA and automated backup orchestration are paid-service features. IBM Cloud account/payment terms apply. [Pricing model](https://cloud.ibm.com/docs/cloud-databases?topic=cloud-databases-hosting-pricing). |
+| **Oracle OCI Search with OpenSearch** | Not Always Free. The first two data-node **management fees** are waived, but compute, RAM, block/object storage are still charged. The only free access is the **30-day / US$300 credit**. | OCI has UK/EU regions; fully managed patching, resizing and automated backups are paid-service features. Signup may require card/identity verification. [OCI Free Tier](https://www.oracle.com/cloud/free/), [OpenSearch pricing](https://www.oracle.com/cloud/search/pricing/), [features/backups](https://www.oracle.com/cloud/search/features/). |
+| **Meilisearch Cloud** | **14-day trial**, no card; then paid (published entry pricing starts around $20–30/month depending billing model). No ongoing cloud free plan yet. Meilisearch's March 2026 roadmap targets serverless/free tier work for Q3 2026, which is future intent, not a current offer. | Region selectable; cloud handles backups/updates. SLA up to 99.999% is an enterprise feature, not trial. [Pricing](https://www.meilisearch.com/pricing), [roadmap](https://www.meilisearch.com/blog/2026-march-roadmap). |
+| **Typesense Cloud** | First **720 cluster-hours + 10 GB bandwidth once per account lifetime**; it does not renew. No card to start, then running clusters charge or stop. | London and Frankfurt available. A free single node has no HA/support SLA; production HA requires at least 3 paid nodes. [Free-tier terms](https://cloud-help.typesense.org/article/how-does-the-free-tier-work), [regions](https://cloud-help.typesense.org/article/data-center-locations), [HA](https://cloud-help.typesense.org/article/high-availability). |
+| **ZincSearch hosting** | ZincSearch is free to self-host. Elestio managed hosting offers only **$20 credit valid 3 days**; OctaByte advertises a trial, not an ongoing free plan. | Elestio can use European infrastructure and manages backups/updates on paid instances. Trial card terms not clearly published. [Elestio pricing](https://elest.io/open-source/zincsearch/resources/plans-and-pricing), [OctaByte](https://octabyte.io/fully-managed-open-source-services/applications/search/zincsearch/). |
+| **Quickwit hosting** | Quickwit has no first-party hosted SaaS; it is open-source/self-hosted. Elestio's managed Quickwit is paid after the same short signup credit. | European Elestio locations are available; backups/monitoring belong to the paid managed service. [Quickwit](https://quickwit.io/), [Elestio managed Quickwit](https://elest.io/open-source/quickwit). |
+| **Orama Cloud** | OramaJS is free **self-hosted/in-app**. Managed Orama Cloud Pro is paid with a monthly fee plus one-time onboarding; no public cloud free tier. | Managed region/SLA/backup details are sales-scoped. [Pricing](https://orama.com/pricing). |
+
+### Capacity interpretation for this corpus
+
+- **Current baseline:** 82,252 growing episode documents; Azure reports ~49 MB after indexing. That 49 MB is useful for order-of-magnitude comparison but is **not portable sizing**: OpenSearch/Lucene, Algolia record accounting, Mongo BSON plus indexes, and Upstash's character/record accounting differ.
+- **Comfortable:** Aiven 20 GB and Algolia's 1M-record allowance. Algolia fails on likely query volume, not corpus size.
+- **Borderline:** Upstash reaches 200k records but only 20k monthly operations and lacks required browse semantics. Atlas M0 has 512 MB inclusive storage and shared resources; a full representative import is mandatory.
+- **Impossible now:** Bonsai's 35k documents, Searchly's 20 MB, and any unverified free plan below 82,252 documents.
+- **Growth check:** At the current document count, a plan should ideally allow at least 250k records and multiple times the measured index footprint to absorb Lucene overhead, reindexing, schema changes and several years of additions. Only Aiven clears both tests without a request-meter problem, and it still fails the production reliability test.
+
+### Authoritative sources checked
+
+- Aiven: [free-tier limits/idle/SLA](https://aiven.io/docs/products/opensearch/concepts/opensearch-free-tier), [generic pricing conflict](https://aiven.io/docs/platform/concepts/service-pricing), [creation/region group](https://aiven.io/docs/products/opensearch/howto/create-free-tier-opensearch), [backups](https://aiven.io/docs/platform/concepts/service_backups).
+- Algolia: [pricing](https://www.algolia.com/pricing), [Build plan](https://www.algolia.com/pricing/build-plan), [support exclusion](https://support.algolia.com/hc/en-us/articles/10109389226769-How-can-I-upgrade-to-a-plan-with-Support).
+- Upstash: [Search pricing](https://upstash.com/pricing/search), [FAQ and document limits](https://upstash.com/docs/search/help/faq), [filtering](https://upstash.com/docs/search/features/filtering), [search API](https://upstash.com/docs/search/sdks/ts/commands/search).
+- MongoDB: [Atlas pricing](https://www.mongodb.com/pricing), [Free limits](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/), [cluster/region comparison](https://www.mongodb.com/docs/atlas/manage-clusters/), [production SLA](https://www.mongodb.com/docs/atlas/production-notes/).
+- Other providers are linked directly in the exclusion tables above.
+
+---
+
+## References (code)
+
+- Schema: `Class-Libraries/RedditPodcastPoster.Search/EpisodeSearchRecord.cs`
+- Public proxy: `Api/src/search.ts`, `Api/src/getPageDetails.ts`
+- Consumers: `website/cultpodcasts/src/app/search-api/`, `podcast-api/`, `subject-api/`, `episode.service.ts`
+- Indexing: `RedditPodcastPoster.EntitySearchIndexer`, `Console-Apps/CreateSearchIndex`
+- Slimming plan: [search-index-slimming-plan.md](./search-index-slimming-plan.md)
+- Migration assumes Azure Search: [migration/README.md](./migration/README.md), [migration/azure-functions-microservices-reference-architecture.md](./migration/azure-functions-microservices-reference-architecture.md)


### PR DESCRIPTION
## Summary
- remove `explicit` from indexed episode documents
- replace Spotify, Apple, podcast Apple, and YouTube service URLs with compact IDs
- store derivable YouTube thumbnail variants instead of full thumbnail URLs, while retaining opaque image fallbacks
- trim redundant fractional zeros from durations
- keep `lang` filterable and facetable while making it non-retrievable
- keep bulk index creation and incremental push mapping consistent with the slim schema
- update the legacy `SearchDocument` helper and add mapper/schema coverage

## Verification
- `dotnet test Cloud/Unit-Tests/Indexer.Tests/Indexer.Tests.csproj --filter "FullyQualifiedName~PodcastEpisodeExtensionsTests"` — 3 passed
- `dotnet build Console-Apps/CreateSearchIndex/CreateSearchIndex.csproj` — succeeded
- `dotnet build Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/RedditPodcastPoster.EntitySearchIndexer.csproj` — succeeded

## Production state and rollout
The production index was already rebuilt from this working tree/new schema and now reports **82,127 documents / 47.52 MB**. The website PR must be merged and promoted because the old production app may not fully support the new shape; the branch preview has been manually verified.

During the rebuild, an indexer free-tier 10k/run multi-attempt monitor correlation bug was discovered. Completion required single-shot retries. No Cosmos data was written.