### PR TITLE
feat(submit-url): return guest enrichment people in episode details

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Persistence/EpisodeGuestAndHandlePersistenceRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Persistence/EpisodeGuestAndHandlePersistenceRules.cs
@@ -27,7 +27,7 @@ public class EpisodeGuestAndHandlePersistenceRules
             .WithPodcast(podcast)
             .Customize(e =>
             {
-                e.Guests = ["Janja Lalich", "Steven Hassan"];
+                e.Guests = ["Ada Example", "Pat Placeholder"];
             })
             .Create();
 
@@ -36,7 +36,7 @@ public class EpisodeGuestAndHandlePersistenceRules
         var stored = repository.GetStored(episode.Id);
 
         // Assert
-        stored.Guests.Should().Equal("Janja Lalich", "Steven Hassan");
+        stored.Guests.Should().Equal("Ada Example", "Pat Placeholder");
     }
 
     [Fact(DisplayName =
@@ -52,7 +52,7 @@ public class EpisodeGuestAndHandlePersistenceRules
             .WithYouTube(youTubeInput.YouTubeId, youTubeInput.YouTubeUrl)
             .Customize(e =>
             {
-                e.Guests = ["Janja Lalich"];
+                e.Guests = ["Ada Example"];
                 e.SpotifyId = string.Empty;
                 e.Urls.Spotify = null;
             })
@@ -68,7 +68,7 @@ public class EpisodeGuestAndHandlePersistenceRules
 
         // Assert
         result.MergedEpisodes.Should().ContainSingle();
-        stored.Guests.Should().Equal("Janja Lalich");
+        stored.Guests.Should().Equal("Ada Example");
         stored.SpotifyId.Should().Be(spotifyInput.SpotifyId);
         stored.Urls.Spotify.Should().Be(spotifyInput.SpotifyUrl);
     }

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Persistence/EpisodeRemovedSubjectsRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Persistence/EpisodeRemovedSubjectsRules.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using RedditPodcastPoster.Models;
+
+namespace RedditPodcastPoster.Episodes.Tests.BusinessRules.Persistence;
+
+public class EpisodeRemovedSubjectsRules
+{
+    [Fact(DisplayName = "Removing a subject adds it to removedSubjects.")]
+    public void apply_user_subjects_removal_adds_to_removed_subjects()
+    {
+        var episode = new Episode
+        {
+            Subjects = ["Cults", "Scientology"]
+        };
+
+        var changed = episode.ApplyUserSubjects(["Scientology"]);
+
+        changed.Should().BeTrue();
+        episode.Subjects.Should().Equal("Scientology");
+        episode.RemovedSubjects.Should().Equal("Cults");
+    }
+
+    [Fact(DisplayName = "Re-adding a removed subject clears it from removedSubjects.")]
+    public void apply_user_subjects_readd_clears_removed_subjects()
+    {
+        var episode = new Episode
+        {
+            Subjects = ["Scientology"],
+            RemovedSubjects = ["Cults"]
+        };
+
+        var changed = episode.ApplyUserSubjects(["Scientology", "Cults"]);
+
+        changed.Should().BeTrue();
+        episode.Subjects.Should().Equal("Scientology", "Cults");
+        episode.RemovedSubjects.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Identical subject lists are a no-op.")]
+    public void apply_user_subjects_no_change_returns_false()
+    {
+        var episode = new Episode
+        {
+            Subjects = ["Cults"],
+            RemovedSubjects = ["Scientology"]
+        };
+
+        var changed = episode.ApplyUserSubjects(["Cults"]);
+
+        changed.Should().BeFalse();
+        episode.RemovedSubjects.Should().Equal("Scientology");
+    }
+
+    [Fact(DisplayName = "Removed-subject tracking is case-insensitive.")]
+    public void apply_user_subjects_is_case_insensitive()
+    {
+        var episode = new Episode
+        {
+            Subjects = ["Scientology"],
+            RemovedSubjects = ["cults"]
+        };
+
+        episode.ApplyUserSubjects(["Scientology", "CULTS"]);
+
+        episode.RemovedSubjects.Should().BeEmpty();
+        episode.Subjects.Should().Equal("Scientology", "CULTS");
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Persistence/EpisodeRemovedSubjectsRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Persistence/EpisodeRemovedSubjectsRules.cs
@@ -65,4 +65,33 @@ public class EpisodeRemovedSubjectsRules
         episode.RemovedSubjects.Should().BeEmpty();
         episode.Subjects.Should().Equal("Scientology", "CULTS");
     }
+
+    [Fact(DisplayName = "Removing a subject clears its match records.")]
+    public void apply_user_subjects_removal_clears_matches()
+    {
+        var episode = new Episode
+        {
+            Subjects = ["Cults", "Scientology"],
+            Matches =
+            [
+                new EpisodeSubjectMatch
+                {
+                    Subject = "Cults",
+                    Term = "cult",
+                    Source = SubjectMatchSource.Title
+                },
+                new EpisodeSubjectMatch
+                {
+                    Subject = "Scientology",
+                    Term = "scientology",
+                    Source = SubjectMatchSource.Description
+                }
+            ]
+        };
+
+        episode.ApplyUserSubjects(["Scientology"]);
+
+        episode.Matches.Should().ContainSingle();
+        episode.Matches[0].Subject.Should().Be("Scientology");
+    }
 }

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/EpisodeCreationLoggerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/EpisodeCreationLoggerRules.cs
@@ -30,13 +30,15 @@ public class EpisodeCreationLoggerRules
             episode,
             podcastId,
             EpisodeCreationSource.Indexer,
-            Service.Spotify);
+            Service.Spotify,
+            caller: "FakeIndexerComponent.CreateEpisode");
 
         message.Should().StartWith(EpisodeCreationLogger.MessagePrefix);
         message.Should().Contain($"episode-id='{episodeId}'");
         message.Should().Contain("title='Preacher Boys Episode'");
         message.Should().Contain($"podcast-id='{podcastId}'");
         message.Should().Contain("source='Indexer'");
+        message.Should().Contain("caller='FakeIndexerComponent.CreateEpisode'");
         message.Should().Contain("service='Spotify'");
         message.Should().Contain("spotify-id='spotifyEp123'");
         message.Should().Contain("spotify-url='https://open.spotify.com/episode/spotifyEp123'");
@@ -91,8 +93,9 @@ public class EpisodeCreationLoggerRules
         };
 
         var message = EpisodeCreationLogger.FormatMessage(
-            episode, Guid.NewGuid(), source, Service.Spotify);
+            episode, Guid.NewGuid(), source, Service.Spotify, caller: "FakeSubmitPath.Persist");
 
         message.Should().Contain($"source='{source}'");
+        message.Should().Contain("caller='FakeSubmitPath.Persist'");
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/EpisodeCreationLoggerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/EpisodeCreationLoggerRules.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using RedditPodcastPoster.Models;
+
+namespace RedditPodcastPoster.Episodes.Tests;
+
+public class EpisodeCreationLoggerRules
+{
+    [Fact(DisplayName = "FormatMessage uses stable Episode created: prefix and includes ids/urls.")]
+    public void format_message_includes_provenance_and_urls()
+    {
+        var episodeId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var podcastId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var episode = new Episode
+        {
+            Id = episodeId,
+            PodcastId = podcastId,
+            Title = "Preacher Boys Episode",
+            SpotifyId = "spotifyEp123",
+            YouTubeId = "ytVid456",
+            AppleId = 9876543210,
+            Urls = new ServiceUrls
+            {
+                Spotify = new Uri("https://open.spotify.com/episode/spotifyEp123"),
+                YouTube = new Uri("https://www.youtube.com/watch?v=ytVid456"),
+                Apple = new Uri("https://podcasts.apple.com/us/podcast/id1?i=9876543210")
+            }
+        };
+
+        var message = EpisodeCreationLogger.FormatMessage(
+            episode,
+            podcastId,
+            EpisodeCreationSource.Indexer,
+            Service.Spotify);
+
+        message.Should().StartWith(EpisodeCreationLogger.MessagePrefix);
+        message.Should().Contain($"episode-id='{episodeId}'");
+        message.Should().Contain("title='Preacher Boys Episode'");
+        message.Should().Contain($"podcast-id='{podcastId}'");
+        message.Should().Contain("source='Indexer'");
+        message.Should().Contain("service='Spotify'");
+        message.Should().Contain("spotify-id='spotifyEp123'");
+        message.Should().Contain("spotify-url='https://open.spotify.com/episode/spotifyEp123'");
+        message.Should().Contain("youtube-id='ytVid456'");
+        message.Should().Contain("youtube-url='https://www.youtube.com/watch?v=ytVid456'");
+        message.Should().Contain("apple-id='9876543210'");
+        message.Should().Contain("apple-url='https://podcasts.apple.com/us/podcast/id1?i=9876543210'");
+    }
+
+    [Fact(DisplayName = "ResolveCreatingService returns sole present platform identity.")]
+    public void resolve_creating_service_sole_identity()
+    {
+        var spotifyOnly = new Episode { SpotifyId = "sp1" };
+        var youTubeOnly = new Episode { YouTubeId = "yt1" };
+        var appleOnly = new Episode { AppleId = 1 };
+
+        EpisodeCreationLogger.ResolveCreatingService(spotifyOnly, Service.YouTube)
+            .Should().Be(Service.Spotify);
+        EpisodeCreationLogger.ResolveCreatingService(youTubeOnly, Service.Spotify)
+            .Should().Be(Service.YouTube);
+        EpisodeCreationLogger.ResolveCreatingService(appleOnly, Service.Spotify)
+            .Should().Be(Service.Apple);
+    }
+
+    [Fact(DisplayName = "ResolveCreatingService prefers release authority when multiple ids present.")]
+    public void resolve_creating_service_prefers_release_authority()
+    {
+        var episode = new Episode
+        {
+            SpotifyId = "sp1",
+            YouTubeId = "yt1"
+        };
+
+        EpisodeCreationLogger.ResolveCreatingService(episode, Service.YouTube)
+            .Should().Be(Service.YouTube);
+        EpisodeCreationLogger.ResolveCreatingService(episode, Service.Spotify)
+            .Should().Be(Service.Spotify);
+    }
+
+    [Theory(DisplayName = "FormatMessage includes source enum name for KQL filtering.")]
+    [InlineData(EpisodeCreationSource.Indexer)]
+    [InlineData(EpisodeCreationSource.SubmitUrl)]
+    [InlineData(EpisodeCreationSource.Discovery)]
+    public void format_message_includes_source(EpisodeCreationSource source)
+    {
+        var episode = new Episode
+        {
+            Id = Guid.NewGuid(),
+            Title = "t",
+            SpotifyId = "x",
+            Urls = new ServiceUrls { Spotify = new Uri("https://open.spotify.com/episode/x") }
+        };
+
+        var message = EpisodeCreationLogger.FormatMessage(
+            episode, Guid.NewGuid(), source, Service.Spotify);
+
+        message.Should().Contain($"source='{source}'");
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeCreationLogger.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeCreationLogger.cs
@@ -13,14 +13,24 @@ public static class EpisodeCreationLogger
     public const string MessagePrefix = "Episode created:";
 
     public const string MessageTemplate =
-        "Episode created: episode-id='{EpisodeId}' title='{Title}' podcast-id='{PodcastId}' source='{Source}' service='{Service}' spotify-id='{SpotifyId}' spotify-url='{SpotifyUrl}' apple-id='{AppleId}' apple-url='{AppleUrl}' youtube-id='{YouTubeId}' youtube-url='{YouTubeUrl}'";
+        "Episode created: episode-id='{EpisodeId}' title='{Title}' podcast-id='{PodcastId}' source='{Source}' caller='{Caller}' service='{Service}' spotify-id='{SpotifyId}' spotify-url='{SpotifyUrl}' apple-id='{AppleId}' apple-url='{AppleUrl}' youtube-id='{YouTubeId}' youtube-url='{YouTubeUrl}'";
 
+    /// <summary>
+    /// Logs episode create provenance.
+    /// </summary>
+    /// <param name="caller">
+    /// Creating call site — who invoked <see cref="LogCreated"/> (the caller), e.g.
+    /// <c>PodcastUpdater.Update</c> or <c>CategorisedItemProcessor.ProcessCategorisedItem</c>.
+    /// Named <c>caller</c> deliberately: in C# logging this matches <c>CallerMemberName</c>
+    /// semantics; not the callee (<see cref="LogCreated"/> itself).
+    /// </param>
     public static void LogCreated(
         ILogger logger,
         Episode episode,
         Guid podcastId,
         EpisodeCreationSource source,
-        Service service)
+        Service service,
+        string caller)
     {
         logger.LogWarning(
             MessageTemplate,
@@ -28,6 +38,7 @@ public static class EpisodeCreationLogger
             episode.Title,
             podcastId,
             source,
+            caller,
             service,
             EmptyToNull(episode.SpotifyId),
             episode.Urls.Spotify,
@@ -40,14 +51,16 @@ public static class EpisodeCreationLogger
     /// <summary>
     /// Same content as the rendered Warning message (for unit tests / docs).
     /// </summary>
+    /// <param name="caller">Creating call site (caller of <see cref="LogCreated"/>), e.g. <c>PodcastUpdater.Update</c>.</param>
     public static string FormatMessage(
         Episode episode,
         Guid podcastId,
         EpisodeCreationSource source,
-        Service service)
+        Service service,
+        string caller)
     {
         return
-            $"{MessagePrefix} episode-id='{episode.Id}' title='{episode.Title}' podcast-id='{podcastId}' source='{source}' service='{service}' spotify-id='{EmptyToNull(episode.SpotifyId)}' spotify-url='{episode.Urls.Spotify}' apple-id='{episode.AppleId}' apple-url='{episode.Urls.Apple}' youtube-id='{EmptyToNull(episode.YouTubeId)}' youtube-url='{episode.Urls.YouTube}'";
+            $"{MessagePrefix} episode-id='{episode.Id}' title='{episode.Title}' podcast-id='{podcastId}' source='{source}' caller='{caller}' service='{service}' spotify-id='{EmptyToNull(episode.SpotifyId)}' spotify-url='{episode.Urls.Spotify}' apple-id='{episode.AppleId}' apple-url='{episode.Urls.Apple}' youtube-id='{EmptyToNull(episode.YouTubeId)}' youtube-url='{episode.Urls.YouTube}'";
     }
 
     /// <summary>

--- a/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeCreationLogger.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeCreationLogger.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models;
+
+namespace RedditPodcastPoster.Episodes;
+
+/// <summary>
+/// Emits a stable Warning-level provenance line for new episode creates so App Insights
+/// can answer submit-url vs indexer (and service) by episode-id or URL substring.
+/// Warning is intentional: Information is heavily sampled in production.
+/// </summary>
+public static class EpisodeCreationLogger
+{
+    public const string MessagePrefix = "Episode created:";
+
+    public const string MessageTemplate =
+        "Episode created: episode-id='{EpisodeId}' title='{Title}' podcast-id='{PodcastId}' source='{Source}' service='{Service}' spotify-id='{SpotifyId}' spotify-url='{SpotifyUrl}' apple-id='{AppleId}' apple-url='{AppleUrl}' youtube-id='{YouTubeId}' youtube-url='{YouTubeUrl}'";
+
+    public static void LogCreated(
+        ILogger logger,
+        Episode episode,
+        Guid podcastId,
+        EpisodeCreationSource source,
+        Service service)
+    {
+        logger.LogWarning(
+            MessageTemplate,
+            episode.Id,
+            episode.Title,
+            podcastId,
+            source,
+            service,
+            EmptyToNull(episode.SpotifyId),
+            episode.Urls.Spotify,
+            episode.AppleId,
+            episode.Urls.Apple,
+            EmptyToNull(episode.YouTubeId),
+            episode.Urls.YouTube);
+    }
+
+    /// <summary>
+    /// Same content as the rendered Warning message (for unit tests / docs).
+    /// </summary>
+    public static string FormatMessage(
+        Episode episode,
+        Guid podcastId,
+        EpisodeCreationSource source,
+        Service service)
+    {
+        return
+            $"{MessagePrefix} episode-id='{episode.Id}' title='{episode.Title}' podcast-id='{podcastId}' source='{source}' service='{service}' spotify-id='{EmptyToNull(episode.SpotifyId)}' spotify-url='{episode.Urls.Spotify}' apple-id='{episode.AppleId}' apple-url='{episode.Urls.Apple}' youtube-id='{EmptyToNull(episode.YouTubeId)}' youtube-url='{episode.Urls.YouTube}'";
+    }
+
+    /// <summary>
+    /// Which platform supplied the create: sole present identity, else release authority when present on the episode, else first available.
+    /// </summary>
+    public static Service ResolveCreatingService(Episode episode, Service? releaseAuthority = null)
+    {
+        var hasSpotify = !string.IsNullOrWhiteSpace(episode.SpotifyId);
+        var hasYouTube = !string.IsNullOrWhiteSpace(episode.YouTubeId);
+        var hasApple = episode.AppleId is > 0;
+
+        var presentCount = (hasSpotify ? 1 : 0) + (hasYouTube ? 1 : 0) + (hasApple ? 1 : 0);
+        if (presentCount == 1)
+        {
+            if (hasSpotify)
+            {
+                return Service.Spotify;
+            }
+
+            if (hasYouTube)
+            {
+                return Service.YouTube;
+            }
+
+            return Service.Apple;
+        }
+
+        if (releaseAuthority is Service.Spotify or Service.YouTube or Service.Apple)
+        {
+            var authority = releaseAuthority.Value;
+            if ((authority == Service.Spotify && hasSpotify) ||
+                (authority == Service.YouTube && hasYouTube) ||
+                (authority == Service.Apple && hasApple))
+            {
+                return authority;
+            }
+        }
+
+        if (hasSpotify)
+        {
+            return Service.Spotify;
+        }
+
+        if (hasYouTube)
+        {
+            return Service.YouTube;
+        }
+
+        if (hasApple)
+        {
+            return Service.Apple;
+        }
+
+        return releaseAuthority ?? Service.Other;
+    }
+
+    private static string? EmptyToNull(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeCreationSource.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/EpisodeCreationSource.cs
@@ -1,0 +1,11 @@
+namespace RedditPodcastPoster.Episodes;
+
+/// <summary>
+/// Provenance of an episode create: which product path persisted the new episode.
+/// </summary>
+public enum EpisodeCreationSource
+{
+    Indexer = 1,
+    SubmitUrl,
+    Discovery
+}

--- a/Class-Libraries/RedditPodcastPoster.Episodes/RedditPodcastPoster.Episodes.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/RedditPodcastPoster.Episodes.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Models/Episode.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Episode.cs
@@ -79,6 +79,10 @@ public class Episode
     [JsonPropertyOrder(71)]
     public List<string> RemovedSubjects { get; set; } = [];
 
+    [JsonPropertyName("matches")]
+    [JsonPropertyOrder(72)]
+    public List<EpisodeSubjectMatch> Matches { get; set; } = [];
+
     [JsonPropertyName("searchTerms")]
     [JsonPropertyOrder(80)]
     public string? SearchTerms { get; set; }
@@ -301,6 +305,7 @@ public class Episode
 
         RemovedSubjects.RemoveAll(s => newSet.Contains(s));
         Subjects = newList;
+        Matches.RemoveAll(m => !newSet.Contains(m.Subject, StringComparer.OrdinalIgnoreCase));
         return true;
     }
 

--- a/Class-Libraries/RedditPodcastPoster.Models/Episode.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Episode.cs
@@ -72,6 +72,13 @@ public class Episode
     [JsonPropertyOrder(70)]
     public List<string> Subjects { get; set; } = [];
 
+    /// <summary>
+    /// Subjects removed by a curator; indexer enrichment must not re-add these.
+    /// </summary>
+    [JsonPropertyName("removedSubjects")]
+    [JsonPropertyOrder(71)]
+    public List<string> RemovedSubjects { get; set; } = [];
+
     [JsonPropertyName("searchTerms")]
     [JsonPropertyOrder(80)]
     public string? SearchTerms { get; set; }
@@ -270,4 +277,33 @@ public class Episode
         Language = podcastLanguage;
         return true;
     }
+
+    /// <summary>
+    /// Applies a curator subject update and maintains <see cref="RemovedSubjects"/>.
+    /// </summary>
+    public bool ApplyUserSubjects(IEnumerable<string> newSubjects)
+    {
+        var newList = newSubjects.ToList();
+        if (Subjects.SequenceEqual(newList))
+        {
+            return false;
+        }
+
+        var newSet = new HashSet<string>(newList, StringComparer.OrdinalIgnoreCase);
+        foreach (var subject in Subjects)
+        {
+            if (!newSet.Contains(subject) &&
+                !RemovedSubjects.Contains(subject, StringComparer.OrdinalIgnoreCase))
+            {
+                RemovedSubjects.Add(subject);
+            }
+        }
+
+        RemovedSubjects.RemoveAll(s => newSet.Contains(s));
+        Subjects = newList;
+        return true;
+    }
+
+    public bool IsSubjectRemovedByUser(string subjectName) =>
+        RemovedSubjects.Contains(subjectName, StringComparer.OrdinalIgnoreCase);
 }

--- a/Class-Libraries/RedditPodcastPoster.Models/EpisodeSubjectMatch.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/EpisodeSubjectMatch.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace RedditPodcastPoster.Models;
+
+public class EpisodeSubjectMatch
+{
+    [JsonPropertyName("subject")]
+    public string Subject { get; set; } = string.Empty;
+
+    [JsonPropertyName("term")]
+    public string Term { get; set; } = string.Empty;
+
+    [JsonPropertyName("source")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public SubjectMatchSource Source { get; set; }
+}

--- a/Class-Libraries/RedditPodcastPoster.Models/SubjectMatchSource.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/SubjectMatchSource.cs
@@ -1,0 +1,7 @@
+namespace RedditPodcastPoster.Models;
+
+public enum SubjectMatchSource
+{
+    Title = 1,
+    Description
+}

--- a/Class-Libraries/RedditPodcastPoster.People.Tests/EpisodeGuestEnricherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.People.Tests/EpisodeGuestEnricherTests.cs
@@ -16,10 +16,10 @@ public class EpisodeGuestEnricherTests
     [Fact]
     public async Task EnrichGuests_HighConfidenceTitleMatch_UnionsCanonicalName()
     {
-        var episode = CreateEpisode("Interview with Janja Lalich");
+        var episode = CreateEpisode("Interview with Ada Example");
         var match = new PersonMatch(
-            new PersonMatchPerson(Guid.NewGuid(), "Janja Lalich", null, null),
-            [new PersonMatchResult("Janja Lalich", 1)]);
+            new PersonMatchPerson(Guid.NewGuid(), "Ada Example", null, null),
+            [new PersonMatchResult("Ada Example", 1)]);
 
         _personService
             .Setup(x => x.MatchEpisode(episode, false))
@@ -28,18 +28,18 @@ public class EpisodeGuestEnricherTests
         var result = await CreateSut().EnrichGuests(episode);
 
         result.Additions.Should().ContainSingle()
-            .Which.Person.Name.Should().Be("Janja Lalich");
+            .Which.Person.Name.Should().Be("Ada Example");
         result.SkippedLowConfidence.Should().BeEmpty();
-        episode.Guests.Should().Equal("Janja Lalich");
+        episode.Guests.Should().Equal("Ada Example");
     }
 
     [Fact]
     public async Task EnrichGuests_ShortTerm_SkippedAsLowConfidence()
     {
-        var episode = CreateEpisode("Chat with Jon about cults");
+        var episode = CreateEpisode("Chat with Sam about widgets");
         var match = new PersonMatch(
-            new PersonMatchPerson(Guid.NewGuid(), "Jon", null, null),
-            [new PersonMatchResult("Jon", 1)]);
+            new PersonMatchPerson(Guid.NewGuid(), "Sam", null, null),
+            [new PersonMatchResult("Sam", 1)]);
 
         _personService
             .Setup(x => x.MatchEpisode(episode, false))
@@ -49,19 +49,19 @@ public class EpisodeGuestEnricherTests
 
         result.Additions.Should().BeEmpty();
         result.SkippedLowConfidence.Should().ContainSingle()
-            .Which.Person.Name.Should().Be("Jon");
+            .Which.Person.Name.Should().Be("Sam");
         episode.Guests.Should().BeNull();
     }
 
     [Fact]
     public async Task EnrichGuests_NeverRemovesExistingGuests()
     {
-        var episode = CreateEpisode("Interview with Janja Lalich");
+        var episode = CreateEpisode("Interview with Ada Example");
         episode.Guests = ["Existing Guest"];
 
         var match = new PersonMatch(
-            new PersonMatchPerson(Guid.NewGuid(), "Janja Lalich", null, null),
-            [new PersonMatchResult("Janja Lalich", 1)]);
+            new PersonMatchPerson(Guid.NewGuid(), "Ada Example", null, null),
+            [new PersonMatchResult("Ada Example", 1)]);
 
         _personService
             .Setup(x => x.MatchEpisode(episode, false))
