### PR TITLE
refactor(search): nest RedditPodcastPoster.Search into folders matching Spotify/YouTube

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/EntitySearchIndexerResponse.cs
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/EntitySearchIndexerResponse.cs
@@ -1,4 +1,4 @@
-﻿using RedditPodcastPoster.Search;
+﻿using RedditPodcastPoster.Search.Models;
 
 namespace RedditPodcastPoster.EntitySearchIndexer;
 

--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/EpisodeSearchIndexerService.cs
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/EpisodeSearchIndexerService.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions;
-using RedditPodcastPoster.Search;
+using RedditPodcastPoster.Search.Models;
 using Podcast = RedditPodcastPoster.Models.Podcast;
 
 namespace RedditPodcastPoster.EntitySearchIndexer;

--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Extensions/PodcastEpisodeExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Extensions/PodcastEpisodeExtensions.cs
@@ -1,5 +1,6 @@
 using RedditPodcastPoster.Models;
-using RedditPodcastPoster.Search;
+using RedditPodcastPoster.Search.Formatting;
+using RedditPodcastPoster.Search.Models;
 
 namespace RedditPodcastPoster.EntitySearchIndexer.Extensions;
 

--- a/Class-Libraries/RedditPodcastPoster.Search/Configuration/SearchIndexConfig.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Configuration/SearchIndexConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace RedditPodcastPoster.Search;
+﻿namespace RedditPodcastPoster.Search.Configuration;
 
 public class SearchIndexConfig
 {

--- a/Class-Libraries/RedditPodcastPoster.Search/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.Search.Configuration;
+using RedditPodcastPoster.Search.Factories;
+using RedditPodcastPoster.Search.Services;
 
 namespace RedditPodcastPoster.Search.Extensions;
 

--- a/Class-Libraries/RedditPodcastPoster.Search/Factories/ISearchClientFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Factories/ISearchClientFactory.cs
@@ -1,6 +1,6 @@
 ﻿using Azure.Search.Documents;
 
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Factories;
 
 public interface ISearchClientFactory
 {

--- a/Class-Libraries/RedditPodcastPoster.Search/Factories/ISearchIndexClientFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Factories/ISearchIndexClientFactory.cs
@@ -1,6 +1,6 @@
 ﻿using Azure.Search.Documents.Indexes;
 
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Factories;
 
 public interface ISearchIndexClientFactory
 {

--- a/Class-Libraries/RedditPodcastPoster.Search/Factories/ISearchIndexerClientFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Factories/ISearchIndexerClientFactory.cs
@@ -1,6 +1,6 @@
 ﻿using Azure.Search.Documents.Indexes;
 
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Factories;
 
 public interface ISearchIndexerClientFactory
 {

--- a/Class-Libraries/RedditPodcastPoster.Search/Factories/SearchClientFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Factories/SearchClientFactory.cs
@@ -2,8 +2,9 @@
 using Azure.Search.Documents;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using RedditPodcastPoster.Search.Configuration;
 
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Factories;
 
 public class SearchClientFactory(
     IOptions<SearchIndexConfig> searchIndexConfig,

--- a/Class-Libraries/RedditPodcastPoster.Search/Factories/SearchIndexClientFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Factories/SearchIndexClientFactory.cs
@@ -2,8 +2,9 @@
 using Azure.Search.Documents.Indexes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using RedditPodcastPoster.Search.Configuration;
 
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Factories;
 
 public class SearchIndexClientFactory(
     IOptions<SearchIndexConfig> searchIndexConfig,

--- a/Class-Libraries/RedditPodcastPoster.Search/Factories/SearchIndexerClientFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Factories/SearchIndexerClientFactory.cs
@@ -2,8 +2,9 @@
 using Azure.Search.Documents.Indexes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using RedditPodcastPoster.Search.Configuration;
 
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Factories;
 
 public class SearchIndexerClientFactory(
     IOptions<SearchIndexConfig> searchIndexConfig,

--- a/Class-Libraries/RedditPodcastPoster.Search/Formatting/Constants.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Formatting/Constants.cs
@@ -1,4 +1,4 @@
-﻿namespace RedditPodcastPoster.Search;
+﻿namespace RedditPodcastPoster.Search.Formatting;
 
 public static class Constants
 {

--- a/Class-Libraries/RedditPodcastPoster.Search/Formatting/DescriptionTruncator.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Formatting/DescriptionTruncator.cs
@@ -1,4 +1,4 @@
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Formatting;
 
 public static class DescriptionTruncator
 {

--- a/Class-Libraries/RedditPodcastPoster.Search/ISearchIndexerServices.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/ISearchIndexerServices.cs
@@ -1,6 +1,0 @@
-﻿namespace RedditPodcastPoster.Search;
-
-public interface ISearchIndexerService
-{
-    Task<IndexerStateWrapper> RunIndexer();
-}

--- a/Class-Libraries/RedditPodcastPoster.Search/Models/EpisodeSearchRecord.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Models/EpisodeSearchRecord.cs
@@ -1,7 +1,7 @@
 ﻿using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Indexes.Models;
 
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Models;
 
 public class EpisodeSearchRecord
 {

--- a/Class-Libraries/RedditPodcastPoster.Search/Models/IndexerState.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Models/IndexerState.cs
@@ -1,4 +1,4 @@
-﻿namespace RedditPodcastPoster.Search;
+﻿namespace RedditPodcastPoster.Search.Models;
 
 public enum IndexerState
 {

--- a/Class-Libraries/RedditPodcastPoster.Search/Models/IndexerStateWrapper.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Models/IndexerStateWrapper.cs
@@ -1,4 +1,4 @@
-﻿namespace RedditPodcastPoster.Search;
+﻿namespace RedditPodcastPoster.Search.Models;
 
 public record IndexerStateWrapper(
     IndexerState IndexerState,

--- a/Class-Libraries/RedditPodcastPoster.Search/Models/SearchDocument.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Models/SearchDocument.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 using RedditPodcastPoster.Models;
 
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Models;
 
 public class SearchDocument
 {

--- a/Class-Libraries/RedditPodcastPoster.Search/Services/ISearchIndexerService.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Services/ISearchIndexerService.cs
@@ -1,0 +1,8 @@
+﻿using RedditPodcastPoster.Search.Models;
+
+namespace RedditPodcastPoster.Search.Services;
+
+public interface ISearchIndexerService
+{
+    Task<IndexerStateWrapper> RunIndexer();
+}

--- a/Class-Libraries/RedditPodcastPoster.Search/Services/SearchIndexerService.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Services/SearchIndexerService.cs
@@ -4,8 +4,10 @@ using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Indexes.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using RedditPodcastPoster.Search.Configuration;
+using RedditPodcastPoster.Search.Models;
 
-namespace RedditPodcastPoster.Search;
+namespace RedditPodcastPoster.Search.Services;
 
 public class SearchIndexerService(
     SearchIndexerClient searchIndexerClient,

--- a/Cloud/Api/Dtos/IndexerState.cs
+++ b/Cloud/Api/Dtos/IndexerState.cs
@@ -6,7 +6,7 @@ public class IndexerState
 {
     [JsonPropertyName("state")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public RedditPodcastPoster.Search.IndexerState State { get; set; }
+    public RedditPodcastPoster.Search.Models.IndexerState State { get; set; }
 
     [JsonPropertyName("nextRun")]
     public TimeSpan? NextRun { get; set; }

--- a/Cloud/Api/Extensions/EntitySearchIndexerResponseExtensions.cs
+++ b/Cloud/Api/Extensions/EntitySearchIndexerResponseExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Api.Dtos;
 using RedditPodcastPoster.EntitySearchIndexer;
-using IndexerState = RedditPodcastPoster.Search.IndexerState;
+using IndexerState = RedditPodcastPoster.Search.Models.IndexerState;
 
 namespace Api.Extensions;
 

--- a/Cloud/Api/Extensions/IndexerStateWrapperExtensions.cs
+++ b/Cloud/Api/Extensions/IndexerStateWrapperExtensions.cs
@@ -1,4 +1,4 @@
-﻿using RedditPodcastPoster.Search;
+﻿using RedditPodcastPoster.Search.Models;
 using IndexerState = Api.Dtos.IndexerState;
 
 namespace Api.Extensions;

--- a/Cloud/Api/Handlers/SearchIndexHandler.cs
+++ b/Cloud/Api/Handlers/SearchIndexHandler.cs
@@ -4,8 +4,8 @@ using Api.Extensions;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Auth0;
-using RedditPodcastPoster.Search;
-using IndexerState = RedditPodcastPoster.Search.IndexerState;
+using RedditPodcastPoster.Search.Services;
+using IndexerState = RedditPodcastPoster.Search.Models.IndexerState;
 
 namespace Api.Handlers;
 

--- a/Cloud/Indexer/Publisher.cs
+++ b/Cloud/Indexer/Publisher.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RedditPodcastPoster.Configuration;
 using RedditPodcastPoster.ContentPublisher;
-using RedditPodcastPoster.Search;
+using RedditPodcastPoster.Search.Services;
 
 namespace Indexer;
 

--- a/Cloud/Unit-Tests/Indexer.Tests/DescriptionTruncatorTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/DescriptionTruncatorTests.cs
@@ -1,5 +1,5 @@
 using FluentAssertions;
-using RedditPodcastPoster.Search;
+using RedditPodcastPoster.Search.Formatting;
 using Xunit;
 
 namespace Indexer.Tests;

--- a/Cloud/Unit-Tests/Indexer.Tests/PodcastEpisodeExtensionsTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/PodcastEpisodeExtensionsTests.cs
@@ -4,7 +4,8 @@ using Azure.Search.Documents.Indexes;
 using FluentAssertions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
 using RedditPodcastPoster.Models;
-using RedditPodcastPoster.Search;
+using RedditPodcastPoster.Search.Formatting;
+using RedditPodcastPoster.Search.Models;
 using Xunit;
 
 namespace Indexer.Tests;

--- a/Console-Apps/AddSubjectToSearchMatches/Processor.cs
+++ b/Console-Apps/AddSubjectToSearchMatches/Processor.cs
@@ -2,7 +2,7 @@
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.EntitySearchIndexer;
 using RedditPodcastPoster.Persistence.Abstractions;
-using RedditPodcastPoster.Search;
+using RedditPodcastPoster.Search.Models;
 using RedditPodcastPoster.Subjects;
 using RedditPodcastPoster.Subjects.Models;
 

--- a/Console-Apps/CreateSearchIndex/CreateSearchIndexProcessor.cs
+++ b/Console-Apps/CreateSearchIndex/CreateSearchIndexProcessor.cs
@@ -12,7 +12,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RedditPodcastPoster.Models.Extensions;
 using RedditPodcastPoster.Persistence;
-using RedditPodcastPoster.Search;
+using RedditPodcastPoster.Search.Formatting;
+using RedditPodcastPoster.Search.Models;
+using RedditPodcastPoster.Search.Services;
 
 namespace CreateSearchIndex;
 

--- a/Console-Apps/RemoveEpisodes/Processor.cs
+++ b/Console-Apps/RemoveEpisodes/Processor.cs
@@ -1,7 +1,7 @@
 ﻿using Azure.Search.Documents;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Persistence.Abstractions;
-using RedditPodcastPoster.Search;
+using RedditPodcastPoster.Search.Models;
 
 namespace RemoveEpisodes;
 


### PR DESCRIPTION
## Summary

Reorganises `RedditPodcastPoster.Search` from a top-heavy layout (15/16 `.cs` files at root, 94%) into technical-layer folders, mirroring the Spotify/YouTube/Apple (#896)/Abstractions (#897)/Reddit (#898) precedent. No root leftovers remain — every type mapped cleanly onto a layer.

### Folder map

| Folder | Files |
|---|---|
| `Configuration/` | `SearchIndexConfig` |
| `Models/` | `EpisodeSearchRecord`, `IndexerState`, `IndexerStateWrapper`, `SearchDocument` |
| `Factories/` | `ISearchClientFactory`/`SearchClientFactory`, `ISearchIndexClientFactory`/`SearchIndexClientFactory`, `ISearchIndexerClientFactory`/`SearchIndexerClientFactory` |
| `Services/` | `ISearchIndexerService`, `SearchIndexerService` |
| `Formatting/` | `Constants`, `DescriptionTruncator` |
| `Extensions/` | `ServiceCollectionExtensions` (unchanged location) |

### Notes

- **Public API unchanged**: no public type or DI extension method (`AddSearch()`) renamed.
- **File rename only**: `ISearchIndexerServices.cs` (plural, mismatched) renamed to `ISearchIndexerService.cs` to match the interface it contains.
- **Namespace collision handled**: `RedditPodcastPoster.Search.Models.IndexerState` vs `Api.Dtos.IndexerState` — existing type aliases in `SearchIndexHandler.cs` and `EntitySearchIndexerResponseExtensions.cs` repointed to the new namespace; fully-qualified reference in `Api/Dtos/IndexerState.cs` updated too.
- **Consumer usings fixed** across `Console-Apps` (`RemoveEpisodes`, `CreateSearchIndex`, `AddSubjectToSearchMatches`), `Cloud/Indexer` (`Publisher.cs`), `Cloud/Api` (`Handlers`, `Extensions`, `Dtos`), and `RedditPodcastPoster.EntitySearchIndexer`. Files that only used the `AddSearch()` DI extension needed no changes.
- Discovery, Persistence.Abstractions, Models, and hosts were **not** touched in this pass.

## Test plan

- `dotnet build RedditPodcastPoster.slnx` — succeeds, 0 errors.
- `dotnet test Cloud/Unit-Tests/Indexer.Tests` — **90/90 passing**.