### PR TITLE
fix(people): persist isOrganization for full-name sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -437,3 +437,6 @@ plan-blocks.md
 .local/
 **/people-seed*.json
 !**/sample-people-seed.json
+
+# Local production cookie (never commit)
+.cookie

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/PeoplePublisher.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/PeoplePublisher.cs
@@ -32,6 +32,7 @@ public class PeoplePublisher(
                 id = x.Id,
                 name = x.Name,
                 sortName = x.SortName,
+                isOrganization = x.IsOrganization ? true : (bool?)null,
                 aliases = x.Aliases,
                 twitterHandle = x.TwitterHandle,
                 blueskyHandle = x.BlueskyHandle

--- a/Class-Libraries/RedditPodcastPoster.Models/Person.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Person.cs
@@ -34,6 +34,14 @@ public sealed class Person : CosmosSelector
     [JsonPropertyOrder(12)]
     public string? SortName { get; set; }
 
+    /// <summary>
+    /// When true, this entry is an organization/entity: sort using the full name
+    /// (see <c>sortName</c> / <see cref="GetEffectiveSortKey()"/>) rather than a surname token.
+    /// </summary>
+    [JsonPropertyName("isOrganization")]
+    [JsonPropertyOrder(13)]
+    public bool IsOrganization { get; set; }
+
     [JsonPropertyName("aliases")]
     [JsonPropertyOrder(20)]
     public string[]? Aliases { get; set; }

--- a/Class-Libraries/RedditPodcastPoster.People.Tests/PersonSortNameTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.People.Tests/PersonSortNameTests.cs
@@ -69,7 +69,22 @@ public class PersonSortNameTests
         person.Name.Should().Be("Ada Example");
         person.NameKey.Should().Be("ada example");
         person.SortName.Should().Be("Example, Ada");
+        person.IsOrganization.Should().BeFalse();
         person.GetEffectiveSortKey().Should().Be("Example, Ada");
+    }
+
+    [Fact]
+    public void PersonFactory_Create_OrganizationFlag_PersistsFullNameSort()
+    {
+        var person = new PersonFactory().Create(
+            "Mira Voss",
+            sortName: "Voss",
+            isOrganization: true);
+
+        person.IsOrganization.Should().BeTrue();
+        person.SortName.Should().Be("Mira Voss");
+        person.GetEffectiveSortKey().Should().Be("Mira Voss");
+        person.NameKey.Should().Be("mira voss");
     }
 
     [Fact]
@@ -100,6 +115,17 @@ public class PersonSortNameTests
         PersonSortNameResolver.ResolveForPersist("Ada Example", "Example").Should().BeNull();
         PersonSortNameResolver.ResolveForPersist("Ada Example", "  Example  ").Should().BeNull();
         PersonSortNameResolver.ResolveForPersist("Pat Placeholder", null).Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveForPersist_ExplicitOrganizationFlag_UsesFullName_EvenWithoutHeuristic()
+    {
+        // Surname-style name: heuristic says not org, but curator flag forces full-name sort.
+        PersonSortNameResolver.LooksLikeOrganization("Mira Voss").Should().BeFalse();
+        PersonSortNameResolver.ResolveForPersist("Mira Voss", "Voss", isOrganization: true)
+            .Should().Be("Mira Voss");
+        PersonSortNameResolver.ResolveForPersist("Mira Voss", null, isOrganization: true)
+            .Should().Be("Mira Voss");
     }
 
     [Fact]

--- a/Class-Libraries/RedditPodcastPoster.People/Factories/PersonFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.People/Factories/PersonFactory.cs
@@ -9,7 +9,8 @@ public interface IPersonFactory
         string[]? aliases = null,
         string? twitterHandle = null,
         string? blueskyHandle = null,
-        string? sortName = null);
+        string? sortName = null,
+        bool isOrganization = false);
 }
 
 public class PersonFactory : IPersonFactory
@@ -19,7 +20,8 @@ public class PersonFactory : IPersonFactory
         string[]? aliases = null,
         string? twitterHandle = null,
         string? blueskyHandle = null,
-        string? sortName = null)
+        string? sortName = null,
+        bool isOrganization = false)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -28,7 +30,8 @@ public class PersonFactory : IPersonFactory
 
         var person = new Person(name.Trim())
         {
-            SortName = string.IsNullOrWhiteSpace(sortName) ? null : sortName.Trim(),
+            IsOrganization = isOrganization,
+            SortName = PersonSortNameResolver.ResolveForPersist(name.Trim(), sortName, isOrganization),
             Aliases = aliases?.Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).ToArray(),
             TwitterHandle = NormalizeHandle(twitterHandle),
             BlueskyHandle = NormalizeHandle(blueskyHandle)

--- a/Class-Libraries/RedditPodcastPoster.People/PersonSortNameResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.People/PersonSortNameResolver.cs
@@ -89,12 +89,12 @@ public static class PersonSortNameResolver
     /// <summary>
     /// Value to store on <see cref="Person.SortName"/>.
     /// <list type="bullet">