@@ -70,19 +70,19 @@ public class EpisodeGuestEnricherTests
         var result = await CreateSut().EnrichGuests(episode);
 
         result.Additions.Should().ContainSingle()
-            .Which.Person.Name.Should().Be("Janja Lalich");
-        episode.Guests.Should().BeEquivalentTo(["Existing Guest", "Janja Lalich"]);
+            .Which.Person.Name.Should().Be("Ada Example");
+        episode.Guests.Should().BeEquivalentTo(["Existing Guest", "Ada Example"]);
     }
 
     [Fact]
     public async Task EnrichGuests_DoesNotDuplicateExistingGuest_CaseInsensitive()
     {
-        var episode = CreateEpisode("Interview with Janja Lalich");
-        episode.Guests = ["janja lalich"];
+        var episode = CreateEpisode("Interview with Ada Example");
+        episode.Guests = ["ada example"];
 
         var match = new PersonMatch(
-            new PersonMatchPerson(Guid.NewGuid(), "Janja Lalich", null, null),
-            [new PersonMatchResult("Janja Lalich", 1)]);
+            new PersonMatchPerson(Guid.NewGuid(), "Ada Example", null, null),
+            [new PersonMatchResult("Ada Example", 1)]);
 
         _personService
             .Setup(x => x.MatchEpisode(episode, false))
@@ -91,16 +91,16 @@ public class EpisodeGuestEnricherTests
         var result = await CreateSut().EnrichGuests(episode);
 
         result.Additions.Should().BeEmpty();
-        episode.Guests.Should().Equal("janja lalich");
+        episode.Guests.Should().Equal("ada example");
     }
 
     [Fact]
     public async Task EnrichGuests_MinMatchCount_SkipsBelowThreshold()
     {
-        var episode = CreateEpisode("Interview with Janja Lalich");
+        var episode = CreateEpisode("Interview with Ada Example");
         var match = new PersonMatch(
-            new PersonMatchPerson(Guid.NewGuid(), "Janja Lalich", null, null),
-            [new PersonMatchResult("Janja Lalich", 1)]);
+            new PersonMatchPerson(Guid.NewGuid(), "Ada Example", null, null),
+            [new PersonMatchResult("Ada Example", 1)]);
 
         _personService
             .Setup(x => x.MatchEpisode(episode, false))
@@ -112,17 +112,17 @@ public class EpisodeGuestEnricherTests
 
         result.Additions.Should().BeEmpty();
         result.SkippedLowConfidence.Should().ContainSingle()
-            .Which.Person.Name.Should().Be("Janja Lalich");
+            .Which.Person.Name.Should().Be("Ada Example");
         episode.Guests.Should().BeNull();
     }
 
     [Fact]
     public async Task EnrichGuests_MinMatchCount_AcceptsAtOrAboveThreshold()
     {
-        var episode = CreateEpisode("Interview with Janja Lalich");
+        var episode = CreateEpisode("Interview with Ada Example");
         var match = new PersonMatch(
-            new PersonMatchPerson(Guid.NewGuid(), "Janja Lalich", null, null),
-            [new PersonMatchResult("Janja Lalich", 2)]);
+            new PersonMatchPerson(Guid.NewGuid(), "Ada Example", null, null),
+            [new PersonMatchResult("Ada Example", 2)]);
 
         _personService
             .Setup(x => x.MatchEpisode(episode, false))
@@ -133,8 +133,8 @@ public class EpisodeGuestEnricherTests
             GuestEnrichmentOptions.Default with { MinMatchCount = 2 });
 
         result.Additions.Should().ContainSingle()
-            .Which.Person.Name.Should().Be("Janja Lalich");
-        episode.Guests.Should().Equal("Janja Lalich");
+            .Which.Person.Name.Should().Be("Ada Example");
+        episode.Guests.Should().Equal("Ada Example");
     }
 
     [Fact]

--- a/Class-Libraries/RedditPodcastPoster.People.Tests/EpisodeGuestEnricherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.People.Tests/EpisodeGuestEnricherTests.cs
@@ -27,7 +27,8 @@ public class EpisodeGuestEnricherTests
 
         var result = await CreateSut().EnrichGuests(episode);
 
-        result.Additions.Should().Equal("Janja Lalich");
+        result.Additions.Should().ContainSingle()
+            .Which.Person.Name.Should().Be("Janja Lalich");
         result.SkippedLowConfidence.Should().BeEmpty();
         episode.Guests.Should().Equal("Janja Lalich");
     }
@@ -68,7 +69,8 @@ public class EpisodeGuestEnricherTests
 
         var result = await CreateSut().EnrichGuests(episode);
 
-        result.Additions.Should().Equal("Janja Lalich");
+        result.Additions.Should().ContainSingle()
+            .Which.Person.Name.Should().Be("Janja Lalich");
         episode.Guests.Should().BeEquivalentTo(["Existing Guest", "Janja Lalich"]);
     }
 
@@ -130,7 +132,8 @@ public class EpisodeGuestEnricherTests
             episode,
             GuestEnrichmentOptions.Default with { MinMatchCount = 2 });
 
-        result.Additions.Should().Equal("Janja Lalich");
+        result.Additions.Should().ContainSingle()
+            .Which.Person.Name.Should().Be("Janja Lalich");
         episode.Guests.Should().Equal("Janja Lalich");
     }
 

--- a/Class-Libraries/RedditPodcastPoster.People.Tests/PersonGetNamesTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.People.Tests/PersonGetNamesTests.cs
@@ -8,20 +8,20 @@ public class PersonGetNamesTests
     [Fact]
     public void GetNames_YieldsTrimmedName()
     {
-        var person = new Person("  Ilhan Omar  ");
+        var person = new Person("  Ada Example  ");
 
-        person.GetNames().Should().Equal("Ilhan Omar");
+        person.GetNames().Should().Equal("Ada Example");
     }
 
     [Fact]
     public void GetNames_YieldsTrimmedNameAndAliases()
     {
-        var person = new Person("Ilhan Omar")
+        var person = new Person("Ada Example")
         {
-            Aliases = ["  Ilhan  ", "Omar", "  ", null!]
+            Aliases = ["  Ada  ", "Example", "  ", null!]
         };
 
-        person.GetNames().Should().Equal("Ilhan Omar", "Ilhan", "Omar");
+        person.GetNames().Should().Equal("Ada Example", "Ada", "Example");
     }
 
     [Fact]

--- a/Class-Libraries/RedditPodcastPoster.People.Tests/PersonNameConflictTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.People.Tests/PersonNameConflictTests.cs
@@ -12,22 +12,22 @@ public class PersonNameConflictTests
     [Fact]
     public async Task GetByName_UsesNormalizedKey_CaseInsensitive()
     {
-        var existing = new PersonFactory().Create("Ilhan Omar");
+        var existing = new PersonFactory().Create("Ada Example");
         var repository = new Mock<IPersonRepository>();
         repository
-            .Setup(x => x.GetByName("ilhan omar"))
+            .Setup(x => x.GetByName("ada example"))
             .ReturnsAsync(existing);
 
-        var result = await repository.Object.GetByName("ilhan omar");
+        var result = await repository.Object.GetByName("ada example");
 
         result.Should().BeSameAs(existing);
-        repository.Verify(x => x.GetByName("ilhan omar"), Times.Once);
+        repository.Verify(x => x.GetByName("ada example"), Times.Once);
     }
 
     [Fact]
     public async Task Match_FindsPerson_WhenCaseDiffers()
     {
-        var existing = new PersonFactory().Create("Ilhan Omar");
+        var existing = new PersonFactory().Create("Ada Example");
         var repository = new Mock<IPersonRepository>();
         repository
             .Setup(x => x.GetAll())
@@ -35,7 +35,7 @@ public class PersonNameConflictTests
 
         var sut = new PersonService(repository.Object, Mock.Of<ITextSanitiser>());
 
-        var result = await sut.Match("ilhan omar");
+        var result = await sut.Match("ada example");
 
         result.Should().BeSameAs(existing);
     }
@@ -43,8 +43,8 @@ public class PersonNameConflictTests
     [Fact]
     public void ConflictingNameKeys_AreDetected()
     {
-        var existingKey = Person.NormalizeNameKey("Ilhan Omar");
-        var incomingKey = Person.NormalizeNameKey("ilhan omar");
+        var existingKey = Person.NormalizeNameKey("Ada Example");
+        var incomingKey = Person.NormalizeNameKey("ada example");
         var selfKey = Person.NormalizeNameKey("Someone Else");
 
         (existingKey == incomingKey).Should().BeTrue();

--- a/Class-Libraries/RedditPodcastPoster.People.Tests/PersonNameKeyTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.People.Tests/PersonNameKeyTests.cs
@@ -7,10 +7,10 @@ namespace RedditPodcastPoster.People.Tests;
 public class PersonNameKeyTests
 {
     [Theory]
-    [InlineData("Ilhan Omar", "ilhan omar")]
-    [InlineData("  Ilhan Omar  ", "ilhan omar")]
-    [InlineData("ILHAN OMAR", "ilhan omar")]
-    [InlineData("ilhan omar", "ilhan omar")]
+    [InlineData("Ada Example", "ada example")]
+    [InlineData("  Ada Example  ", "ada example")]
+    [InlineData("ADA EXAMPLE", "ada example")]
+    [InlineData("ada example", "ada example")]
     public void NormalizeNameKey_TrimsAndLowercases(string input, string expected)
     {
         Person.NormalizeNameKey(input).Should().Be(expected);
@@ -28,9 +28,9 @@ public class PersonNameKeyTests
     [Fact]
     public void Constructor_SetsNameKey()
     {
-        var person = new Person("  Ilhan Omar  ");
+        var person = new Person("  Ada Example  ");
 
-        person.NameKey.Should().Be("ilhan omar");
+        person.NameKey.Should().Be("ada example");
     }
 
     [Fact]
@@ -47,17 +47,17 @@ public class PersonNameKeyTests
     [Fact]
     public void PersonFactory_Create_SetsNameKey()
     {
-        var person = new PersonFactory().Create("  Ilhan Omar  ");
+        var person = new PersonFactory().Create("  Ada Example  ");
 
-        person.Name.Should().Be("Ilhan Omar");
-        person.NameKey.Should().Be("ilhan omar");
+        person.Name.Should().Be("Ada Example");
+        person.NameKey.Should().Be("ada example");
     }
 
     [Fact]
     public void NameKeys_DifferingOnlyByCase_AreEqual()
     {
-        var a = Person.NormalizeNameKey("Ilhan Omar");
-        var b = Person.NormalizeNameKey("ilhan omar");
+        var a = Person.NormalizeNameKey("Ada Example");
+        var b = Person.NormalizeNameKey("ada example");
 
         a.Should().Be(b);
     }

--- a/Class-Libraries/RedditPodcastPoster.People.Tests/PersonSortNameTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.People.Tests/PersonSortNameTests.cs
@@ -7,9 +7,9 @@ namespace RedditPodcastPoster.People.Tests;
 public class PersonSortNameTests
 {
     [Theory]
-    [InlineData("Ilhan Omar", "Omar")]
+    [InlineData("Ada Example", "Example")]
     [InlineData("  Mary Smith-Jones  ", "Smith-Jones")]
-    [InlineData("Madonna", "Madonna")]
+    [InlineData("Solara", "Solara")]
     [InlineData("Jean-Luc Picard", "Picard")]
     [InlineData("A B C", "C")]
     public void DeriveSortKeyFromName_UsesLastWhitespaceToken(string name, string expected)
@@ -29,15 +29,15 @@ public class PersonSortNameTests
     [Fact]
     public void GetEffectiveSortKey_NullSortName_DerivesLastToken()
     {
-        Person.GetEffectiveSortKey("Ilhan Omar", null).Should().Be("Omar");
-        Person.GetEffectiveSortKey("Ilhan Omar", "").Should().Be("Omar");
-        Person.GetEffectiveSortKey("Ilhan Omar", "   ").Should().Be("Omar");
+        Person.GetEffectiveSortKey("Ada Example", null).Should().Be("Example");
+        Person.GetEffectiveSortKey("Ada Example", "").Should().Be("Example");
+        Person.GetEffectiveSortKey("Ada Example", "   ").Should().Be("Example");
     }
 
     [Fact]
     public void GetEffectiveSortKey_ExplicitSortName_UsesOverride()
     {
-        Person.GetEffectiveSortKey("Ilhan Omar", "Omar, Ilhan").Should().Be("Omar, Ilhan");
+        Person.GetEffectiveSortKey("Ada Example", "Example, Ada").Should().Be("Example, Ada");
         Person.GetEffectiveSortKey("Something Else", "  Custom  ").Should().Be("Custom");
     }
 
@@ -51,8 +51,8 @@ public class PersonSortNameTests
     [Fact]
     public void Instance_GetEffectiveSortKey_UsesPersistedSortName()
     {
-        var person = new Person("Ilhan Omar") { SortName = null };
-        person.GetEffectiveSortKey().Should().Be("Omar");
+        var person = new Person("Ada Example") { SortName = null };
+        person.GetEffectiveSortKey().Should().Be("Example");
 
         person.SortName = "Church of Scientology";
         person.Name = "Church of Scientology";
@@ -63,31 +63,31 @@ public class PersonSortNameTests
     public void PersonFactory_Create_SetsSortName_WithoutChangingNameKey()
     {
         var person = new PersonFactory().Create(
-            "  Ilhan Omar  ",
-            sortName: "  Omar, Ilhan  ");
+            "  Ada Example  ",
+            sortName: "  Example, Ada  ");
 
-        person.Name.Should().Be("Ilhan Omar");
-        person.NameKey.Should().Be("ilhan omar");
-        person.SortName.Should().Be("Omar, Ilhan");
-        person.GetEffectiveSortKey().Should().Be("Omar, Ilhan");
+        person.Name.Should().Be("Ada Example");
+        person.NameKey.Should().Be("ada example");
+        person.SortName.Should().Be("Example, Ada");
+        person.GetEffectiveSortKey().Should().Be("Example, Ada");
     }
 
     [Fact]
     public void PersonFactory_Create_BlankSortName_LeavesNull()
     {
-        var person = new PersonFactory().Create("Ilhan Omar", sortName: "  ");
+        var person = new PersonFactory().Create("Ada Example", sortName: "  ");
 
         person.SortName.Should().BeNull();
-        person.GetEffectiveSortKey().Should().Be("Omar");
-        person.NameKey.Should().Be("ilhan omar");
+        person.GetEffectiveSortKey().Should().Be("Example");
+        person.NameKey.Should().Be("ada example");
     }
 
     [Theory]
     [InlineData("CNN News Central", true)]
     [InlineData("Church of Scientology", true)]
     [InlineData("University of Michigan", true)]
-    [InlineData("Ilhan Omar", false)]
-    [InlineData("Daniella Mestyanek Young", false)]
+    [InlineData("Ada Example", false)]
+    [InlineData("Casey Compound Surname", false)]
     public void LooksLikeOrganization_DetectsOrgKeywords(string name, bool expected)
     {
         PersonSortNameResolver.LooksLikeOrganization(name).Should().Be(expected);
@@ -96,10 +96,10 @@ public class PersonSortNameTests
     [Fact]
     public void ResolveForPersist_OmitsLastTokenDefault()
     {
-        PersonSortNameResolver.ResolveForPersist("Ilhan Omar", null).Should().BeNull();
-        PersonSortNameResolver.ResolveForPersist("Ilhan Omar", "Omar").Should().BeNull();
-        PersonSortNameResolver.ResolveForPersist("Ilhan Omar", "  Omar  ").Should().BeNull();
-        PersonSortNameResolver.ResolveForPersist("Alan Sherry", null).Should().BeNull();
+        PersonSortNameResolver.ResolveForPersist("Ada Example", null).Should().BeNull();
+        PersonSortNameResolver.ResolveForPersist("Ada Example", "Example").Should().BeNull();
+        PersonSortNameResolver.ResolveForPersist("Ada Example", "  Example  ").Should().BeNull();
+        PersonSortNameResolver.ResolveForPersist("Pat Placeholder", null).Should().BeNull();
     }
 
     [Fact]
@@ -129,8 +129,8 @@ public class PersonSortNameTests
     [Fact]
     public void GuessSortName_Person_UsesLastToken()
     {
-        PersonSortNameResolver.GuessSortName("Ilhan Omar").Should().Be("Omar");
-        PersonSortNameResolver.GuessSortName("Madonna").Should().Be("Madonna");
+        PersonSortNameResolver.GuessSortName("Ada Example").Should().Be("Example");
+        PersonSortNameResolver.GuessSortName("Solara").Should().Be("Solara");
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class PersonSortNameTests
     [Fact]
     public void ResolveForPersist_KeepsManualOverride()
     {
-        PersonSortNameResolver.ResolveForPersist("Daniella Mestyanek Young", "Mestyanek Young")
-            .Should().Be("Mestyanek Young");
+        PersonSortNameResolver.ResolveForPersist("Casey Compound Surname", "Compound Surname")
+            .Should().Be("Compound Surname");
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.People/EpisodeGuestEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.People/EpisodeGuestEnricher.cs
@@ -22,7 +22,7 @@ public class EpisodeGuestEnricher(
         var existing = episode.Guests?.ToHashSet(StringComparer.OrdinalIgnoreCase)
                        ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var additions = new List<string>();
+        var additions = new List<PersonMatch>();
         var skipped = new List<PersonMatch>();
 
         foreach (var match in matches)
@@ -38,14 +38,15 @@ public class EpisodeGuestEnricher(
                 continue;
             }
 
-            additions.Add(match.Person.Name);
+            additions.Add(match);
             existing.Add(match.Person.Name);
         }
 
         if (additions.Count > 0)
         {
+            var addedNames = additions.Select(x => x.Person.Name).ToArray();
             episode.Guests = (episode.Guests ?? [])
-                .Concat(additions)
+                .Concat(addedNames)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
@@ -53,7 +54,7 @@ public class EpisodeGuestEnricher(
                 "{Method}: added {Count} guest(s) [{Guests}] to '{EpisodeTitle}' ({EpisodeId}); skipped {Skipped} low-confidence.",
                 nameof(EnrichGuests),
                 additions.Count,
-                string.Join(", ", additions),
+                string.Join(", ", addedNames),
                 episode.Title,
                 episode.Id,
                 skipped.Count);

--- a/Class-Libraries/RedditPodcastPoster.People/Models/EnrichGuestsResult.cs
+++ b/Class-Libraries/RedditPodcastPoster.People/Models/EnrichGuestsResult.cs
@@ -1,5 +1,5 @@
 namespace RedditPodcastPoster.People.Models;
 
 public record EnrichGuestsResult(
-    string[] Additions,
+    PersonMatch[] Additions,
     PersonMatch[] SkippedLowConfidence);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Categorisers/SpotifyUrlCategoriserRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Categorisers/SpotifyUrlCategoriserRules.cs
@@ -271,6 +271,7 @@ public class SpotifyUrlCategoriserRules
             DurationMs = (int)_fixture.CreateDuration().TotalMilliseconds,
             ReleaseDate = DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd"),
             Explicit = false,
+            IsPlayable = true,
             ExternalUrls = new Dictionary<string, string>
             {
                 ["spotify"] = _fixture.DefaultSpotifyUrl(episodeId).ToString()
@@ -296,7 +297,8 @@ public class SpotifyUrlCategoriserRules
             Name = _fixture.CreateTitle(),
             DurationMs = (int)_fixture.CreateDuration().TotalMilliseconds,
             ReleaseDate = release.ToString("yyyy-MM-dd"),
-            Type = ItemType.Episode
+            Type = ItemType.Episode,
+            IsPlayable = true
         };
 
     private static SpotifyUrlCategoriser CreateSut(ISpotifyEpisodeResolver resolver) =>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Categorisers/SpotifyUrlCategoriserUrlAuthorityRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Categorisers/SpotifyUrlCategoriserUrlAuthorityRules.cs
@@ -151,6 +151,7 @@ public class SpotifyUrlCategoriserUrlAuthorityRules
             DurationMs = (int)_fixture.CreateDuration().TotalMilliseconds,
             ReleaseDate = DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd"),
             Explicit = false,
+            IsPlayable = true,
             ExternalUrls = new Dictionary<string, string>
             {
                 ["spotify"] = _fixture.DefaultSpotifyUrl(episodeId).ToString()

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyEpisodeEnricherCatalogueReleaseReducerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyEpisodeEnricherCatalogueReleaseReducerRules.cs
@@ -96,6 +96,7 @@ public class SpotifyEpisodeEnricherCatalogueReleaseReducerRules
             HtmlDescription = $"<p>{_fixture.Create<string>()}</p>",
             DurationMs = (int)duration.TotalMilliseconds,
             ReleaseDate = release.ToString("yyyy-MM-dd"),
+            IsPlayable = true,
             ExternalUrls = new Dictionary<string, string> { ["spotify"] = spotifyUrl },
             Images = []
         };

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyEpisodeEnricherCatalogueRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyEpisodeEnricherCatalogueRules.cs
@@ -212,6 +212,7 @@ public class SpotifyEpisodeEnricherCatalogueRules
             HtmlDescription = $"<p>{_fixture.Create<string>()}</p>",
             DurationMs = (int)duration.TotalMilliseconds,
             ReleaseDate = release.ToString("yyyy-MM-dd"),
+            IsPlayable = true,
             ExternalUrls = new Dictionary<string, string> { ["spotify"] = spotifyUrl },
             Images = []
         };

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyPodcastEnricherRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyPodcastEnricherRules.cs
@@ -91,7 +91,8 @@ public class SpotifyPodcastEnricherRules
         {
             Id = resolvedEpisodeId,
             Name = episode.Title,
-            ReleaseDate = DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd")
+            ReleaseDate = DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd"),
+            IsPlayable = true
         };
         var podcastResolver = new Mock<ISpotifyPodcastResolver>(MockBehavior.Strict);
         var episodeResolver = new Mock<ISpotifyEpisodeResolver>();

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Extensions/SpotifyEpisodeExtensionsRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Extensions/SpotifyEpisodeExtensionsRules.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
+using RedditPodcastPoster.PodcastServices.Spotify.Models;
 using SpotifyAPI.Web;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Extensions;
@@ -106,6 +107,76 @@ public class SpotifyEpisodeExtensionsRules
 
         // Act / Assert
         episode.IsSpotifyFree().Should().Be(isPlayable);
+    }
+
+    [Fact(DisplayName =
+        "When SimpleEpisode is the base SDK type without Restrictions, GetSpotifyRestrictionReason returns (none) " +
+        "because absent restriction data must still log an explicit reason placeholder.")]
+    public void Simple_episode_without_restrictions_returns_none()
+    {
+        // Arrange
+        var episode = CreateSimpleEpisode(DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd"));
+        episode.IsPlayable = false;
+
+        // Act / Assert
+        episode.GetSpotifyRestrictionReason().Should().Be(SpotifyEpisodeExtensions.AbsentRestrictionReason);
+    }
+
+    [Fact(DisplayName =
+        "When SimpleEpisodeWithRestrictions has restrictions.reason, GetSpotifyRestrictionReason returns that value " +
+        "because skip logs should surface why Spotify marked the episode non-playable.")]
+    public void Simple_episode_with_restriction_reason_returns_reason()
+    {
+        // Arrange
+        var episode = new SimpleEpisodeWithRestrictions
+        {
+            Id = _fixture.CreateSpotifyId(),
+            Name = _fixture.CreateTitle(),
+            ReleaseDate = DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd"),
+            IsPlayable = false,
+            Restrictions = new Dictionary<string, string> { ["reason"] = "payment_required" }
+        };
+
+        // Act / Assert
+        episode.GetSpotifyRestrictionReason().Should().Be("payment_required");
+    }
+
+    [Fact(DisplayName =
+        "When FullEpisodeWithRestrictions has empty Restrictions, GetSpotifyRestrictionReason returns (none) " +
+        "because missing reason must not be logged as a blank value.")]
+    public void Full_episode_with_empty_restrictions_returns_none()
+    {
+        // Arrange
+        var episode = new FullEpisodeWithRestrictions
+        {
+            Id = _fixture.CreateSpotifyId(),
+            Name = _fixture.CreateTitle(),
+            ReleaseDate = DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd"),
+            IsPlayable = false,
+            Restrictions = new Dictionary<string, string>()
+        };
+
+        // Act / Assert
+        episode.GetSpotifyRestrictionReason().Should().Be(SpotifyEpisodeExtensions.AbsentRestrictionReason);
+    }
+
+    [Fact(DisplayName =
+        "When FullEpisodeWithRestrictions has restrictions.reason, GetSpotifyRestrictionReason returns that value " +
+        "because hydrate/enricher skip paths share the same logging helper.")]
+    public void Full_episode_with_restriction_reason_returns_reason()
+    {
+        // Arrange
+        var episode = new FullEpisodeWithRestrictions
+        {
+            Id = _fixture.CreateSpotifyId(),
+            Name = _fixture.CreateTitle(),
+            ReleaseDate = DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd"),
+            IsPlayable = false,
+            Restrictions = new Dictionary<string, string> { ["reason"] = "payment_required" }
+        };
+
+        // Act / Assert
+        episode.GetSpotifyRestrictionReason().Should().Be("payment_required");
     }
 
     private SimpleEpisode CreateSimpleEpisode(string? releaseDate) =>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Extensions/SpotifyEpisodeExtensionsRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Extensions/SpotifyEpisodeExtensionsRules.cs
@@ -78,12 +78,43 @@ public class SpotifyEpisodeExtensionsRules
         result.Should().Be(DateTime.ParseExact(releaseDate, "yyyy-MM-dd", null));
     }
 
+    [Theory(DisplayName =
+        "When SimpleEpisode IsPlayable is set, IsSpotifyFree mirrors that flag " +
+        "because paywall filtering uses IsPlayable as the free-episode signal.")]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Simple_episode_is_spotify_free_matches_is_playable(bool isPlayable)
+    {
+        // Arrange
+        var episode = CreateSimpleEpisode(DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd"));
+        episode.IsPlayable = isPlayable;
+
+        // Act / Assert
+        episode.IsSpotifyFree().Should().Be(isPlayable);
+    }
+
+    [Theory(DisplayName =
+        "When FullEpisode IsPlayable is set, IsSpotifyFree mirrors that flag " +
+        "because enricher and resolver gates share the same free-episode helper.")]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Full_episode_is_spotify_free_matches_is_playable(bool isPlayable)
+    {
+        // Arrange
+        var episode = CreateFullEpisode(DomainTestFixture.UtcDateDaysAgo(1).ToString("yyyy-MM-dd"));
+        episode.IsPlayable = isPlayable;
+
+        // Act / Assert
+        episode.IsSpotifyFree().Should().Be(isPlayable);
+    }
+
     private SimpleEpisode CreateSimpleEpisode(string? releaseDate) =>
         new()
         {
             Id = _fixture.CreateSpotifyId(),
             Name = _fixture.CreateTitle(),
-            ReleaseDate = releaseDate!
+            ReleaseDate = releaseDate!,
+            IsPlayable = true
         };
 
     private FullEpisode CreateFullEpisode(string? releaseDate) =>
@@ -91,6 +122,7 @@ public class SpotifyEpisodeExtensionsRules
         {
             Id = _fixture.CreateSpotifyId(),
             Name = _fixture.CreateTitle(),
-            ReleaseDate = releaseDate!
+            ReleaseDate = releaseDate!,
+            IsPlayable = true
         };
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Providers/SpotifyEpisodeProviderRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Providers/SpotifyEpisodeProviderRules.cs
@@ -99,6 +99,26 @@ public class SpotifyEpisodeProviderRules
         result.ExpensiveQueryFound.Should().BeFalse();
     }
 
+    [Fact(DisplayName =
+        "When a SimpleEpisode has IsPlayable=false, GetEpisodes excludes it from mapped results " +
+        "because paywalled Spotify episodes must not be indexed via the Spotify provider.")]
+    public async Task Non_playable_episode_is_excluded_from_mapped_results()
+    {
+        // Arrange
+        var free = CreateSimpleEpisode(DomainTestFixture.UtcDateDaysAgo(1), isPlayable: true);
+        var paywalled = CreateSimpleEpisode(DomainTestFixture.UtcDateDaysAgo(1), isPlayable: false);
+        var inner = CreateInnerProvider([free, paywalled], expensive: false);
+        var sut = CreateSut(inner.Object);
+        var request = new GetEpisodesRequest(new SpotifyPodcastId(_fixture.CreateSpotifyId()), Market: null);
+
+        // Act
+        var result = await sut.GetEpisodes(request, new IndexingContext());
+
+        // Assert
+        result.Results.Should().ContainSingle();
+        result.Results![0].SpotifyId.Should().Be(free.Id);
+    }
+
     private Mock<ISpotifyPodcastEpisodesProvider> CreateInnerProvider(
         IList<SimpleEpisode> episodes,
         bool expensive)
@@ -110,7 +130,7 @@ public class SpotifyEpisodeProviderRules
         return inner;
     }
 
-    private SimpleEpisode CreateSimpleEpisode(DateTime release)
+    private SimpleEpisode CreateSimpleEpisode(DateTime release, bool isPlayable = true)
     {
         var id = _fixture.CreateSpotifyId();
         return new SimpleEpisode
@@ -121,6 +141,7 @@ public class SpotifyEpisodeProviderRules
             DurationMs = (int)_fixture.CreateDuration().TotalMilliseconds,
             ReleaseDate = release.ToString("yyyy-MM-dd"),
             Explicit = false,
+            IsPlayable = isPlayable,
             ExternalUrls = new Dictionary<string, string>
             {
                 ["spotify"] = _fixture.DefaultSpotifyUrl(id).ToString()

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Providers/SpotifyPodcastEpisodesProviderRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Providers/SpotifyPodcastEpisodesProviderRules.cs
@@ -296,18 +296,56 @@ public class SpotifyPodcastEpisodesProviderRules
             Times.Never);
     }
 
+    [Fact(DisplayName =
+        "When the first page includes a non-playable episode, GetEpisodes excludes it under the expensive-query guard " +
+        "because paywalled Spotify episodes must not enter the catalogue matching cache.")]
+    public async Task Known_id_path_excludes_non_playable_on_first_page()
+    {
+        // Arrange
+        var showId = _fixture.CreateSpotifyId();
+        var free = CreateEpisode(_fixture.CreateSpotifyId(), daysAgo: 1, isPlayable: true);
+        var paywalled = CreateEpisode(_fixture.CreateSpotifyId(), daysAgo: 1, isPlayable: false);
+        var wrapper = new Mock<ISpotifyClientWrapper>();
+        wrapper
+            .Setup(x => x.GetShowEpisodes(
+                showId,
+                It.IsAny<ShowEpisodesRequest>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Paging<SimpleEpisode>
+            {
+                Items = [free, paywalled],
+                Next = "https://api.spotify.com/v1/shows/x/episodes?offset=5"
+            });
+
+        var sut = CreateSut(wrapper.Object, Mock.Of<ISpotifyQueryPaginator>(), Mock.Of<ISpotifySearchResultFinder>());
+        var indexingContext = new IndexingContext(
+            ReleasedSince: DomainTestFixture.UtcDateDaysAgo(2),
+            SkipPodcastDiscovery: true,
+            SkipExpensiveSpotifyQueries: true);
+
+        // Act
+        var result = await sut.GetEpisodes(
+            new GetEpisodesRequest(new SpotifyPodcastId(showId), Market.CountryCode, HasExpensiveSpotifyEpisodesQuery: true),
+            indexingContext);
+
+        // Assert
+        result.Episodes.Select(x => x.Id).Should().ContainSingle().Which.Should().Be(free.Id);
+    }
+
     private static SpotifyPodcastEpisodesProvider CreateSut(
         ISpotifyClientWrapper wrapper,
         ISpotifyQueryPaginator paginator,
         ISpotifySearchResultFinder finder) =>
         new(wrapper, paginator, finder, NullLogger<SpotifyPodcastEpisodesProvider>.Instance);
 
-    private SimpleEpisode CreateEpisode(string id, int daysAgo) =>
+    private SimpleEpisode CreateEpisode(string id, int daysAgo, bool isPlayable = true) =>
         new()
         {
             Id = id,
             Name = _fixture.CreateTitle(),
             ReleaseDate = DomainTestFixture.UtcDateDaysAgo(daysAgo).ToString("yyyy-MM-dd"),
-            Type = ItemType.Episode
+            Type = ItemType.Episode,
+            IsPlayable = isPlayable
         };
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Resolvers/SpotifyEpisodeResolverRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Resolvers/SpotifyEpisodeResolverRules.cs
@@ -55,7 +55,7 @@ public class SpotifyEpisodeResolverRules
     {
         // Arrange
         var episodeId = _fixture.CreateSpotifyId();
-        var fullEpisode = new FullEpisode { Id = episodeId, Name = _fixture.CreateTitle() };
+        var fullEpisode = new FullEpisode { Id = episodeId, Name = _fixture.CreateTitle(), IsPlayable = true };
         var provider = new Mock<ISpotifyPodcastEpisodesProvider>(MockBehavior.Strict);
         var wrapper = new Mock<ISpotifyClientWrapper>();
         wrapper
@@ -105,7 +105,7 @@ public class SpotifyEpisodeResolverRules
         var released = DomainTestFixture.UtcDateDaysAgo(2);
         var matchId = _fixture.CreateSpotifyId();
         var catalogueEpisode = CreateSimpleEpisode(matchId, title, released);
-        var hydrated = new FullEpisode { Id = matchId, Name = title };
+        var hydrated = new FullEpisode { Id = matchId, Name = title, IsPlayable = true };
         var provider = new Mock<ISpotifyPodcastEpisodesProvider>();
         provider
             .Setup(x => x.GetAllEpisodes(
@@ -180,7 +180,7 @@ public class SpotifyEpisodeResolverRules
         var released = DomainTestFixture.UtcDateDaysAgo(1);
         var matchId = _fixture.CreateSpotifyId();
         var catalogueEpisode = CreateSimpleEpisode(matchId, title, released);
-        var hydrated = new FullEpisode { Id = matchId, Name = title };
+        var hydrated = new FullEpisode { Id = matchId, Name = title, IsPlayable = true };
         var provider = new Mock<ISpotifyPodcastEpisodesProvider>();
         provider
             .Setup(x => x.GetAllEpisodes(
@@ -254,7 +254,7 @@ public class SpotifyEpisodeResolverRules
         var released = DomainTestFixture.UtcDateDaysAgo(3);
         var matchId = _fixture.CreateSpotifyId();
         var catalogueEpisode = CreateSimpleEpisode(matchId, title, released, length);
-        var hydrated = new FullEpisode { Id = matchId, Name = title };
+        var hydrated = new FullEpisode { Id = matchId, Name = title, IsPlayable = true };
         Func<SimpleEpisode, bool>? reducer = _ => true;
         var provider = new Mock<ISpotifyPodcastEpisodesProvider>();
         provider
@@ -334,7 +334,7 @@ public class SpotifyEpisodeResolverRules
         var released = DomainTestFixture.UtcDateDaysAgo(4);
         var matchId = _fixture.CreateSpotifyId();
         var catalogueEpisode = CreateSimpleEpisode(matchId, title, released, length);
-        var hydrated = new FullEpisode { Id = matchId, Name = title };
+        var hydrated = new FullEpisode { Id = matchId, Name = title, IsPlayable = true };
         var provider = new Mock<ISpotifyPodcastEpisodesProvider>();
         provider
             .Setup(x => x.GetAllEpisodes(
@@ -439,6 +439,51 @@ public class SpotifyEpisodeResolverRules
             Times.Once);
     }
 
+    [Fact(DisplayName =
+        "When GetFullEpisode returns an episode with IsPlayable=false, FindEpisode returns no episode " +
+        "because paywalled Spotify episodes must not be attached or enriched.")]
+    public async Task Non_playable_full_episode_is_excluded()
+    {
+        // Arrange
+        var episodeId = _fixture.CreateSpotifyId();
+        var paywalled = new FullEpisode
+        {
+            Id = episodeId,
+            Name = _fixture.CreateTitle(),
+            IsPlayable = false
+        };
+        var provider = new Mock<ISpotifyPodcastEpisodesProvider>(MockBehavior.Strict);
+        var wrapper = new Mock<ISpotifyClientWrapper>();
+        wrapper
+            .Setup(x => x.GetFullEpisode(
+                episodeId,
+                It.IsAny<EpisodeRequest>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paywalled);
+        var finder = new Mock<ISpotifySearchResultFinder>(MockBehavior.Strict);
+        var sut = CreateSut(provider.Object, wrapper.Object, finder.Object);
+        var request = new FindSpotifyEpisodeRequest(
+            PodcastSpotifyId: _fixture.CreateSpotifyId(),
+            PodcastName: _fixture.CreateTitle(),
+            EpisodeSpotifyId: episodeId,
+            EpisodeTitle: _fixture.CreateTitle(),
+            Released: DomainTestFixture.UtcDateDaysAgo(1),
+            HasExpensiveSpotifyEpisodesQuery: false);
+
+        // Act
+        var result = await sut.FindEpisode(request, new IndexingContext());
+
+        // Assert
+        result.FullEpisode.Should().BeNull();
+        provider.Verify(
+            x => x.GetAllEpisodes(
+                It.IsAny<FindSpotifyEpisodeRequest>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<string>()),
+            Times.Never);
+    }
+
     private SimpleEpisode CreateSimpleEpisode(
         string id,
         string title,
@@ -450,7 +495,8 @@ public class SpotifyEpisodeResolverRules
             Name = title,
             DurationMs = (int)(length ?? _fixture.CreateDuration()).TotalMilliseconds,
             ReleaseDate = release.ToString("yyyy-MM-dd"),
-            Type = ItemType.Episode
+            Type = ItemType.Episode,
+            IsPlayable = true
         };
 
     private static SpotifyEpisodeResolver CreateSut(

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Search/SpotifySearcherRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Search/SpotifySearcherRules.cs
@@ -220,11 +220,41 @@ public class SpotifySearcherRules
         return client;
     }
 
+    [Fact(DisplayName =
+        "When a search hit has IsPlayable=false, Search excludes it before hydrate " +
+        "because paywalled Spotify episodes must not enter discovery results.")]
+    public async Task Non_playable_search_hit_is_excluded()
+    {
+        // Arrange
+        const string query = "cultists";
+        var episodeId = _fixture.CreateSpotifyId();
+        var searchHit = CreateSimpleEpisode(
+            episodeId,
+            name: $"Interview with {query} today",
+            release: DomainTestFixture.UtcDateDaysAgo(1),
+            isPlayable: false);
+        var client = CreateClientReturning([searchHit], fullEpisode: null);
+        var sut = CreateSut(client.Object);
+
+        // Act
+        var results = await sut.Search(query, new IndexingContext(ReleasedSince: DomainTestFixture.UtcDateDaysAgo(3)));
+
+        // Assert
+        results.Should().BeEmpty();
+        client.Verify(
+            x => x.GetSeveral(
+                It.IsAny<EpisodesRequest>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private SimpleEpisode CreateSimpleEpisode(
         string id,
         string name,
         DateTime release,
-        string? description = null) =>
+        string? description = null,
+        bool isPlayable = true) =>
         new()
         {
             Id = id,
@@ -232,7 +262,8 @@ public class SpotifySearcherRules
             Description = description ?? _fixture.CreateTitle(),
             DurationMs = (int)_fixture.CreateDuration().TotalMilliseconds,
             ReleaseDate = release.ToString("yyyy-MM-dd"),
-            Type = ItemType.Episode
+            Type = ItemType.Episode,
+            IsPlayable = isPlayable
         };
 
     private FullEpisode CreateFullEpisode(string episodeId, string title, DateTime release)
@@ -246,6 +277,7 @@ public class SpotifySearcherRules
             DurationMs = (int)_fixture.CreateDuration().TotalMilliseconds,
             ReleaseDate = release.ToString("yyyy-MM-dd"),
             Explicit = false,
+            IsPlayable = true,
             ExternalUrls = new Dictionary<string, string>
             {
                 ["spotify"] = _fixture.DefaultSpotifyUrl(episodeId).ToString()

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Serialization/SpotifyEpisodeRestrictionsConverterRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Serialization/SpotifyEpisodeRestrictionsConverterRules.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using RedditPodcastPoster.PodcastServices.Spotify.Models;
+using RedditPodcastPoster.PodcastServices.Spotify.Serialization;
+using SpotifyAPI.Web;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Serialization;
+
+public class SpotifyEpisodeRestrictionsConverterRules
+{
+    private readonly JsonSerializerSettings _settings = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore,
+        ContractResolver = new DefaultContractResolver
+        {
+            NamingStrategy = new SnakeCaseNamingStrategy()
+        },
+        Converters = { new SpotifyEpisodeRestrictionsConverter() }
+    };
+
+    [Fact(DisplayName =
+        "When SimpleEpisode JSON includes restrictions.reason, deserialize yields SimpleEpisodeWithRestrictions " +
+        "because SpotifyAPI.Web 7.4.2 does not model episode Restrictions.")]
+    public void Simple_episode_json_with_restrictions_deserializes_subclass()
+    {
+        // Arrange
+        const string json = """
+            {
+              "id": "abc123",
+              "name": "Paywalled",
+              "is_playable": false,
+              "restrictions": { "reason": "payment_required" },
+              "type": "episode"
+            }
+            """;
+
+        // Act
+        var episode = JsonConvert.DeserializeObject<SimpleEpisode>(json, _settings);
+
+        // Assert
+        episode.Should().BeOfType<SimpleEpisodeWithRestrictions>();
+        var withRestrictions = (SimpleEpisodeWithRestrictions)episode!;
+        withRestrictions.IsPlayable.Should().BeFalse();
+        withRestrictions.Restrictions.Should().ContainKey("reason")
+            .WhoseValue.Should().Be("payment_required");
+    }
+
+    [Fact(DisplayName =
+        "When FullEpisode JSON includes restrictions.reason, deserialize yields FullEpisodeWithRestrictions " +
+        "because hydrate paths also need the reason for non-playable skip logs.")]
+    public void Full_episode_json_with_restrictions_deserializes_subclass()
+    {
+        // Arrange
+        const string json = """
+            {
+              "id": "xyz789",
+              "name": "Paywalled Full",
+              "is_playable": false,
+              "restrictions": { "reason": "payment_required" },
+              "type": "episode"
+            }
+            """;
+
+        // Act
+        var episode = JsonConvert.DeserializeObject<FullEpisode>(json, _settings);
+
+        // Assert
+        episode.Should().BeOfType<FullEpisodeWithRestrictions>();
+        var withRestrictions = (FullEpisodeWithRestrictions)episode!;
+        withRestrictions.Restrictions.Should().ContainKey("reason")
+            .WhoseValue.Should().Be("payment_required");
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Categorisers/SpotifyUrlCategoriser.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Categorisers/SpotifyUrlCategoriser.cs
@@ -91,6 +91,15 @@ public class SpotifyUrlCategoriser(
             return null;
         }
 
+        if (!findEpisodeResponse.FullEpisode.IsSpotifyFree())
+        {
+            logger.LogWarning(
+                "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                findEpisodeResponse.FullEpisode.Id,
+                findEpisodeResponse.FullEpisode.Name);
+            return null;
+        }
+
         return new ResolvedSpotifyItem(
             findEpisodeResponse.FullEpisode.Show.Id,
             findEpisodeResponse.FullEpisode.Id,
@@ -133,6 +142,16 @@ public class SpotifyUrlCategoriser(
             indexingContext);
         if (findEpisodeResponse.FullEpisode != null)
         {
+            if (!findEpisodeResponse.FullEpisode.IsSpotifyFree())
+            {
+                logger.LogWarning(
+                    "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                    findEpisodeResponse.FullEpisode.Id,
+                    findEpisodeResponse.FullEpisode.Name);
+                throw new InvalidOperationException(
+                    $"Spotify episode '{episodeId}' is not free/playable.");
+            }
+
             return new ResolvedSpotifyItem(
                 findEpisodeResponse.FullEpisode.Show.Id,
                 findEpisodeResponse.FullEpisode.Id,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Categorisers/SpotifyUrlCategoriser.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Categorisers/SpotifyUrlCategoriser.cs
@@ -94,9 +94,10 @@ public class SpotifyUrlCategoriser(
         if (!findEpisodeResponse.FullEpisode.IsSpotifyFree())
         {
             logger.LogWarning(
-                "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
                 findEpisodeResponse.FullEpisode.Id,
-                findEpisodeResponse.FullEpisode.Name);
+                findEpisodeResponse.FullEpisode.Name,
+                findEpisodeResponse.FullEpisode.GetSpotifyRestrictionReason());
             return null;
         }
 
@@ -145,9 +146,10 @@ public class SpotifyUrlCategoriser(
             if (!findEpisodeResponse.FullEpisode.IsSpotifyFree())
             {
                 logger.LogWarning(
-                    "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                    "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
                     findEpisodeResponse.FullEpisode.Id,
-                    findEpisodeResponse.FullEpisode.Name);
+                    findEpisodeResponse.FullEpisode.Name,
+                    findEpisodeResponse.FullEpisode.GetSpotifyRestrictionReason());
                 throw new InvalidOperationException(
                     $"Spotify episode '{episodeId}' is not free/playable.");
             }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyEpisodeEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyEpisodeEnricher.cs
@@ -1,82 +1,90 @@
-﻿using Microsoft.Extensions.Logging;
-using RedditPodcastPoster.Episodes.Adapters;
-using RedditPodcastPoster.Episodes.Adapters.Inputs;
-using RedditPodcastPoster.Episodes.Applying;
-using RedditPodcastPoster.Episodes.Matching;
-using RedditPodcastPoster.Models;
-using RedditPodcastPoster.PodcastServices.Abstractions;
-using RedditPodcastPoster.PodcastServices.Abstractions.Enriching;
-using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
-using RedditPodcastPoster.PodcastServices.Spotify.Factories;
-using RedditPodcastPoster.PodcastServices.Spotify.Mapping;
-using RedditPodcastPoster.PodcastServices.Spotify.Resolvers;
-using RedditPodcastPoster.Text;
-
-namespace RedditPodcastPoster.PodcastServices.Spotify.Enrichers;
-
-public class SpotifyEpisodeEnricher(
-    ISpotifyEpisodeResolver spotifyEpisodeResolver,
-    IEpisodePlatformMatcher platformMatcher,
-    IEpisodeCatalogueAdapter<SpotifyCatalogueInput> spotifyAdapter,
-    IPlatformEnrichmentApplicator enrichmentApplicator,
-    ISpotifyEnrichmentSideEffect enrichmentSideEffect,
-    IHtmlSanitiser htmlSanitiser,
-    ILogger<SpotifyEpisodeEnricher> logger)
-    : PlatformEpisodeEnricherTemplate(enrichmentApplicator), ISpotifyEpisodeEnricher
-{
-    public async Task Enrich(
-        EnrichmentRequest request,
-        IndexingContext indexingContext,
-        EnrichmentContext enrichmentContext)
-    {
-        if (IsBypassedByDelayedYouTubePublishing(request, "Spotify", logger))
-        {
-            return;
-        }
-
-        var findSpotifyEpisodeRequest = FindSpotifyEpisodeRequestFactory.Create(request.Podcast, request.Episode);
-        var probeEpisode = new Episode
-        {
-            Title = request.Episode.Title,
-            Length = request.Episode.Length,
-            Release = findSpotifyEpisodeRequest.Released ?? request.Episode.Release
-        };
-        var assignedSpotifyIds = request.Episodes
-            .Where(x => !string.IsNullOrWhiteSpace(x.SpotifyId))
-            .Select(x => x.SpotifyId)
-            .ToHashSet(StringComparer.Ordinal);
-
-        var findEpisodeResult = await spotifyEpisodeResolver.FindEpisode(
-            findSpotifyEpisodeRequest,
-            indexingContext,
-            y => !assignedSpotifyIds.Contains(y.Id) &&
-                 findSpotifyEpisodeRequest.Released.HasValue &&
-                 platformMatcher.CatalogueReleaseMatches(
-                     probeEpisode,
-                     new Episode
-                     {
-                         Title = y.Name,
-                         Length = y.GetDuration(),
-                         Release = y.GetReleaseDate(),
-                         SpotifyId = y.Id
-                     },
-                     request.Podcast));
-
-        if (findEpisodeResult.FullEpisode != null &&
-            request.Episodes.All(x => x.SpotifyId != findEpisodeResult.FullEpisode.Id))
-        {
-            logger.LogInformation(
-                "{EnrichName} Found matching Spotify episode: '{FullEpisodeId}' with title '{FullEpisodeName}' and release-date '{FullEpisodeReleaseDate}'.",
-                nameof(Enrich),
-                findEpisodeResult.FullEpisode.Id,
-                findEpisodeResult.FullEpisode.Name,
-                findEpisodeResult.FullEpisode.ReleaseDate);
-
-            var catalogueInput = findEpisodeResult.FullEpisode.ToCatalogueInput(htmlSanitiser);
-            ApplyResolvedCandidate(request, spotifyAdapter.Adapt(catalogueInput), enrichmentContext);
-        }
-
-        enrichmentSideEffect.OnFindComplete(request.Podcast, findEpisodeResult.IsExpensiveQuery);
-    }
-}
+﻿using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes.Adapters;
+using RedditPodcastPoster.Episodes.Adapters.Inputs;
+using RedditPodcastPoster.Episodes.Applying;
+using RedditPodcastPoster.Episodes.Matching;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.Abstractions.Enriching;
+using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
+using RedditPodcastPoster.PodcastServices.Spotify.Factories;
+using RedditPodcastPoster.PodcastServices.Spotify.Mapping;
+using RedditPodcastPoster.PodcastServices.Spotify.Resolvers;
+using RedditPodcastPoster.Text;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Enrichers;
+
+public class SpotifyEpisodeEnricher(
+    ISpotifyEpisodeResolver spotifyEpisodeResolver,
+    IEpisodePlatformMatcher platformMatcher,
+    IEpisodeCatalogueAdapter<SpotifyCatalogueInput> spotifyAdapter,
+    IPlatformEnrichmentApplicator enrichmentApplicator,
+    ISpotifyEnrichmentSideEffect enrichmentSideEffect,
+    IHtmlSanitiser htmlSanitiser,
+    ILogger<SpotifyEpisodeEnricher> logger)
+    : PlatformEpisodeEnricherTemplate(enrichmentApplicator), ISpotifyEpisodeEnricher
+{
+    public async Task Enrich(
+        EnrichmentRequest request,
+        IndexingContext indexingContext,
+        EnrichmentContext enrichmentContext)
+    {
+        if (IsBypassedByDelayedYouTubePublishing(request, "Spotify", logger))
+        {
+            return;
+        }
+
+        var findSpotifyEpisodeRequest = FindSpotifyEpisodeRequestFactory.Create(request.Podcast, request.Episode);
+        var probeEpisode = new Episode
+        {
+            Title = request.Episode.Title,
+            Length = request.Episode.Length,
+            Release = findSpotifyEpisodeRequest.Released ?? request.Episode.Release
+        };
+        var assignedSpotifyIds = request.Episodes
+            .Where(x => !string.IsNullOrWhiteSpace(x.SpotifyId))
+            .Select(x => x.SpotifyId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var findEpisodeResult = await spotifyEpisodeResolver.FindEpisode(
+            findSpotifyEpisodeRequest,
+            indexingContext,
+            y => !assignedSpotifyIds.Contains(y.Id) &&
+                 findSpotifyEpisodeRequest.Released.HasValue &&
+                 platformMatcher.CatalogueReleaseMatches(
+                     probeEpisode,
+                     new Episode
+                     {
+                         Title = y.Name,
+                         Length = y.GetDuration(),
+                         Release = y.GetReleaseDate(),
+                         SpotifyId = y.Id
+                     },
+                     request.Podcast));
+
+        if (findEpisodeResult.FullEpisode != null &&
+            !findEpisodeResult.FullEpisode.IsSpotifyFree())
+        {
+            logger.LogWarning(
+                "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                findEpisodeResult.FullEpisode.Id,
+                findEpisodeResult.FullEpisode.Name);
+        }
+        else if (findEpisodeResult.FullEpisode != null &&
+            request.Episodes.All(x => x.SpotifyId != findEpisodeResult.FullEpisode.Id))
+        {
+            logger.LogInformation(
+                "{EnrichName} Found matching Spotify episode: '{FullEpisodeId}' with title '{FullEpisodeName}' and release-date '{FullEpisodeReleaseDate}'.",
+                nameof(Enrich),
+                findEpisodeResult.FullEpisode.Id,
+                findEpisodeResult.FullEpisode.Name,
+                findEpisodeResult.FullEpisode.ReleaseDate);
+
+            var catalogueInput = findEpisodeResult.FullEpisode.ToCatalogueInput(htmlSanitiser);
+            ApplyResolvedCandidate(request, spotifyAdapter.Adapt(catalogueInput), enrichmentContext);
+        }
+
+        enrichmentSideEffect.OnFindComplete(request.Podcast, findEpisodeResult.IsExpensiveQuery);
+    }
+}
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyEpisodeEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyEpisodeEnricher.cs
@@ -66,9 +66,10 @@ public class SpotifyEpisodeEnricher(
             !findEpisodeResult.FullEpisode.IsSpotifyFree())
         {
             logger.LogWarning(
-                "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
                 findEpisodeResult.FullEpisode.Id,
-                findEpisodeResult.FullEpisode.Name);
+                findEpisodeResult.FullEpisode.Name,
+                findEpisodeResult.FullEpisode.GetSpotifyRestrictionReason());
         }
         else if (findEpisodeResult.FullEpisode != null &&
             request.Episodes.All(x => x.SpotifyId != findEpisodeResult.FullEpisode.Id))

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyPodcastEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyPodcastEnricher.cs
@@ -10,9 +10,7 @@ namespace RedditPodcastPoster.PodcastServices.Spotify.Enrichers;
 public class SpotifyPodcastEnricher(
     ISpotifyEpisodeResolver spotifyIdResolver,
     ISpotifyPodcastResolver spotifyPodcastResolver,
-#pragma warning disable CS9113 // Parameter is unread.
     ILogger<SpotifyPodcastEnricher> logger)
-#pragma warning restore CS9113 // Parameter is unread.
     : ISpotifyPodcastEnricher
 {
     public async Task<bool> AddIdAndUrls(Podcast podcast, IEnumerable<Episode> episodes, IndexingContext indexingContext)
@@ -48,7 +46,15 @@ public class SpotifyPodcastEnricher(
                             podcast,
                             podcastEpisode),
                         indexingContext);
-                    if (!string.IsNullOrWhiteSpace(findEpisodeResponse.FullEpisode?.Id))
+                    if (findEpisodeResponse.FullEpisode != null &&
+                        !findEpisodeResponse.FullEpisode.IsSpotifyFree())
+                    {
+                        logger.LogWarning(
+                            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                            findEpisodeResponse.FullEpisode.Id,
+                            findEpisodeResponse.FullEpisode.Name);
+                    }
+                    else if (!string.IsNullOrWhiteSpace(findEpisodeResponse.FullEpisode?.Id))
                     {
                         podcastEpisode.SpotifyId = findEpisodeResponse.FullEpisode.Id;
                         podcastShouldUpdate = true;

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyPodcastEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyPodcastEnricher.cs
@@ -50,9 +50,10 @@ public class SpotifyPodcastEnricher(
                         !findEpisodeResponse.FullEpisode.IsSpotifyFree())
                     {
                         logger.LogWarning(
-                            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
                             findEpisodeResponse.FullEpisode.Id,
-                            findEpisodeResponse.FullEpisode.Name);
+                            findEpisodeResponse.FullEpisode.Name,
+                            findEpisodeResponse.FullEpisode.GetSpotifyRestrictionReason());
                     }
                     else if (!string.IsNullOrWhiteSpace(findEpisodeResponse.FullEpisode?.Id))
                     {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Extensions/SpotifyEpisodeExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Extensions/SpotifyEpisodeExtensions.cs
@@ -7,6 +7,15 @@ public static class SpotifyEpisodeExtensions
 {
     private const string SpotifyDateFormat = "yyyy-MM-dd";
 
+    /// <summary>
+    /// Spotify marks paywalled episodes with <c>is_playable=false</c> when a market is requested.
+    /// Prefer this over <c>restrictions.reason</c>, which SpotifyAPI.Web may not deserialize.
+    /// </summary>
+    public static bool IsSpotifyFree(this SimpleEpisode episode) => episode.IsPlayable;
+
+    /// <inheritdoc cref="IsSpotifyFree(SimpleEpisode)"/>
+    public static bool IsSpotifyFree(this FullEpisode episode) => episode.IsPlayable;
+
     public static DateTime GetReleaseDate(this SimpleEpisode episode)
     {
         if (episode.ReleaseDate is null or "0000")

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Extensions/SpotifyEpisodeExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Extensions/SpotifyEpisodeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using RedditPodcastPoster.PodcastServices.Spotify.Models;
 using SpotifyAPI.Web;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Extensions;
@@ -8,13 +9,50 @@ public static class SpotifyEpisodeExtensions
     private const string SpotifyDateFormat = "yyyy-MM-dd";
 
     /// <summary>
+    /// Logged when Spotify omits <c>restrictions</c> or does not include a <c>reason</c> value.
+    /// </summary>
+    public const string AbsentRestrictionReason = "(none)";
+
+    /// <summary>
     /// Spotify marks paywalled episodes with <c>is_playable=false</c> when a market is requested.
-    /// Prefer this over <c>restrictions.reason</c>, which SpotifyAPI.Web may not deserialize.
+    /// Use <see cref="GetSpotifyRestrictionReason(SimpleEpisode)"/> for the accompanying reason when logging skips.
     /// </summary>
     public static bool IsSpotifyFree(this SimpleEpisode episode) => episode.IsPlayable;
 
     /// <inheritdoc cref="IsSpotifyFree(SimpleEpisode)"/>
     public static bool IsSpotifyFree(this FullEpisode episode) => episode.IsPlayable;
+
+    /// <summary>
+    /// Returns Spotify <c>restrictions.reason</c> when captured on our episode subclass; otherwise <see cref="AbsentRestrictionReason"/>.
+    /// </summary>
+    public static string GetSpotifyRestrictionReason(this SimpleEpisode episode)
+    {
+        ArgumentNullException.ThrowIfNull(episode);
+        return GetReasonFromMap(episode is SimpleEpisodeWithRestrictions withRestrictions
+            ? withRestrictions.Restrictions
+            : null);
+    }
+
+    /// <inheritdoc cref="GetSpotifyRestrictionReason(SimpleEpisode)"/>
+    public static string GetSpotifyRestrictionReason(this FullEpisode episode)
+    {
+        ArgumentNullException.ThrowIfNull(episode);
+        return GetReasonFromMap(episode is FullEpisodeWithRestrictions withRestrictions
+            ? withRestrictions.Restrictions
+            : null);
+    }
+
+    private static string GetReasonFromMap(IReadOnlyDictionary<string, string>? restrictions)
+    {
+        if (restrictions != null &&
+            restrictions.TryGetValue("reason", out var reason) &&
+            !string.IsNullOrWhiteSpace(reason))
+        {
+            return reason;
+        }
+
+        return AbsentRestrictionReason;
+    }
 
     public static DateTime GetReleaseDate(this SimpleEpisode episode)
     {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Factories/SpotifyClientConfigFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Factories/SpotifyClientConfigFactory.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RedditPodcastPoster.PodcastServices.Spotify.Configuration;
+using RedditPodcastPoster.PodcastServices.Spotify.Serialization;
 using SpotifyAPI.Web;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Factories;
@@ -21,7 +22,9 @@ public class SpotifyClientConfigFactory(
             _settings.ClientSecret[^2..]
         );
 
-        var config = SpotifyClientConfig.CreateDefault();
+        var config = SpotifyClientConfig
+            .CreateDefault()
+            .WithJSONSerializer(new SpotifyEpisodeRestrictionsJsonSerializer());
 
         var token = await GetToken(config);
         if (token == null)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/FullEpisodeWithRestrictions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/FullEpisodeWithRestrictions.cs
@@ -1,0 +1,15 @@
+using SpotifyAPI.Web;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Models;
+
+/// <summary>
+/// SpotifyAPI.Web 7.4.2 deserializes <see cref="FullEpisode.IsPlayable"/> but omits
+/// <c>restrictions</c>. Subclass captures it for skip-logging only (not persisted on Episode).
+/// </summary>
+public class FullEpisodeWithRestrictions : FullEpisode
+{
+    /// <summary>
+    /// Spotify restriction map; typically contains key <c>reason</c> (e.g. <c>payment_required</c>).
+    /// </summary>
+    public Dictionary<string, string>? Restrictions { get; set; }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/SimpleEpisodeWithRestrictions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/SimpleEpisodeWithRestrictions.cs
@@ -1,0 +1,15 @@
+using SpotifyAPI.Web;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Models;
+
+/// <summary>
+/// SpotifyAPI.Web 7.4.2 deserializes <see cref="SimpleEpisode.IsPlayable"/> but omits
+/// <c>restrictions</c>. Subclass captures it for skip-logging only (not persisted on Episode).
+/// </summary>
+public class SimpleEpisodeWithRestrictions : SimpleEpisode
+{
+    /// <summary>
+    /// Spotify restriction map; typically contains key <c>reason</c> (e.g. <c>payment_required</c>).
+    /// </summary>
+    public Dictionary<string, string>? Restrictions { get; set; }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyEpisodeProvider.cs
@@ -46,9 +46,10 @@ public class SpotifyEpisodeProvider(
         }
 
         logger.LogWarning(
-            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
             episode.Id,
-            episode.Name);
+            episode.Name,
+            episode.GetSpotifyRestrictionReason());
         return false;
     }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyEpisodeProvider.cs
@@ -16,9 +16,7 @@ public class SpotifyEpisodeProvider(
     IHtmlSanitiser htmlSanitiser,
     IEpisodeCatalogueAdapter<SpotifyCatalogueInput> spotifyEpisodeAdapter,
     IEpisodeFromCandidateFactory episodeFromCandidateFactory,
-#pragma warning disable CS9113 // Parameter is unread.
     ILogger<SpotifyEpisodeProvider> logger)
-#pragma warning restore CS9113 // Parameter is unread.
     : ISpotifyEpisodeProvider
 {
     public async Task<GetEpisodesResponse> GetEpisodes(GetEpisodesRequest request, IndexingContext indexingContext)
@@ -33,9 +31,25 @@ public class SpotifyEpisodeProvider(
             episodes = episodes.Where(x => x.GetReleaseDate() >= indexingContext.ReleasedSince.Value);
         }
 
+        episodes = episodes.Where(IsFreeSpotifyEpisode).ToList();
+
         return new GetEpisodesResponse(
             episodes.Select(MapEpisode).ToList(),
             expensiveQueryFound);
+    }
+
+    private bool IsFreeSpotifyEpisode(SpotifyAPI.Web.SimpleEpisode episode)
+    {
+        if (episode.IsSpotifyFree())
+        {
+            return true;
+        }
+
+        logger.LogWarning(
+            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+            episode.Id,
+            episode.Name);
+        return false;
     }
 
     private Episode MapEpisode(SpotifyAPI.Web.SimpleEpisode episode)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyPodcastEpisodesProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyPodcastEpisodesProvider.cs
@@ -170,9 +170,10 @@ public class SpotifyPodcastEpisodesProvider(
             if (!episode.IsSpotifyFree())
             {
                 logger.LogWarning(
-                    "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                    "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
                     episode.Id,
-                    episode.Name);
+                    episode.Name,
+                    episode.GetSpotifyRestrictionReason());
                 continue;
             }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyPodcastEpisodesProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyPodcastEpisodesProvider.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Spotify.Client;
+using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
 using RedditPodcastPoster.PodcastServices.Spotify.Finders;
 using RedditPodcastPoster.PodcastServices.Spotify.Models;
 using RedditPodcastPoster.PodcastServices.Spotify.Paginators;
@@ -95,12 +96,13 @@ public class SpotifyPodcastEpisodesProvider(
             if (allEpisodes.Any())
             {
                 return new PodcastEpisodesResult(
-                    allEpisodes
-                        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-                        .Where(x => x != null && x.Any())
-                        .SelectMany(x => x)
-                        .GroupBy(x => x.Id)
-                        .Select(x => x.First()),
+                    TakeFreeEpisodes(
+                        allEpisodes
+                            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+                            .Where(x => x != null && x.Any())
+                            .SelectMany(x => x)
+                            .GroupBy(x => x.Id)
+                            .Select(x => x.First())),
                     expensiveQueryFound);
             }
         }
@@ -143,11 +145,40 @@ public class SpotifyPodcastEpisodesProvider(
             logger.LogInformation(
                 "{nameofGetEpisodes} - Skipping pagination of query results as {nameofSkipExpensiveSpotifyQueries} is set.",
                 nameof(GetEpisodes), nameof(indexingContext.SkipExpensiveSpotifyQueries));
-            return new PodcastEpisodesResult(pagedEpisodes?.Items ?? []);
+            return new PodcastEpisodesResult(TakeFreeEpisodes(pagedEpisodes?.Items ?? []));
         }
 
         var results = await spotifyQueryPaginator.PaginateEpisodes(pagedEpisodes, indexingContext);
-        _cache[request.SpotifyPodcastId.PodcastId] = results;
-        return results;
+        var freeResults = new PodcastEpisodesResult(
+            TakeFreeEpisodes(results.Episodes),
+            results.ExpensiveQueryFound);
+        _cache[request.SpotifyPodcastId.PodcastId] = freeResults;
+        return freeResults;
+    }
+
+    private List<SimpleEpisode> TakeFreeEpisodes(IEnumerable<SimpleEpisode> episodes)
+    {
+        var free = new List<SimpleEpisode>();
+        foreach (var episode in episodes)
+        {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (episode == null)
+            {
+                continue;
+            }
+
+            if (!episode.IsSpotifyFree())
+            {
+                logger.LogWarning(
+                    "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                    episode.Id,
+                    episode.Name);
+                continue;
+            }
+
+            free.Add(episode);
+        }
+
+        return free;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
@@ -82,9 +82,10 @@ public class SpotifyEpisodeResolver(
         }
 
         logger.LogWarning(
-            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
             episode.Id,
-            episode.Name);
+            episode.Name,
+            episode.GetSpotifyRestrictionReason());
         return null;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
@@ -39,7 +39,7 @@ public class SpotifyEpisodeResolver(
             fullEpisode = await spotifyClientWrapper.GetFullEpisode(request.EpisodeSpotifyId, episodeRequest, indexingContext);
             if (fullEpisode != null)
             {
-                return new FindEpisodeResponse(fullEpisode);
+                return new FindEpisodeResponse(TakeIfFree(fullEpisode));
             }
         }
 
@@ -71,6 +71,20 @@ public class SpotifyEpisodeResolver(
             fullEpisode = await spotifyClientWrapper.GetFullEpisode(matchingEpisode.Id, showRequest, indexingContext);
         }
 
-        return new FindEpisodeResponse(fullEpisode, podcastEpisodes.ExpensiveQueryFound);
+        return new FindEpisodeResponse(TakeIfFree(fullEpisode), podcastEpisodes.ExpensiveQueryFound);
+    }
+
+    private FullEpisode? TakeIfFree(FullEpisode? episode)
+    {
+        if (episode == null || episode.IsSpotifyFree())
+        {
+            return episode;
+        }
+
+        logger.LogWarning(
+            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+            episode.Id,
+            episode.Name);
+        return null;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Search/SpotifySearcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Search/SpotifySearcher.cs
@@ -38,12 +38,27 @@ public class SpotifySearcher(
             var termRegex = new Regex(queryRegexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             var allResults = await spotifyClient.PaginateAll(results, response => response.Episodes, indexingContext);
 
-            var recentResults =
-                allResults?
-                    .Where(x =>
-                        x != null &&
-                        x.GetReleaseDate() >= indexingContext.ReleasedSince &&
-                        (termRegex.IsMatch(x.Name) || termRegex.IsMatch(x.Description))) ?? [];
+            var recentResults = new List<SimpleEpisode>();
+            foreach (var hit in allResults ?? [])
+            {
+                if (hit == null ||
+                    hit.GetReleaseDate() < indexingContext.ReleasedSince ||
+                    (!termRegex.IsMatch(hit.Name) && !termRegex.IsMatch(hit.Description)))
+                {
+                    continue;
+                }
+
+                if (!hit.IsSpotifyFree())
+                {
+                    logger.LogWarning(
+                        "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                        hit.Id,
+                        hit.Name);
+                    continue;
+                }
+
+                recentResults.Add(hit);
+            }
 
             if (recentResults.Any())
             {
@@ -60,7 +75,9 @@ public class SpotifySearcher(
                         nameof(Search), episodeIds.Length, query, string.Join(",", episodeIds));
                 }
 
-                var episodeResults = fullShows?.Episodes.Select(ToEpisodeResult) ?? Enumerable.Empty<EpisodeResult>();
+                var episodeResults = fullShows?.Episodes
+                    .Where(IsFreeFullEpisode)
+                    .Select(ToEpisodeResult) ?? Enumerable.Empty<EpisodeResult>();
                 logger.LogInformation(
                     "{SearchName}: Found {Count} items from spotify matching query '{Query}'.", nameof(Search), episodeResults.Count(x => x.Released >= indexingContext.ReleasedSince), query);
 
@@ -70,6 +87,20 @@ public class SpotifySearcher(
 
         logger.LogInformation("{SearchName}: Found no items from spotify matching query '{Query}'.", nameof(Search), query);
         return new List<EpisodeResult>();
+    }
+
+    private bool IsFreeFullEpisode(FullEpisode episode)
+    {
+        if (episode.IsSpotifyFree())
+        {
+            return true;
+        }
+
+        logger.LogWarning(
+            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+            episode.Id,
+            episode.Name);
+        return false;
     }
 
     private EpisodeResult ToEpisodeResult(FullEpisode episode)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Search/SpotifySearcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Search/SpotifySearcher.cs
@@ -51,9 +51,10 @@ public class SpotifySearcher(
                 if (!hit.IsSpotifyFree())
                 {
                     logger.LogWarning(
-                        "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+                        "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
                         hit.Id,
-                        hit.Name);
+                        hit.Name,
+                        hit.GetSpotifyRestrictionReason());
                     continue;
                 }
 
@@ -97,9 +98,10 @@ public class SpotifySearcher(
         }
 
         logger.LogWarning(
-            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false).",
+            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
             episode.Id,
-            episode.Name);
+            episode.Name,
+            episode.GetSpotifyRestrictionReason());
         return false;
     }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Serialization/SpotifyEpisodeRestrictionsConverter.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Serialization/SpotifyEpisodeRestrictionsConverter.cs
@@ -1,0 +1,33 @@
+using Newtonsoft.Json;
+using RedditPodcastPoster.PodcastServices.Spotify.Models;
+using SpotifyAPI.Web;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Serialization;
+
+/// <summary>
+/// Deserializes Spotify episode DTOs into subclasses that include <c>restrictions</c>,
+/// which SpotifyAPI.Web 7.4.2 does not model on <see cref="SimpleEpisode"/> / <see cref="FullEpisode"/>.
+/// </summary>
+public sealed class SpotifyEpisodeRestrictionsConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType) =>
+        objectType == typeof(SimpleEpisode) || objectType == typeof(FullEpisode);
+
+    public override bool CanWrite => false;
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer) =>
+        throw new NotSupportedException();
+
+    public override object? ReadJson(
+        JsonReader reader,
+        Type objectType,
+        object? existingValue,
+        JsonSerializer serializer)
+    {
+        var targetType = objectType == typeof(FullEpisode)
+            ? typeof(FullEpisodeWithRestrictions)
+            : typeof(SimpleEpisodeWithRestrictions);
+
+        return serializer.Deserialize(reader, targetType);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Serialization/SpotifyEpisodeRestrictionsJsonSerializer.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Serialization/SpotifyEpisodeRestrictionsJsonSerializer.cs
@@ -1,0 +1,66 @@
+using System.Net.Http;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using SpotifyAPI.Web.Http;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Serialization;
+
+/// <summary>
+/// Mirrors SpotifyAPI.Web's Newtonsoft serializer, plus a converter so episode
+/// <c>restrictions.reason</c> is retained for non-playable skip logging.
+/// </summary>
+public sealed class SpotifyEpisodeRestrictionsJsonSerializer : IJSONSerializer
+{
+    private readonly JsonSerializerSettings _serializerSettings;
+
+    public SpotifyEpisodeRestrictionsJsonSerializer()
+    {
+        var contractResolver = new PrivateFieldDefaultContractResolver
+        {
+            NamingStrategy = new SnakeCaseNamingStrategy()
+        };
+
+        _serializerSettings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = contractResolver,
+            Converters = { new SpotifyEpisodeRestrictionsConverter() }
+        };
+    }
+
+    public IAPIResponse<T> DeserializeResponse<T>(IResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        if (response.ContentType?.Equals("application/json", StringComparison.OrdinalIgnoreCase) is true)
+        {
+            var body = JsonConvert.DeserializeObject<T>(response.Body as string ?? "", _serializerSettings);
+            return new APIResponse<T>(response, body!);
+        }
+
+        return new APIResponse<T>(response);
+    }
+
+    public void SerializeRequest(IRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Body is string or Stream or HttpContent or null)
+        {
+            return;
+        }
+
+        request.Body = JsonConvert.SerializeObject(request.Body, _serializerSettings);
+    }
+
+    private sealed class PrivateFieldDefaultContractResolver : DefaultContractResolver
+    {
+        protected override List<MemberInfo> GetSerializableMembers(Type objectType)
+        {
+            var list = base.GetSerializableMembers(objectType);
+            list.AddRange(objectType.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance));
+            return list;
+        }
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/IndexingGuestEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/IndexingGuestEnrichmentRules.cs
@@ -66,9 +66,9 @@ public class IndexingGuestEnrichmentRules
             .Setup(x => x.EnrichGuests(added, It.IsAny<GuestEnrichmentOptions?>()))
             .Callback<Episode, GuestEnrichmentOptions?>((episode, _) =>
             {
-                episode.Guests = ["Janja Lalich"];
+                episode.Guests = ["Ada Example"];
             })
-            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Janja Lalich")], []));
+            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Ada Example")], []));
 
         var indexer = new Indexer(
             podcastRepository,
@@ -90,7 +90,7 @@ public class IndexingGuestEnrichmentRules
             Times.Once);
         episodeRepository.SavedEpisodes.Should().ContainSingle();
         var saved = episodeRepository.SavedEpisodes.Single();
-        saved.Guests.Should().Equal("Janja Lalich");
+        saved.Guests.Should().Equal("Ada Example");
     }
 
     [Fact(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/IndexingGuestEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/IndexingGuestEnrichmentRules.cs
@@ -23,6 +23,11 @@ public class IndexingGuestEnrichmentRules
     private static readonly DateTime ReleasedSince = DomainTestFixture.UtcDateDaysAgo(400);
     private readonly DomainTestFixture _fixture = new();
 
+    private static PersonMatch CreatePersonMatch(string name) =>
+        new(
+            new PersonMatchPerson(Guid.NewGuid(), name, null, null),
+            [new PersonMatchResult(name, 1)]);
+
     [Fact(DisplayName =
         "When indexing adds an episode, guest enrichment unions guests and persists the episode.")]
     public async Task indexing_added_episode_enriches_guests()
@@ -63,7 +68,7 @@ public class IndexingGuestEnrichmentRules
             {
                 episode.Guests = ["Janja Lalich"];
             })
-            .ReturnsAsync(new EnrichGuestsResult(["Janja Lalich"], []));
+            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Janja Lalich")], []));
 
         var indexer = new Indexer(
             podcastRepository,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
@@ -154,6 +154,17 @@ public class PodcastUpdater(
         // Persist newly added episodes
         if (mergeResult.AddedEpisodes.Any())
         {
+            foreach (var added in mergeResult.AddedEpisodes)
+            {
+                var service = EpisodeCreationLogger.ResolveCreatingService(added, podcast.ReleaseAuthority);
+                EpisodeCreationLogger.LogCreated(
+                    logger,
+                    added,
+                    podcast.Id,
+                    EpisodeCreationSource.Indexer,
+                    service);
+            }
+
             await episodeRepository.Save(mergeResult.AddedEpisodes);
         }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/PodcastUpdater.cs
@@ -162,7 +162,8 @@ public class PodcastUpdater(
                     added,
                     podcast.Id,
                     EpisodeCreationSource.Indexer,
-                    service);
+                    service,
+                    caller: "PodcastUpdater.Update");
             }
 
             await episodeRepository.Save(mergeResult.AddedEpisodes);

--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/CategorisePodcastLoggerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/CategorisePodcastLoggerRules.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+
+namespace RedditPodcastPoster.Subjects.Tests;
+
+public class CategorisePodcastLoggerRules
+{
+    [Fact(DisplayName = "FormatMessage uses stable Categorise podcast: prefix with ids and subject delta.")]
+    public void format_message_includes_podcast_episodes_and_delta()
+    {
+        var podcastId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var episodeId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var deltas = new[]
+        {
+            CategoriseEpisodeDelta.From(
+                episodeId,
+                "Preacher Boys Episode",
+                before: [],
+                after: ["Abuse", "Cult"],
+                persisted: true)
+        };
+
+        var message = CategorisePodcastLogger.FormatMessage(podcastId, "Preacher Boys Podcast", deltas);
+
+        message.Should().StartWith(CategorisePodcastLogger.MessagePrefix);
+        message.Should().Contain($"podcast-id='{podcastId}'");
+        message.Should().Contain("podcast-name='Preacher Boys Podcast'");
+        message.Should().Contain($"episode-id='{episodeId}'");
+        message.Should().Contain("title='Preacher Boys Episode'");
+        message.Should().Contain("before→after=[]→['Abuse', 'Cult']");
+        message.Should().Contain("added=['Abuse', 'Cult']");
+        message.Should().Contain("removed=[]");
+        message.Should().Contain("persisted=True");
+    }
+
+    [Fact(DisplayName = "FormatMessage reports unchanged when subjects did not change.")]
+    public void format_message_reports_unchanged()
+    {
+        var episodeId = Guid.NewGuid();
+        var deltas = new[]
+        {
+            CategoriseEpisodeDelta.From(
+                episodeId,
+                "Empty Title",
+                before: [],
+                after: [],
+                persisted: false)
+        };
+
+        var message = CategorisePodcastLogger.FormatMessage(Guid.NewGuid(), "Some Podcast", deltas);
+
+        message.Should().Contain($"episode-id='{episodeId}'");
+        message.Should().Contain("unchanged before→after=[]");
+        message.Should().Contain("persisted=False");
+        message.Should().NotContain("added=");
+    }
+
+    [Fact(DisplayName = "CategoriseEpisodeDelta computes added and removed subjects.")]
+    public void episode_delta_computes_added_and_removed()
+    {
+        var delta = CategoriseEpisodeDelta.From(
+            Guid.NewGuid(),
+            "t",
+            before: ["Keep", "Old"],
+            after: ["Keep", "New"],
+            persisted: true);
+
+        delta.Added.Should().BeEquivalentTo(["New"]);
+        delta.Removed.Should().BeEquivalentTo(["Old"]);
+        delta.Before.Should().BeEquivalentTo(["Keep", "Old"]);
+        delta.After.Should().BeEquivalentTo(["Keep", "New"]);
+    }
+
+    [Fact(DisplayName = "FormatMessage lists multiple episodes for one podcast line.")]
+    public void format_message_lists_multiple_episodes()
+    {
+        var e1 = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var e2 = Guid.Parse("ffffffff-0000-1111-2222-333333333333");
+        var deltas = new[]
+        {
+            CategoriseEpisodeDelta.From(e1, "One", [], ["A"], true),
+            CategoriseEpisodeDelta.From(e2, "Two", [], [], false)
+        };
+
+        var message = CategorisePodcastLogger.FormatMessage(Guid.NewGuid(), "Pod", deltas);
+
+        message.Should().Contain($"episode-id='{e1}'");
+        message.Should().Contain($"episode-id='{e2}'");
+        message.Should().Contain("title='One'");
+        message.Should().Contain("title='Two'");
+        message.Should().Contain(";");
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectEnricherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectEnricherTests.cs
@@ -117,4 +117,47 @@ public class SubjectEnricherTests
         // assert
         result.Additions.Should().StartWith(options.DefaultSubject);
     }
+
+    [Fact]
+    public async Task EnrichSubjects_DoesNotReAddUserRemovedSubject()
+    {
+        // arrange
+        var removedSubject = _subjectMatches.First().Subject.Name;
+        var episode = _fixture.Build<Episode>()
+            .With(x => x.Subjects, [])
+            .With(x => x.RemovedSubjects, [removedSubject])
+            .Create();
+        var options = _fixture.Create<SubjectEnrichmentOptions>();
+        var sut = _mocker.CreateInstance<SubjectEnricher>();
+
+        // act
+        var result = await sut.EnrichSubjects(episode, options);
+
+        // assert
+        result.Additions.Should().NotContain(removedSubject);
+        episode.Subjects.Should().NotContain(removedSubject);
+    }
+
+    [Fact]
+    public async Task EnrichSubjects_DoesNotApplyDefaultSubjectWhenUserRemovedIt()
+    {
+        // arrange
+        var defaultSubject = "Cults";
+        var episode = _fixture.Build<Episode>()
+            .With(x => x.Subjects, [])
+            .With(x => x.RemovedSubjects, [defaultSubject])
+            .Create();
+        var options = _fixture.Build<SubjectEnrichmentOptions>()
+            .With(x => x.DefaultSubject, defaultSubject)
+            .Create();
+        _subjectMatches = [];
+        var sut = _mocker.CreateInstance<SubjectEnricher>();
+
+        // act
+        var result = await sut.EnrichSubjects(episode, options);
+
+        // assert
+        result.Additions.Should().BeEmpty();
+        episode.Subjects.Should().BeEmpty();
+    }
 }

--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectEnricherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectEnricherTests.cs
@@ -21,7 +21,7 @@ public class SubjectEnricherTests
         _mocker.GetMock<ISubjectMatcher>()
             .Setup(x => x.MatchSubjects(It.IsAny<Episode>(), It.IsAny<SubjectEnrichmentOptions>()))
             .ReturnsAsync(() => _subjectMatches);
-        _fixture.Customize<Episode>(x => x.Without(o => o.Subjects));
+        _fixture.Customize<Episode>(x => x.Without(o => o.Subjects).Without(o => o.Matches));
     }
 
     [Fact]
@@ -159,5 +159,83 @@ public class SubjectEnricherTests
         // assert
         result.Additions.Should().BeEmpty();
         episode.Subjects.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EnrichSubjects_PopulatesMatchesForMatchedSubjects()
+    {
+        // arrange
+        var episode = _fixture.Create<Episode>();
+        var options = _fixture.Create<SubjectEnrichmentOptions>();
+        _subjectMatches =
+        [
+            new SubjectMatch(
+                new Subject("Cults"),
+                [
+                    new MatchResult("cult", 1, SubjectMatchSource.Title),
+                    new MatchResult("cult", 1, SubjectMatchSource.Description)
+                ])
+        ];
+        var sut = _mocker.CreateInstance<SubjectEnricher>();
+
+        // act
+        await sut.EnrichSubjects(episode, options);
+
+        // assert
+        episode.Matches.Should().HaveCount(2);
+        episode.Matches.Should().Contain(m =>
+            m.Subject == "Cults" && m.Term == "cult" && m.Source == SubjectMatchSource.Title);
+        episode.Matches.Should().Contain(m =>
+            m.Subject == "Cults" && m.Term == "cult" && m.Source == SubjectMatchSource.Description);
+    }
+
+    [Fact]
+    public async Task EnrichSubjects_OmitsDefaultSubjectWithoutMatchEvidence()
+    {
+        // arrange
+        var defaultSubject = "Cults";
+        var episode = _fixture.Create<Episode>();
+        var options = _fixture.Build<SubjectEnrichmentOptions>()
+            .With(x => x.DefaultSubject, defaultSubject)
+            .Create();
+        _subjectMatches = [];
+        var sut = _mocker.CreateInstance<SubjectEnricher>();
+
+        // act
+        await sut.EnrichSubjects(episode, options);
+
+        // assert
+        episode.Subjects.Should().Contain(defaultSubject);
+        episode.Matches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EnrichSubjects_DoesNotPopulateMatchesForUserRemovedSubject()
+    {
+        // arrange
+        var removedSubject = "Cults";
+        var episode = _fixture.Build<Episode>()
+            .With(x => x.Subjects, [])
+            .With(x => x.RemovedSubjects, [removedSubject])
+            .Create();
+        var options = new SubjectEnrichmentOptions(null, null, null, string.Empty);
+        var subjectMatches = new List<SubjectMatch>
+        {
+            new(
+                new Subject(removedSubject),
+                [new MatchResult("cult", 1, SubjectMatchSource.Title)])
+        };
+        _mocker.GetMock<ISubjectMatcher>()
+            .Setup(x => x.MatchSubjects(It.IsAny<Episode>(), It.IsAny<SubjectEnrichmentOptions?>()))
+            .ReturnsAsync(subjectMatches);
+        var sut = _mocker.CreateInstance<SubjectEnricher>();
+
+        // act
+        await sut.EnrichSubjects(episode, options);
+
+        // assert
+        episode.Matches.Should().NotContain(m =>
+            m.Subject.Equals(removedSubject, StringComparison.OrdinalIgnoreCase));
+        episode.Subjects.Should().NotContain(removedSubject);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Subjects/CategoriseEpisodeDelta.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/CategoriseEpisodeDelta.cs
@@ -1,0 +1,24 @@
+namespace RedditPodcastPoster.Subjects;
+
+/// <summary>
+/// Subject delta for one episode within a podcast-level categorise log line.
+/// </summary>
+public sealed record CategoriseEpisodeDelta(
+    Guid EpisodeId,
+    string Title,
+    IReadOnlyList<string> Before,
+    IReadOnlyList<string> After,
+    IReadOnlyList<string> Added,
+    IReadOnlyList<string> Removed,
+    bool Persisted)
+{
+    public static CategoriseEpisodeDelta From(Guid episodeId, string title, IReadOnlyList<string> before,
+        IReadOnlyList<string> after, bool persisted)
+    {
+        var beforeSet = before.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var afterSet = after.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var added = after.Where(s => !beforeSet.Contains(s)).ToArray();
+        var removed = before.Where(s => !afterSet.Contains(s)).ToArray();
+        return new CategoriseEpisodeDelta(episodeId, title, before, after, added, removed, persisted);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Subjects/CategorisePodcastLogger.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/CategorisePodcastLogger.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+
+namespace RedditPodcastPoster.Subjects;
+
+/// <summary>
+/// Emits a stable Warning-level podcast categorise line so App Insights can show
+/// which episodes were categorised and the subject delta in one KQL-friendly message.
+/// Warning is intentional: Information is heavily sampled in production.
+/// </summary>
+public static class CategorisePodcastLogger
+{
+    public const string MessagePrefix = "Categorise podcast:";
+
+    public static void Log(
+        ILogger logger,
+        Guid podcastId,
+        string podcastName,
+        IReadOnlyList<CategoriseEpisodeDelta> episodes)
+    {
+        logger.LogWarning("{Message}", FormatMessage(podcastId, podcastName, episodes));
+    }
+
+    /// <summary>
+    /// Same content as the rendered Warning message (for unit tests / docs).
+    /// </summary>
+    public static string FormatMessage(
+        Guid podcastId,
+        string podcastName,
+        IReadOnlyList<CategoriseEpisodeDelta> episodes)
+    {
+        var episodeSummaries = episodes.Select(FormatEpisode);
+        return
+            $"{MessagePrefix} podcast-id='{podcastId}' podcast-name='{podcastName}' episodes=[{string.Join("; ", episodeSummaries)}]";
+    }
+
+    private static string FormatEpisode(CategoriseEpisodeDelta episode)
+    {
+        var delta = DescribeDelta(episode);
+        return
+            $"episode-id='{episode.EpisodeId}' title='{episode.Title}' {delta} persisted={episode.Persisted}";
+    }
+
+    private static string DescribeDelta(CategoriseEpisodeDelta episode)
+    {
+        if (episode.Added.Count == 0 && episode.Removed.Count == 0)
+        {
+            return $"unchanged before→after={FormatSubjects(episode.Before)}";
+        }
+
+        return
+            $"before→after={FormatSubjects(episode.Before)}→{FormatSubjects(episode.After)} added={FormatSubjects(episode.Added)} removed={FormatSubjects(episode.Removed)}";
+    }
+
+    private static string FormatSubjects(IReadOnlyList<string> subjects) =>
+        $"[{string.Join(", ", subjects.Select(s => $"'{s}'"))}]";
+}

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Models/MatchResult.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Models/MatchResult.cs
@@ -1,3 +1,5 @@
-﻿namespace RedditPodcastPoster.Subjects.Models;
+﻿using RedditPodcastPoster.Models;
 
-public record MatchResult(string Term, int Matches);
+namespace RedditPodcastPoster.Subjects.Models;
+
+public record MatchResult(string Term, int Matches, SubjectMatchSource? Source = null);

--- a/Class-Libraries/RedditPodcastPoster.Subjects/RecentPodcastEpisodeCategoriser.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/RecentPodcastEpisodeCategoriser.cs
@@ -53,33 +53,38 @@ public class RecentPodcastEpisodeCategoriser(
                 .GroupBy(x => x.Podcast.Id)
                 .Select(g => $"'{g.First().Podcast.Name}' ({g.Key})")));
 
-        foreach (var podcastEpisode in podcastEpisodesToCategorise)
+        foreach (var podcastGroup in podcastEpisodesToCategorise.GroupBy(x => x.Podcast.Id))
         {
-            logger.LogWarning("{method}: Categorise podcast '{Name}'.", nameof(Categorise),
-                podcastEpisode.Podcast.Name);
-            logger.LogWarning("{method}: Categorise episode '{episodeTitle}'.", nameof(Categorise),
-                podcastEpisode.Episode.Title);
+            var podcast = podcastGroup.First().Podcast;
+            var episodeDeltas = new List<CategoriseEpisodeDelta>();
 
-            var updatedEpisode = await categoriser.Categorise(
-                podcastEpisode.Episode,
-                podcastEpisode.Podcast.IgnoredAssociatedSubjects,
-                podcastEpisode.Podcast.IgnoredSubjects,
-                podcastEpisode.Podcast.DefaultSubject,
-                podcastEpisode.Podcast.DescriptionRegex);
-
-            if (updatedEpisode)
+            foreach (var podcastEpisode in podcastGroup)
             {
-                await episodeRepository.Save(podcastEpisode.Episode);
+                var episode = podcastEpisode.Episode;
+                var before = episode.Subjects.ToArray();
 
-                updatedEpisodes.Add(podcastEpisode.Episode.Id);
-                logger.LogWarning(
-                    "{method}: Podcast '{podcastName}' with id '{podcastId}' and episode with id {episodeId}, updated subjects persisted: {subjects}.",
-                    nameof(Categorise),
-                    podcastEpisode.Podcast.Name,
-                    podcastEpisode.Podcast.Id,
-                    podcastEpisode.Episode.Id,
-                    string.Join(", ", podcastEpisode.Episode.Subjects.Select(x => $"'{x}'")));
+                var updatedEpisode = await categoriser.Categorise(
+                    episode,
+                    podcast.IgnoredAssociatedSubjects,
+                    podcast.IgnoredSubjects,
+                    podcast.DefaultSubject,
+                    podcast.DescriptionRegex);
+
+                if (updatedEpisode)
+                {
+                    await episodeRepository.Save(episode);
+                    updatedEpisodes.Add(episode.Id);
+                }
+
+                episodeDeltas.Add(CategoriseEpisodeDelta.From(
+                    episode.Id,
+                    episode.Title,
+                    before,
+                    episode.Subjects.ToArray(),
+                    updatedEpisode));
             }
+
+            CategorisePodcastLogger.Log(logger, podcast.Id, podcast.Name, episodeDeltas);
         }
 
         return updatedEpisodes;

--- a/Class-Libraries/RedditPodcastPoster.Subjects/SubjectEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/SubjectEnricher.cs
@@ -14,7 +14,11 @@ public class SubjectEnricher(
         SubjectEnrichmentOptions? options = null)
     {
         var subjectMatches = await subjectMatcher.MatchSubjects(episode, options);
-        var (additions, removals) = CompareSubjects(episode.Subjects, subjectMatches, options?.DefaultSubject);
+        var (additions, removals) = CompareSubjects(
+            episode.Subjects,
+            episode.RemovedSubjects,
+            subjectMatches,
+            options?.DefaultSubject);
         var hadSubjects = episode.Subjects.Any();
         if (additions.Any())
         {
@@ -47,7 +51,9 @@ public class SubjectEnricher(
         }
         else
         {
-            if (!episode.Subjects.Any() && !string.IsNullOrWhiteSpace(options?.DefaultSubject))
+            if (!episode.Subjects.Any() &&
+                !string.IsNullOrWhiteSpace(options?.DefaultSubject) &&
+                !episode.IsSubjectRemovedByUser(options.DefaultSubject))
             {
                 additions.Add(new SubjectMatch(new Subject(options.DefaultSubject), []));
                 episode.Subjects = [options.DefaultSubject];
@@ -69,7 +75,9 @@ public class SubjectEnricher(
                 string.Join(",", removals.Select(x => "'" + x + "'")), episode.Title, episode.Id);
         }
 
-        if (!string.IsNullOrWhiteSpace(options?.DefaultSubject) && !hadSubjects &&
+        if (!string.IsNullOrWhiteSpace(options?.DefaultSubject) &&
+            !episode.IsSubjectRemovedByUser(options.DefaultSubject) &&
+            !hadSubjects &&
             (!episode.Subjects.Any() || episode.Subjects.All(x => x.StartsWith("_"))))
         {
             if (!episode.Subjects.Contains(options.DefaultSubject, StringComparer.OrdinalIgnoreCase))
@@ -93,6 +101,7 @@ public class SubjectEnricher(
 
     private (IList<SubjectMatch>, IList<string>) CompareSubjects(
         IList<string> existingSubjects,
+        IList<string> removedSubjects,
         IList<SubjectMatch> matches,
         string? defaultSubject)
     {
@@ -103,7 +112,8 @@ public class SubjectEnricher(
         foreach (var match in matches)
         {
             var matchName = match.Subject.Name.ToLowerInvariant();
-            if (!loweredExistingSubjects.Contains(matchName))
+            if (!loweredExistingSubjects.Contains(matchName) &&
+                !removedSubjects.Any(x => x.Equals(match.Subject.Name, StringComparison.OrdinalIgnoreCase)))
             {
                 additions.Add(match);
             }

--- a/Class-Libraries/RedditPodcastPoster.Subjects/SubjectEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/SubjectEnricher.cs
@@ -96,7 +96,43 @@ public class SubjectEnricher(
                 options.DefaultSubject, episode.Title, episode.Id);
         }
 
+        SyncSubjectMatches(episode, subjectMatches);
+
         return new EnrichSubjectsResult(additions.Select(x => x.Subject.Name).ToArray(), removals.ToArray());
+    }
+
+    private static void SyncSubjectMatches(Episode episode, IList<SubjectMatch> subjectMatches)
+    {
+        episode.Matches.RemoveAll(m => episode.IsSubjectRemovedByUser(m.Subject));
+
+        var episodeSubjects = new HashSet<string>(episode.Subjects, StringComparer.OrdinalIgnoreCase);
+        foreach (var match in subjectMatches)
+        {
+            if (!episodeSubjects.Contains(match.Subject.Name) ||
+                episode.IsSubjectRemovedByUser(match.Subject.Name))
+            {
+                continue;
+            }
+
+            var evidence = match.MatchResults.Where(r => r.Source.HasValue).ToArray();
+            if (evidence.Length == 0)
+            {
+                continue;
+            }
+
+            episode.Matches.RemoveAll(m =>
+                m.Subject.Equals(match.Subject.Name, StringComparison.OrdinalIgnoreCase));
+
+            foreach (var result in evidence)
+            {
+                episode.Matches.Add(new EpisodeSubjectMatch
+                {
+                    Subject = match.Subject.Name,
+                    Term = result.Term,
+                    Source = result.Source!.Value
+                });
+            }
+        }
     }
 
     private (IList<SubjectMatch>, IList<string>) CompareSubjects(

--- a/Class-Libraries/RedditPodcastPoster.Subjects/SubjectService.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/SubjectService.cs
@@ -202,11 +202,10 @@ public class SubjectService(
             {
                 if (Include(ignoredAssociatedSubjects, term))
                 {
-                    var matchCtr = 0;
-                    var match = GetMatches(term.Term, WebUtility.HtmlDecode(episode.Title));
-                    if (match > 0)
+                    var titleMatch = GetMatches(term.Term, WebUtility.HtmlDecode(episode.Title));
+                    if (titleMatch > 0)
                     {
-                        matchCtr += match;
+                        matches.Add(new MatchResult(term.Term, titleMatch, SubjectMatchSource.Title));
                     }
 
                     if (withDescription)
@@ -216,13 +215,8 @@ public class SubjectService(
                         var descMatch = GetMatches(term.Term, WebUtility.HtmlDecode(episodeDescription));
                         if (descMatch > 0)
                         {
-                            matchCtr += descMatch;
+                            matches.Add(new MatchResult(term.Term, descMatch, SubjectMatchSource.Description));
                         }
-                    }
-
-                    if (matchCtr > 0)
-                    {
-                        matches.Add(new MatchResult(term.Term, matchCtr));
                     }
                 }
             }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
@@ -22,6 +22,11 @@ public class UrlSubmissionGuestEnrichmentRules
 {
     private readonly DomainTestFixture _fixture = new();
 
+    private static PersonMatch CreatePersonMatch(string name) =>
+        new(
+            new PersonMatchPerson(Guid.NewGuid(), name, null, null),
+            [new PersonMatchResult(name, 1)]);
+
     [Fact(DisplayName =
         "When a new episode is created on an existing podcast, guest enrichment unions high-confidence guests onto the episode.")]
     public async Task new_episode_create_path_enriches_guests()
@@ -40,7 +45,7 @@ public class UrlSubmissionGuestEnrichmentRules
             {
                 episode.Guests = ["Janja Lalich"];
             })
-            .ReturnsAsync(new EnrichGuestsResult(["Janja Lalich"], []));
+            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Janja Lalich")], []));
 
         var processor = CreateProcessor(
             matchingEpisode: null,
@@ -55,7 +60,8 @@ public class UrlSubmissionGuestEnrichmentRules
         // Assert
         result.EpisodeResult.Should().Be(SubmitResultState.Created);
         result.Episode!.Guests.Should().Equal("Janja Lalich");
-        result.SubmitEpisodeDetails!.People.Should().Equal("Janja Lalich");
+        result.SubmitEpisodeDetails!.People.Should().ContainSingle()
+            .Which.Person.Name.Should().Be("Janja Lalich");
         guestEnricher.Verify(
             x => x.EnrichGuests(created, It.IsAny<GuestEnrichmentOptions?>()),
             Times.Once);
@@ -116,7 +122,7 @@ public class UrlSubmissionGuestEnrichmentRules
             {
                 episode.Guests = ["Steven Hassan"];
             })
-            .ReturnsAsync(new EnrichGuestsResult(["Steven Hassan"], []));
+            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Steven Hassan")], []));
 
         var processor = CreateProcessor(
             matchingEpisode: existing,
@@ -135,7 +141,8 @@ public class UrlSubmissionGuestEnrichmentRules
         // Assert
         result.EpisodeResult.Should().Be(SubmitResultState.Enriched);
         result.Episode!.Guests.Should().Equal("Steven Hassan");
-        result.SubmitEpisodeDetails!.People.Should().Equal("Steven Hassan");
+        result.SubmitEpisodeDetails!.People.Should().ContainSingle()
+            .Which.Person.Name.Should().Be("Steven Hassan");
         guestEnricher.Verify(
             x => x.EnrichGuests(existing, It.IsAny<GuestEnrichmentOptions?>()),
             Times.Once);
@@ -206,7 +213,7 @@ public class UrlSubmissionGuestEnrichmentRules
             {
                 episode.Guests = ["Janja Lalich"];
             })
-            .ReturnsAsync(new EnrichGuestsResult(["Janja Lalich"], []));
+            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Janja Lalich")], []));
 
         var factory = new PodcastAndEpisodeFactory(
             episodeFactory.Object,

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
@@ -43,9 +43,9 @@ public class UrlSubmissionGuestEnrichmentRules
             .Setup(x => x.EnrichGuests(created, It.IsAny<GuestEnrichmentOptions?>()))
             .Callback<Episode, GuestEnrichmentOptions?>((episode, _) =>
             {
-                episode.Guests = ["Janja Lalich"];
+                episode.Guests = ["Ada Example"];
             })
-            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Janja Lalich")], []));
+            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Ada Example")], []));
 
         var processor = CreateProcessor(
             matchingEpisode: null,
@@ -59,9 +59,9 @@ public class UrlSubmissionGuestEnrichmentRules
 
         // Assert
         result.EpisodeResult.Should().Be(SubmitResultState.Created);
-        result.Episode!.Guests.Should().Equal("Janja Lalich");
+        result.Episode!.Guests.Should().Equal("Ada Example");
         result.SubmitEpisodeDetails!.People.Should().ContainSingle()
-            .Which.Person.Name.Should().Be("Janja Lalich");
+            .Which.Person.Name.Should().Be("Ada Example");
         guestEnricher.Verify(
             x => x.EnrichGuests(created, It.IsAny<GuestEnrichmentOptions?>()),
             Times.Once);
@@ -79,8 +79,8 @@ public class UrlSubmissionGuestEnrichmentRules
         created.Subjects = ["Cults"];
 
         var skipped = new PersonMatch(
-            new PersonMatchPerson(Guid.NewGuid(), "Jon", null, null),
-            [new PersonMatchResult("Jon", 1)]);
+            new PersonMatchPerson(Guid.NewGuid(), "Sam", null, null),
+            [new PersonMatchResult("Sam", 1)]);
 
         var guestEnricher = new Mock<IEpisodeGuestEnricher>();
         guestEnricher
@@ -100,7 +100,7 @@ public class UrlSubmissionGuestEnrichmentRules
         // Assert
         result.SubmitEpisodeDetails!.People.Should().BeEmpty();
         result.SubmitEpisodeDetails!.GuestSuggestions.Should().ContainSingle()
-            .Which.Person.Name.Should().Be("Jon");
+            .Which.Person.Name.Should().Be("Sam");
     }
 
     [Fact(DisplayName =
@@ -120,9 +120,9 @@ public class UrlSubmissionGuestEnrichmentRules
             .Setup(x => x.EnrichGuests(existing, It.IsAny<GuestEnrichmentOptions?>()))
             .Callback<Episode, GuestEnrichmentOptions?>((episode, _) =>
             {
-                episode.Guests = ["Steven Hassan"];
+                episode.Guests = ["Pat Placeholder"];
             })
-            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Steven Hassan")], []));
+            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Pat Placeholder")], []));
 
         var processor = CreateProcessor(
             matchingEpisode: existing,
@@ -140,9 +140,9 @@ public class UrlSubmissionGuestEnrichmentRules
 
         // Assert
         result.EpisodeResult.Should().Be(SubmitResultState.Enriched);
-        result.Episode!.Guests.Should().Equal("Steven Hassan");
+        result.Episode!.Guests.Should().Equal("Pat Placeholder");
         result.SubmitEpisodeDetails!.People.Should().ContainSingle()
-            .Which.Person.Name.Should().Be("Steven Hassan");
+            .Which.Person.Name.Should().Be("Pat Placeholder");
         guestEnricher.Verify(
             x => x.EnrichGuests(existing, It.IsAny<GuestEnrichmentOptions?>()),
             Times.Once);
@@ -211,9 +211,9 @@ public class UrlSubmissionGuestEnrichmentRules
             .Setup(x => x.EnrichGuests(created, It.IsAny<GuestEnrichmentOptions?>()))
             .Callback<Episode, GuestEnrichmentOptions?>((episode, _) =>
             {
-                episode.Guests = ["Janja Lalich"];
+                episode.Guests = ["Ada Example"];
             })
-            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Janja Lalich")], []));
+            .ReturnsAsync(new EnrichGuestsResult([CreatePersonMatch("Ada Example")], []));
 
         var factory = new PodcastAndEpisodeFactory(
             episodeFactory.Object,
@@ -249,7 +249,7 @@ public class UrlSubmissionGuestEnrichmentRules
         var response = await factory.CreatePodcastWithEpisode(categorisedItem);
 
         // Assert
-        response.NewEpisode.Guests.Should().Equal("Janja Lalich");
+        response.NewEpisode.Guests.Should().Equal("Ada Example");
         guestEnricher.Verify(
             x => x.EnrichGuests(created, It.IsAny<GuestEnrichmentOptions?>()),
             Times.Once);

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
@@ -55,6 +55,7 @@ public class UrlSubmissionGuestEnrichmentRules
         // Assert
         result.EpisodeResult.Should().Be(SubmitResultState.Created);
         result.Episode!.Guests.Should().Equal("Janja Lalich");
+        result.SubmitEpisodeDetails!.People.Should().Equal("Janja Lalich");
         guestEnricher.Verify(
             x => x.EnrichGuests(created, It.IsAny<GuestEnrichmentOptions?>()),
             Times.Once);
@@ -98,6 +99,7 @@ public class UrlSubmissionGuestEnrichmentRules
         // Assert
         result.EpisodeResult.Should().Be(SubmitResultState.Enriched);
         result.Episode!.Guests.Should().Equal("Steven Hassan");
+        result.SubmitEpisodeDetails!.People.Should().Equal("Steven Hassan");
         guestEnricher.Verify(
             x => x.EnrichGuests(existing, It.IsAny<GuestEnrichmentOptions?>()),
             Times.Once);

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
@@ -62,6 +62,42 @@ public class UrlSubmissionGuestEnrichmentRules
     }
 
     [Fact(DisplayName =
+        "When guest enrichment skips low-confidence matches, submit episode details include guest suggestions.")]
+    public async Task new_episode_create_path_includes_guest_suggestions()
+    {
+        // Arrange
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        var created = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithDuration(_fixture.CreateDuration()));
+        created.PodcastId = podcast.Id;
+        created.Subjects = ["Cults"];
+
+        var skipped = new PersonMatch(
+            new PersonMatchPerson(Guid.NewGuid(), "Jon", null, null),
+            [new PersonMatchResult("Jon", 1)]);
+
+        var guestEnricher = new Mock<IEpisodeGuestEnricher>();
+        guestEnricher
+            .Setup(x => x.EnrichGuests(created, It.IsAny<GuestEnrichmentOptions?>()))
+            .ReturnsAsync(new EnrichGuestsResult([], [skipped]));
+
+        var processor = CreateProcessor(
+            matchingEpisode: null,
+            createdEpisode: created,
+            guestEnricher: guestEnricher.Object);
+
+        var categorisedItem = CreateSpotifyCategorisedItem(podcast, matchingEpisode: null, podcastEpisodes: []);
+
+        // Act
+        var result = await processor.AddEpisodeToExistingPodcast(categorisedItem);
+
+        // Assert
+        result.SubmitEpisodeDetails!.People.Should().BeEmpty();
+        result.SubmitEpisodeDetails!.GuestSuggestions.Should().ContainSingle()
+            .Which.Person.Name.Should().Be("Jon");
+    }
+
+    [Fact(DisplayName =
         "When an existing episode has no Guests, URL submission enriches guests and reports Enriched.")]
     public async Task existing_episode_without_guests_is_enriched()
     {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/CategorisedItemProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/CategorisedItemProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Persistence.Abstractions;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Factories;
@@ -84,6 +85,21 @@ public class CategorisedItemProcessor(
             {
                 logger.LogWarning("Bypassing persisting new-podcast.");
             }
+        }
+
+        if (submitResult is { EpisodeResult: SubmitResultState.Created, Episode: not null })
+        {
+            var podcastId = submitResult.Episode.PodcastId != Guid.Empty
+                ? submitResult.Episode.PodcastId
+                : submitResult.Podcast?.Id
+                  ?? categorisedItem.MatchingPodcast?.Id
+                  ?? Guid.Empty;
+            EpisodeCreationLogger.LogCreated(
+                logger,
+                submitResult.Episode,
+                podcastId,
+                submitOptions.CreationSource,
+                categorisedItem.Authority);
         }
 
         LogSubmitEpisodeState(submitResult);

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/CategorisedItemProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/CategorisedItemProcessor.cs
@@ -99,7 +99,8 @@ public class CategorisedItemProcessor(
                 submitResult.Episode,
                 podcastId,
                 submitOptions.CreationSource,
-                categorisedItem.Authority);
+                categorisedItem.Authority,
+                caller: "CategorisedItemProcessor.ProcessCategorisedItem");
         }
 
         LogSubmitEpisodeState(submitResult);

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/DiscoveryUrlSubmitter.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/DiscoveryUrlSubmitter.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.UrlSubmission.Models;
@@ -24,6 +25,9 @@ public class DiscoveryUrlSubmitter(
         {
             return new DiscoverySubmitResult(DiscoverySubmitResultState.NoUrls);
         }
+
+        // Discovery path always tags creates as Discovery regardless of caller-supplied CreationSource.
+        submitOptions = submitOptions with { CreationSource = EpisodeCreationSource.Discovery };
 
         Podcast? spotifyPodcast = null, applePodcast = null, youTubePodcast = null;
         if (discoveryResult.Urls.Spotify != null)

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
@@ -57,7 +57,7 @@ public class PodcastAndEpisodeFactory(
 
         var episode = episodeFactory.CreateEpisode(categorisedItem);
         var subjectsResult = await subjectEnricher.EnrichSubjects(episode);
-        await guestEnricher.EnrichGuests(episode);
+        var guestsResult = await guestEnricher.EnrichGuests(episode);
         logger.LogInformation("Created podcast with name '{ShowName}' with id '{NewPodcastId}'.", showName, newPodcast.Id);
 
         var submitEpisodeDetails = new SubmitEpisodeDetails(
@@ -66,7 +66,8 @@ public class PodcastAndEpisodeFactory(
             episode.Urls.YouTube != null,
             subjectsResult.Additions,
             episode.Urls.BBC != null,
-            episode.Urls.InternetArchive != null);
+            episode.Urls.InternetArchive != null,
+            guestsResult.Additions);
         episode.SetPodcastProperties(newPodcast);
         return new CreatePodcastWithEpisodeResponse(newPodcast, episode, submitEpisodeDetails);
     }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
@@ -67,7 +67,8 @@ public class PodcastAndEpisodeFactory(
             subjectsResult.Additions,
             episode.Urls.BBC != null,
             episode.Urls.InternetArchive != null,
-            guestsResult.Additions);
+            guestsResult.Additions,
+            guestsResult.SkippedLowConfidence);
         episode.SetPodcastProperties(newPodcast);
         return new CreatePodcastWithEpisodeResponse(newPodcast, episode, submitEpisodeDetails);
     }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitEpisodeDetails.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitEpisodeDetails.cs
@@ -6,5 +6,6 @@ public record SubmitEpisodeDetails(
     bool YouTube,
     string[]? Subjects = null,
     bool BBC = false,
-    bool InternetArchive = false
+    bool InternetArchive = false,
+    string[]? People = null
 );

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitEpisodeDetails.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitEpisodeDetails.cs
@@ -9,6 +9,6 @@ public record SubmitEpisodeDetails(
     string[]? Subjects = null,
     bool BBC = false,
     bool InternetArchive = false,
-    string[]? People = null,
+    PersonMatch[]? People = null,
     PersonMatch[]? GuestSuggestions = null
 );

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitEpisodeDetails.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitEpisodeDetails.cs
@@ -1,4 +1,6 @@
-﻿namespace RedditPodcastPoster.UrlSubmission.Models;
+﻿using RedditPodcastPoster.People.Models;
+
+namespace RedditPodcastPoster.UrlSubmission.Models;
 
 public record SubmitEpisodeDetails(
     bool Spotify,
@@ -7,5 +9,6 @@ public record SubmitEpisodeDetails(
     string[]? Subjects = null,
     bool BBC = false,
     bool InternetArchive = false,
-    string[]? People = null
+    string[]? People = null,
+    PersonMatch[]? GuestSuggestions = null
 );

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitOptions.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitOptions.cs
@@ -1,7 +1,10 @@
-﻿namespace RedditPodcastPoster.UrlSubmission.Models;
+﻿using RedditPodcastPoster.Episodes;
+
+namespace RedditPodcastPoster.UrlSubmission.Models;
 
 public record SubmitOptions(
     Guid? PodcastId,
     bool MatchOtherServices,
     bool PersistToDatabase = true,
-    bool CreatePodcast = false);
+    bool CreatePodcast = false,
+    EpisodeCreationSource CreationSource = EpisodeCreationSource.SubmitUrl);

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitResult.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitResult.cs
@@ -39,7 +39,8 @@ public record SubmitResult(
 
             if (SubmitEpisodeDetails.People != null)
             {
-                results.Add($"people: '{string.Join("', '", SubmitEpisodeDetails.People)}'");
+                results.Add(
+                    $"people: '{string.Join("', '", SubmitEpisodeDetails.People.Select(x => x.Person.Name))}'");
             }
         }
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitResult.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitResult.cs
@@ -36,6 +36,11 @@ public record SubmitResult(
             {
                 results.Add($"subjects: '{string.Join("', '", SubmitEpisodeDetails.Subjects)}'");
             }
+
+            if (SubmitEpisodeDetails.People != null)
+            {
+                results.Add($"people: '{string.Join("', '", SubmitEpisodeDetails.People)}'");
+            }
         }
 
         return string.Join(", ", results);

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/PodcastProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/PodcastProcessor.cs
@@ -50,6 +50,8 @@ public class PodcastProcessor(
 
         SubmitResultState episodeResult;
         Episode? episode;
+        string[]? subjectAdditions = null;
+        string[]? peopleAdditions = null;
         if (matchingEpisode == null)
         {
             episodeResult = SubmitResultState.Created;
@@ -62,7 +64,7 @@ public class PodcastProcessor(
                     categorisedItem.MatchingPodcast.IgnoredSubjects,
                     categorisedItem.MatchingPodcast.DefaultSubject,
                     categorisedItem.MatchingPodcast.DescriptionRegex));
-            await guestEnricher.EnrichGuests(episode);
+            var guestsResult = await guestEnricher.EnrichGuests(episode);
 
             if (!episode.Subjects.Any())
             {
@@ -90,7 +92,8 @@ public class PodcastProcessor(
                 episode.Urls.YouTube != null,
                 subjectsResult.Additions,
                 episode.Urls.BBC != null,
-                episode.Urls.InternetArchive != null);
+                episode.Urls.InternetArchive != null,
+                guestsResult.Additions);
         }
         else
         {
@@ -105,6 +108,11 @@ public class PodcastProcessor(
                         categorisedItem.MatchingPodcast.IgnoredSubjects,
                         categorisedItem.MatchingPodcast.DefaultSubject,
                         categorisedItem.MatchingPodcast.DescriptionRegex));
+                if (subjectsResult.Additions.Length > 0)
+                {
+                    subjectAdditions = subjectsResult.Additions;
+                }
+
                 if (episode.Subjects.Any())
                 {
                     episodeResult = SubmitResultState.Enriched;
@@ -114,10 +122,20 @@ public class PodcastProcessor(
             if (episode.Guests is not { Length: > 0 })
             {
                 var guestsResult = await guestEnricher.EnrichGuests(episode);
-                if (guestsResult.Additions.Any())
+                if (guestsResult.Additions.Length > 0)
                 {
+                    peopleAdditions = guestsResult.Additions;
                     episodeResult = SubmitResultState.Enriched;
                 }
+            }
+
+            if (subjectAdditions != null || peopleAdditions != null)
+            {
+                submitEpisodeDetails = submitEpisodeDetails! with
+                {
+                    Subjects = subjectAdditions ?? submitEpisodeDetails!.Subjects,
+                    People = peopleAdditions
+                };
             }
         }
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/PodcastProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/PodcastProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.People;
+using RedditPodcastPoster.People.Models;
 using RedditPodcastPoster.Subjects;
 using RedditPodcastPoster.Subjects.Models;
 using RedditPodcastPoster.Text;
@@ -52,6 +53,7 @@ public class PodcastProcessor(
         Episode? episode;
         string[]? subjectAdditions = null;
         string[]? peopleAdditions = null;
+        PersonMatch[]? guestSuggestions = null;
         if (matchingEpisode == null)
         {
             episodeResult = SubmitResultState.Created;
@@ -93,7 +95,8 @@ public class PodcastProcessor(
                 subjectsResult.Additions,
                 episode.Urls.BBC != null,
                 episode.Urls.InternetArchive != null,
-                guestsResult.Additions);
+                guestsResult.Additions,
+                guestsResult.SkippedLowConfidence);
         }
         else
         {
@@ -127,14 +130,20 @@ public class PodcastProcessor(
                     peopleAdditions = guestsResult.Additions;
                     episodeResult = SubmitResultState.Enriched;
                 }
+
+                if (guestsResult.SkippedLowConfidence.Length > 0)
+                {
+                    guestSuggestions = guestsResult.SkippedLowConfidence;
+                }
             }
 
-            if (subjectAdditions != null || peopleAdditions != null)
+            if (subjectAdditions != null || peopleAdditions != null || guestSuggestions != null)
             {
                 submitEpisodeDetails = submitEpisodeDetails! with
                 {
                     Subjects = subjectAdditions ?? submitEpisodeDetails!.Subjects,
-                    People = peopleAdditions
+                    People = peopleAdditions,
+                    GuestSuggestions = guestSuggestions
                 };
             }
         }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/PodcastProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/PodcastProcessor.cs
@@ -52,7 +52,7 @@ public class PodcastProcessor(
         SubmitResultState episodeResult;
         Episode? episode;
         string[]? subjectAdditions = null;
-        string[]? peopleAdditions = null;
+        PersonMatch[]? peopleAdditions = null;
         PersonMatch[]? guestSuggestions = null;
         if (matchingEpisode == null)
         {

--- a/Cloud/Api/Dtos/SubmitEpisodeDetails.cs
+++ b/Cloud/Api/Dtos/SubmitEpisodeDetails.cs
@@ -9,7 +9,8 @@ public class SubmitEpisodeDetails(
     bool BBC,
     bool internetArchive,
     string[] subjects,
-    string[] people
+    string[] people,
+    PersonMatchDto[] guestSuggestions
 )
 {
     [JsonPropertyName("spotify")]
@@ -32,4 +33,7 @@ public class SubmitEpisodeDetails(
 
     [JsonPropertyName("internetArchive")]
     public bool InternetArchive { get; private set; } = internetArchive;
+
+    [JsonPropertyName("guestSuggestions")]
+    public PersonMatchDto[] GuestSuggestions { get; private set; } = guestSuggestions;
 }

--- a/Cloud/Api/Dtos/SubmitEpisodeDetails.cs
+++ b/Cloud/Api/Dtos/SubmitEpisodeDetails.cs
@@ -9,7 +9,7 @@ public class SubmitEpisodeDetails(
     bool BBC,
     bool internetArchive,
     string[] subjects,
-    string[] people,
+    PersonMatchDto[] people,
     PersonMatchDto[] guestSuggestions
 )
 {
@@ -26,7 +26,7 @@ public class SubmitEpisodeDetails(
     public string[] Subject { get; private set; } = subjects;
 
     [JsonPropertyName("people")]
-    public string[] People { get; private set; } = people;
+    public PersonMatchDto[] People { get; private set; } = people;
 
     [JsonPropertyName("bbc")]
     public bool BBC { get; private set; } = BBC;

--- a/Cloud/Api/Dtos/SubmitEpisodeDetails.cs
+++ b/Cloud/Api/Dtos/SubmitEpisodeDetails.cs
@@ -8,7 +8,8 @@ public class SubmitEpisodeDetails(
     bool youTube,
     bool BBC,
     bool internetArchive,
-    string[] subjects
+    string[] subjects,
+    string[] people
 )
 {
     [JsonPropertyName("spotify")]
@@ -22,6 +23,9 @@ public class SubmitEpisodeDetails(
 
     [JsonPropertyName("subjects")]
     public string[] Subject { get; private set; } = subjects;
+
+    [JsonPropertyName("people")]
+    public string[] People { get; private set; } = people;
 
     [JsonPropertyName("bbc")]
     public bool BBC { get; private set; } = BBC;

--- a/Cloud/Api/Dtos/SubmitEpisodeDetails.cs
+++ b/Cloud/Api/Dtos/SubmitEpisodeDetails.cs
@@ -9,8 +9,8 @@ public class SubmitEpisodeDetails(
     bool BBC,
     bool internetArchive,
     string[] subjects,
-    PersonMatchDto[] people,
-    PersonMatchDto[] guestSuggestions
+    string[] people,
+    SubmitGuestSuggestionDto[] guestSuggestions
 )
 {
     [JsonPropertyName("spotify")]
@@ -26,7 +26,7 @@ public class SubmitEpisodeDetails(
     public string[] Subject { get; private set; } = subjects;
 
     [JsonPropertyName("people")]
-    public PersonMatchDto[] People { get; private set; } = people;
+    public string[] People { get; private set; } = people;
 
     [JsonPropertyName("bbc")]
     public bool BBC { get; private set; } = BBC;
@@ -35,5 +35,5 @@ public class SubmitEpisodeDetails(
     public bool InternetArchive { get; private set; } = internetArchive;
 
     [JsonPropertyName("guestSuggestions")]
-    public PersonMatchDto[] GuestSuggestions { get; private set; } = guestSuggestions;
+    public SubmitGuestSuggestionDto[] GuestSuggestions { get; private set; } = guestSuggestions;
 }

--- a/Cloud/Api/Dtos/SubmitGuestSuggestionDto.cs
+++ b/Cloud/Api/Dtos/SubmitGuestSuggestionDto.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Api.Dtos;
+
+/// <summary>
+/// Low-confidence guest match returned on submit-url for toast display.
+/// Name is sufficient because People are unique on normalized name; full PersonMatchDto is reserved for episode edit.
+/// </summary>
+public class SubmitGuestSuggestionDto
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("matchResults")]
+    public required PersonMatchResultDto[] MatchResults { get; set; }
+}

--- a/Cloud/Api/Dtos/SubmitUrlResponse.cs
+++ b/Cloud/Api/Dtos/SubmitUrlResponse.cs
@@ -54,7 +54,8 @@ public class SubmitUrlResponse
                 resultSubmitEpisodeDetails.YouTube,
                 resultSubmitEpisodeDetails.BBC,
                 resultSubmitEpisodeDetails.InternetArchive,
-                resultSubmitEpisodeDetails.Subjects ?? []);
+                resultSubmitEpisodeDetails.Subjects ?? [],
+                resultSubmitEpisodeDetails.People ?? []);
         }
 
         return null;

--- a/Cloud/Api/Dtos/SubmitUrlResponse.cs
+++ b/Cloud/Api/Dtos/SubmitUrlResponse.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using RedditPodcastPoster.People.Models;
 using RedditPodcastPoster.UrlSubmission;
 using RedditPodcastPoster.UrlSubmission.Models;
 
@@ -55,9 +56,29 @@ public class SubmitUrlResponse
                 resultSubmitEpisodeDetails.BBC,
                 resultSubmitEpisodeDetails.InternetArchive,
                 resultSubmitEpisodeDetails.Subjects ?? [],
-                resultSubmitEpisodeDetails.People ?? []);
+                resultSubmitEpisodeDetails.People ?? [],
+                (resultSubmitEpisodeDetails.GuestSuggestions ?? [])
+                .Select(ToPersonMatchDto)
+                .ToArray());
         }
 
         return null;
+    }
+
+    private static PersonMatchDto ToPersonMatchDto(PersonMatch match)
+    {
+        return new PersonMatchDto
+        {
+            Person = new Person
+            {
+                Id = match.Person.Id,
+                Name = match.Person.Name,
+                TwitterHandle = match.Person.TwitterHandle,
+                BlueskyHandle = match.Person.BlueskyHandle
+            },
+            MatchResults = match.MatchResults
+                .Select(x => new PersonMatchResultDto { Term = x.Term, Matches = x.Matches })
+                .ToArray()
+        };
     }
 }

--- a/Cloud/Api/Dtos/SubmitUrlResponse.cs
+++ b/Cloud/Api/Dtos/SubmitUrlResponse.cs
@@ -57,27 +57,21 @@ public class SubmitUrlResponse
                 resultSubmitEpisodeDetails.InternetArchive,
                 resultSubmitEpisodeDetails.Subjects ?? [],
                 (resultSubmitEpisodeDetails.People ?? [])
-                .Select(ToPersonMatchDto)
+                .Select(x => x.Person.Name)
                 .ToArray(),
                 (resultSubmitEpisodeDetails.GuestSuggestions ?? [])
-                .Select(ToPersonMatchDto)
+                .Select(ToSubmitGuestSuggestionDto)
                 .ToArray());
         }
 
         return null;
     }
 
-    private static PersonMatchDto ToPersonMatchDto(PersonMatch match)
+    private static SubmitGuestSuggestionDto ToSubmitGuestSuggestionDto(PersonMatch match)
     {
-        return new PersonMatchDto
+        return new SubmitGuestSuggestionDto
         {
-            Person = new Person
-            {
-                Id = match.Person.Id,
-                Name = match.Person.Name,
-                TwitterHandle = match.Person.TwitterHandle,
-                BlueskyHandle = match.Person.BlueskyHandle
-            },
+            Name = match.Person.Name,
             MatchResults = match.MatchResults
                 .Select(x => new PersonMatchResultDto { Term = x.Term, Matches = x.Matches })
                 .ToArray()

--- a/Cloud/Api/Dtos/SubmitUrlResponse.cs
+++ b/Cloud/Api/Dtos/SubmitUrlResponse.cs
@@ -56,7 +56,9 @@ public class SubmitUrlResponse
                 resultSubmitEpisodeDetails.BBC,
                 resultSubmitEpisodeDetails.InternetArchive,
                 resultSubmitEpisodeDetails.Subjects ?? [],
-                resultSubmitEpisodeDetails.People ?? [],
+                (resultSubmitEpisodeDetails.People ?? [])
+                .Select(ToPersonMatchDto)
+                .ToArray(),
                 (resultSubmitEpisodeDetails.GuestSuggestions ?? [])
                 .Select(ToPersonMatchDto)
                 .ToArray());

--- a/Cloud/Api/Handlers/DiscoveryCurationHandler.cs
+++ b/Cloud/Api/Handlers/DiscoveryCurationHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Auth0;
 using RedditPodcastPoster.EntitySearchIndexer;
+using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.UrlSubmission;
 using RedditPodcastPoster.UrlSubmission.Models;
@@ -45,7 +46,7 @@ public class DiscoveryCurationHandler(
                 SkipExpensiveYouTubeQueries = false,
                 SkipExpensiveSpotifyQueries = false
             };
-            var submitOptions = new SubmitOptions(null, true);
+            var submitOptions = new SubmitOptions(null, true, CreationSource: EpisodeCreationSource.Discovery);
 
             var discoveryResults = await discoveryResultsService.GetDiscoveryResult(m);
             var submitResults = new List<DiscoverySubmitResponseItem>();

--- a/Cloud/Api/Handlers/EpisodeHandler.cs
+++ b/Cloud/Api/Handlers/EpisodeHandler.cs
@@ -754,10 +754,9 @@ public class EpisodeHandler(
                 episodeChangeRequest.BlueskyPosted.HasValue && episodeChangeRequest.BlueskyPosted.Value ? true : null;
         }
 
-        if (episodeChangeRequest.Subjects != null && !episode.Subjects.SequenceEqual(episodeChangeRequest.Subjects))
+        if (episodeChangeRequest.Subjects != null && episode.ApplyUserSubjects(episodeChangeRequest.Subjects))
         {
             changeState.UpdatedSubjects = true;
-            episode.Subjects = episodeChangeRequest.Subjects.ToList();
         }
 
         if (episodeChangeRequest.Urls?.Spotify != null)

--- a/Cloud/Api/Handlers/EpisodeHandler.cs
+++ b/Cloud/Api/Handlers/EpisodeHandler.cs
@@ -560,6 +560,8 @@ public class EpisodeHandler(
             Urls = episode.Urls,
             Images = episode.Images,
             Subjects = episode.Subjects,
+            RemovedSubjects = episode.RemovedSubjects,
+            Matches = episode.Matches,
             SearchTerms = episode.SearchTerms,
             YouTubePodcast = !string.IsNullOrWhiteSpace(podcast.YouTubeChannelId),
             SpotifyPodcast = !string.IsNullOrWhiteSpace(podcast.SpotifyId),


### PR DESCRIPTION
## Summary
- submit-url now includes `episodeDetails.people[]` with names added by guest enrichment (mirroring existing `subjects` from subject enrichment).
- UrlSubmission pipeline and API DTOs map guest enricher additions through `SubmitEpisodeDetails` / `SubmitUrlResponse`.
- Business rules tests assert `People` on guest enrichment scenarios.

## Deployment
Deploy **api-infra** before the separate website PR that consumes `people` for toast counts and tooltips.

## Test plan
- [ ] UrlSubmission guest enrichment business rules pass locally/CI
- [ ] After API deploy, submit a URL that triggers guest enrichment and confirm `episodeDetails.people` in the response

Made with [Cursor](https://cursor.com)