-    /// <item>Org/full-name path: persist <c>StripLeadingThe(Name)</c> (always, when ≠ last-token).</item>
+    /// <item>Explicit <paramref name="isOrganization"/> or heuristic org: persist <c>StripLeadingThe(Name)</c> when ≠ last-token.</item>
     /// <item>Manual overrides kept (leading "The " stripped when the value is an org full-name key).</item>
     /// <item>Null only when effective key equals the last whitespace token of Name.</item>
     /// </list>
     /// </summary>
-    public static string? ResolveForPersist(string? name, string? sortName)
+    public static string? ResolveForPersist(string? name, string? sortName, bool isOrganization = false)
     {
         var trimmedName = name?.Trim() ?? string.Empty;
         if (trimmedName.Length == 0)
@@ -103,8 +103,14 @@ public static class PersonSortNameResolver
         }
 
         var lastToken = Person.DeriveSortKeyFromName(trimmedName);
-        var isOrg = LooksLikeOrganization(trimmedName);
+        var isOrg = isOrganization || LooksLikeOrganization(trimmedName);
         var orgKey = isOrg ? StripLeadingThe(trimmedName) : null;
+
+        // Curator flagged organization: always use the full-name org key (ignore stale surname seed).
+        if (isOrganization && orgKey is not null)
+        {
+            return string.Equals(orgKey, lastToken, StringComparison.Ordinal) ? null : orgKey;
+        }
 
         string effective;
         if (!string.IsNullOrWhiteSpace(sortName))

--- a/Cloud/Api/Dtos/Extensions/PersonExtension.cs
+++ b/Cloud/Api/Dtos/Extensions/PersonExtension.cs
@@ -9,6 +9,7 @@ public static class PersonExtension
             Id = person.Id,
             Name = person.Name,
             SortName = person.SortName,
+            IsOrganization = person.IsOrganization,
             Aliases = person.Aliases,
             TwitterHandle = person.TwitterHandle,
             BlueskyHandle = person.BlueskyHandle

--- a/Cloud/Api/Dtos/Person.cs
+++ b/Cloud/Api/Dtos/Person.cs
@@ -13,6 +13,12 @@ public class Person
     [JsonPropertyName("sortName")]
     public string? SortName { get; set; }
 
+    /// <summary>
+    /// Organization/entity flag. On create/GET always set; on PATCH omit (null) to leave unchanged.
+    /// </summary>
+    [JsonPropertyName("isOrganization")]
+    public bool? IsOrganization { get; set; }
+
     [JsonPropertyName("aliases")]
     public string[]? Aliases { get; set; }
 

--- a/Cloud/Api/Handlers/PersonHandler.cs
+++ b/Cloud/Api/Handlers/PersonHandler.cs
@@ -127,7 +127,8 @@ public class PersonHandler(
             person.Aliases,
             person.TwitterHandle,
             person.BlueskyHandle,
-            person.SortName);
+            person.SortName,
+            person.IsOrganization ?? false);
 
         var nameConflict = await personRepository.GetByName(entity.Name);
         if (nameConflict != null)
@@ -156,11 +157,32 @@ public class PersonHandler(
             entity.EnsureNameKey();
         }
 
+        if (change.IsOrganization.HasValue)
+        {
+            entity.IsOrganization = change.IsOrganization.Value;
+        }
+
         if (change.SortName != null)
         {
-            entity.SortName = string.IsNullOrWhiteSpace(change.SortName)
-                ? null
-                : change.SortName.Trim();
+            entity.SortName = PersonSortNameResolver.ResolveForPersist(
+                entity.Name,
+                change.SortName,
+                entity.IsOrganization);
+        }
+        else if (change.IsOrganization == true)
+        {
+            entity.SortName = PersonSortNameResolver.ResolveForPersist(
+                entity.Name,
+                entity.SortName,
+                isOrganization: true);
+        }
+        else if (change.IsOrganization == false)
+        {
+            // Dropping the org flag without an explicit sortName → surname default.
+            entity.SortName = PersonSortNameResolver.ResolveForPersist(
+                entity.Name,
+                sortName: null,
+                isOrganization: false);
         }
 
         if (change.Aliases != null)


### PR DESCRIPTION
## Summary
- Add `isOrganization` on Person model + API DTO; create/update round-trips the flag
- When organization is set, persist `sortName` as full name (`StripLeadingThe`), ignoring stale surname seeds
- Cover explicit org flag (non-heuristic names) in PersonSortName tests

## Test plan
- [ ] `dotnet test` People.Tests `PersonSortName` (27 passing locally)
- [ ] After deploy: edit a person, check Organization, save — Cosmos has `isOrganization: true` and `sortName` = full name
- [ ] Re-open Edit — checkbox checked, Sort name disabled showing full name
- [ ] Uncheck Organization, save — flag false, surname-default sort (null `sortName`)