### PR TITLE
fix(youtube): skip creating episodes for members-only videos

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Episode/YouTubeEpisodeProviderMembersOnlyRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Episode/YouTubeEpisodeProviderMembersOnlyRules.cs
@@ -1,0 +1,194 @@
+using System.Xml;
+using FluentAssertions;
+using Google.Apis.YouTube.v3.Data;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.AutoMock;
+using RedditPodcastPoster.Episodes.Adapters;
+using RedditPodcastPoster.Episodes.Adapters.Inputs;
+using RedditPodcastPoster.Episodes.Domain;
+using RedditPodcastPoster.Episodes.Factories;
+using RedditPodcastPoster.Models;
+using RedditPodcastPoster.PodcastServices.Abstractions.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.ChannelVideos;
+using RedditPodcastPoster.PodcastServices.YouTube.Clients;
+using RedditPodcastPoster.PodcastServices.YouTube.Episode;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Services;
+using RedditPodcastPoster.PodcastServices.YouTube.Video;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Episode;
+
+/// <summary>
+/// Members-only skip: YouTube channel-membership-gated videos stay publicly listed with real
+/// snippet/contentDetails, so they pass the duration and live/upcoming gates. The Data API omits
+/// <c>statistics.viewCount</c> for them (while still returning likeCount/commentCount), which is
+/// the signal used to skip episode creation. A zero view count is a normal new public upload and
+/// must NOT be skipped.
+/// </summary>
+public class YouTubeEpisodeProviderMembersOnlyRules
+{
+    private const string ChannelId = "UC_fictional_channel_0000";
+    private const string PublicVideoId = "public_vid_01";
+    private const string MembersOnlyVideoId = "members_vid_02";
+
+    private readonly AutoMocker _mocker = new();
+
+    private IYouTubeEpisodeProvider Sut => _mocker.CreateInstance<YouTubeEpisodeProvider>();
+
+    [Fact(DisplayName =
+        "When a channel's uploads contain a members-only video (statistics.viewCount absent), " +
+        "no episode is created for it while the public video still produces an episode.")]
+    public async Task MembersOnly_video_is_skipped_and_public_video_is_created()
+    {
+        // Arrange
+        var podcast = new Podcast { Name = "Fictional Preacher Boys Show", YouTubeChannelId = ChannelId };
+        var indexingContext = new IndexingContext();
+
+        _mocker.GetMock<IYouTubeChannelVideoRetrievalPolicy>()
+            .Setup(x => x.GetUploadsPlaylistReason(It.IsAny<Podcast>()))
+            .Returns("test forces uploads-playlist path");
+
+        var playlistItems = new List<PlaylistItem>
+        {
+            CreatePlaylistItem(PublicVideoId, "Fictional Public Episode About Nothing"),
+            CreatePlaylistItem(MembersOnlyVideoId, "Fictional Members-Only Bonus Episode")
+        };
+        _mocker.GetMock<IYouTubeChannelVideosService>()
+            .Setup(x => x.GetChannelVideos(It.IsAny<YouTubeChannelId>(), It.IsAny<IndexingContext>(), It.IsAny<bool>()))
+            .ReturnsAsync(new RedditPodcastPoster.PodcastServices.YouTube.Models.ChannelVideos(
+                new Google.Apis.YouTube.v3.Data.Channel(), playlistItems));
+
+        _mocker.GetMock<IYouTubeVideoService>()
+            .Setup(x => x.GetVideoContentDetails(
+                It.IsAny<IYouTubeServiceWrapper>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(new List<Google.Apis.YouTube.v3.Data.Video>
+            {
+                CreatePublicVideo(PublicVideoId),
+                CreateMembersOnlyVideo(MembersOnlyVideoId)
+            });
+
+        _mocker.GetMock<IEpisodeFromCandidateFactory>()
+            .Setup(x => x.Create(It.IsAny<EpisodeCandidate>(), It.IsAny<bool>()))
+            .Returns(new RedditPodcastPoster.Models.Episode());
+
+        // Act
+        var episodes = await Sut.GetEpisodes(podcast, indexingContext, knownIds: []);
+
+        // Assert
+        episodes.Should().NotBeNull();
+        episodes!.Should().HaveCount(1, "the members-only video must be skipped and only the public video mapped");
+
+        var adapter = _mocker.GetMock<IEpisodeCatalogueAdapter<YouTubeCatalogueInput>>();
+        adapter.Verify(
+            x => x.Adapt(It.Is<YouTubeCatalogueInput>(i => i.YouTubeId == PublicVideoId)),
+            Times.Once,
+            "the public video should be adapted into a candidate");
+        adapter.Verify(
+            x => x.Adapt(It.Is<YouTubeCatalogueInput>(i => i.YouTubeId == MembersOnlyVideoId)),
+            Times.Never,
+            "the members-only video must never reach episode creation");
+
+        VerifyWarningLoggedContaining(MembersOnlyVideoId);
+    }
+
+    [Fact(DisplayName =
+        "When a channel's uploads contain a public video with zero views (viewCount == 0), " +
+        "it is still created because zero views is not the members-only signal.")]
+    public async Task ZeroView_public_video_is_not_skipped()
+    {
+        // Arrange
+        var podcast = new Podcast { Name = "Fictional Preacher Boys Show", YouTubeChannelId = ChannelId };
+        var indexingContext = new IndexingContext();
+        const string zeroViewVideoId = "brand_new_vid_03";
+
+        _mocker.GetMock<IYouTubeChannelVideoRetrievalPolicy>()
+            .Setup(x => x.GetUploadsPlaylistReason(It.IsAny<Podcast>()))
+            .Returns("test forces uploads-playlist path");
+
+        _mocker.GetMock<IYouTubeChannelVideosService>()
+            .Setup(x => x.GetChannelVideos(It.IsAny<YouTubeChannelId>(), It.IsAny<IndexingContext>(), It.IsAny<bool>()))
+            .ReturnsAsync(new RedditPodcastPoster.PodcastServices.YouTube.Models.ChannelVideos(
+                new Google.Apis.YouTube.v3.Data.Channel(), new List<PlaylistItem>
+                {
+                    CreatePlaylistItem(zeroViewVideoId, "Fictional Brand New Upload")
+                }));
+
+        _mocker.GetMock<IYouTubeVideoService>()
+            .Setup(x => x.GetVideoContentDetails(
+                It.IsAny<IYouTubeServiceWrapper>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(new List<Google.Apis.YouTube.v3.Data.Video>
+            {
+                CreateZeroViewPublicVideo(zeroViewVideoId)
+            });
+
+        _mocker.GetMock<IEpisodeFromCandidateFactory>()
+            .Setup(x => x.Create(It.IsAny<EpisodeCandidate>(), It.IsAny<bool>()))
+            .Returns(new RedditPodcastPoster.Models.Episode());
+
+        // Act
+        var episodes = await Sut.GetEpisodes(podcast, indexingContext, knownIds: []);
+
+        // Assert
+        episodes.Should().NotBeNull();
+        episodes!.Should().HaveCount(1, "a zero-view public upload is not members-only and must be created");
+    }
+
+    private void VerifyWarningLoggedContaining(string fragment) =>
+        _mocker.GetMock<ILogger<YouTubeEpisodeProvider>>().Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains(fragment)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+    private static PlaylistItem CreatePlaylistItem(string videoId, string title) =>
+        new()
+        {
+            Snippet = new PlaylistItemSnippet
+            {
+                Title = title,
+                ResourceId = new ResourceId { VideoId = videoId },
+                PublishedAtDateTimeOffset = DateTimeOffset.UtcNow.AddDays(-1)
+            }
+        };
+
+    private static Google.Apis.YouTube.v3.Data.Video CreatePublicVideo(string videoId) =>
+        BuildVideo(videoId, new VideoStatistics { ViewCount = 5000, LikeCount = 10, CommentCount = 2 });
+
+    private static Google.Apis.YouTube.v3.Data.Video CreateZeroViewPublicVideo(string videoId) =>
+        BuildVideo(videoId, new VideoStatistics { ViewCount = 0, LikeCount = 0, CommentCount = 0 });
+
+    private static Google.Apis.YouTube.v3.Data.Video CreateMembersOnlyVideo(string videoId) =>
+        // No ViewCount -> members-only signal, other statistics still present.
+        BuildVideo(videoId, new VideoStatistics { LikeCount = 1, FavoriteCount = 0, CommentCount = 0 });
+
+    private static Google.Apis.YouTube.v3.Data.Video BuildVideo(string videoId, VideoStatistics statistics) =>
+        new()
+        {
+            Id = videoId,
+            Snippet = new VideoSnippet
+            {
+                Title = $"snippet-{videoId}",
+                Description = $"description-{videoId}",
+                ChannelId = ChannelId,
+                LiveBroadcastContent = "none"
+            },
+            ContentDetails = new VideoContentDetails
+            {
+                Duration = XmlConvert.ToString(TimeSpan.FromMinutes(30)),
+                ContentRating = new ContentRating()
+            },
+            Statistics = statistics
+        };
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Extensions/VideoExtensionsTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Extensions/VideoExtensionsTests.cs
@@ -23,6 +23,63 @@ public class VideoExtensionsTests
     }
 
     [Fact]
+    public void IsMembersOnly_WhenViewCountAbsentButOtherStatisticsPresent_ReturnsTrue()
+    {
+        // Members-only videos stay publicly listed but YouTube omits statistics.viewCount for them,
+        // while still returning likeCount/favoriteCount/commentCount.
+        var video = new Google.Apis.YouTube.v3.Data.Video
+        {
+            Statistics = new VideoStatistics
+            {
+                LikeCount = 0,
+                FavoriteCount = 0,
+                CommentCount = 0
+                // ViewCount deliberately left null (property absent) — the members-only signal.
+            }
+        };
+
+        video.IsMembersOnly().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMembersOnly_WhenViewCountIsZero_ReturnsFalse()
+    {
+        // A brand-new PUBLIC upload with no views returns "viewCount": "0" (present, value 0).
+        // Zero views must NOT be treated as members-only.
+        var video = new Google.Apis.YouTube.v3.Data.Video
+        {
+            Statistics = new VideoStatistics
+            {
+                ViewCount = 0,
+                LikeCount = 0,
+                CommentCount = 0
+            }
+        };
+
+        video.IsMembersOnly().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMembersOnly_WhenViewCountPresent_ReturnsFalse()
+    {
+        var video = new Google.Apis.YouTube.v3.Data.Video
+        {
+            Statistics = new VideoStatistics { ViewCount = 4242 }
+        };
+
+        video.IsMembersOnly().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMembersOnly_WhenStatisticsNotRequested_ReturnsFalse()
+    {
+        // Statistics part not requested -> Statistics is null -> never flag as members-only.
+        var video = new Google.Apis.YouTube.v3.Data.Video { Statistics = null };
+
+        video.IsMembersOnly().Should().BeFalse();
+    }
+
+    [Fact]
     public void GetThumbnailCandidates_OrdersByHeightDescending()
     {
         var video = new Google.Apis.YouTube.v3.Data.Video

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
@@ -62,7 +62,8 @@ public class YouTubeEpisodeProvider(
                     var videoDetails =
                         await youTubeVideoService.GetVideoContentDetails(youTubeService, youTubeVideoIds,
                             indexingContext,
-                            true);
+                            withSnippets: true,
+                            withStatistics: true);
 
                     if (videoDetails != null)
                     {
@@ -70,6 +71,11 @@ public class YouTubeEpisodeProvider(
                         foreach (var videoDetail in videoDetails.Where(videoDetail =>
                                      YouTubeVideoDurationMatcher.HasDuration(videoDetail.GetLength())))
                         {
+                            if (SkipMembersOnly(videoDetail))
+                            {
+                                continue;
+                            }
+
                             episodes.Add(await GetEpisodeAsync(
                                 youTubeVideos.First(searchResult => searchResult.Id.VideoId == videoDetail.Id),
                                 videoDetail));
@@ -122,7 +128,8 @@ public class YouTubeEpisodeProvider(
             youTubeService,
             playlistItems.Select(x => x.Snippet.ResourceId.VideoId),
             indexingContext,
-            true);
+            withSnippets: true,
+            withStatistics: true);
         if (videoDetails == null || !videoDetails.Any())
         {
             return null;
@@ -140,6 +147,11 @@ public class YouTubeEpisodeProvider(
                      .Where(x => x.VideoDetails.IsCompletedPublicVideo())
                      .Where(x => x.VideoDetails.Snippet.ChannelId == request.ChannelId))
         {
+            if (SkipMembersOnly(playlistItemVideo.VideoDetails))
+            {
+                continue;
+            }
+
             episodes.Add(await GetEpisodeAsync(playlistItemVideo.PlaylistItem.Snippet, playlistItemVideo.VideoDetails));
         }
 
@@ -189,7 +201,8 @@ public class YouTubeEpisodeProvider(
                 youTubeService,
                 results.Select(x => x.Snippet.ResourceId.VideoId),
                 indexingContext,
-                true);
+                withSnippets: true,
+                withStatistics: true);
         if (videoDetails != null && videoDetails.Any())
         {
             try
@@ -208,6 +221,11 @@ public class YouTubeEpisodeProvider(
                              .Where(x => youTubeChannelId == null ||
                                          x.VideoDetails.Snippet.ChannelId == youTubeChannelId.ChannelId))
                 {
+                    if (SkipMembersOnly(playlistItemVideo.VideoDetails))
+                    {
+                        continue;
+                    }
+
                     reducedResults.Add(await GetEpisodeAsync(
                         playlistItemVideo.PlaylistItem.Snippet,
                         playlistItemVideo.VideoDetails));
@@ -225,6 +243,20 @@ public class YouTubeEpisodeProvider(
         }
 
         return new GetPlaylistEpisodesResponse(null, isExpensiveQuery);
+    }
+
+    private bool SkipMembersOnly(Google.Apis.YouTube.v3.Data.Video video)
+    {
+        if (!video.IsMembersOnly())
+        {
+            return false;
+        }
+
+        logger.LogWarning(
+            "Skipping YouTube video '{VideoId}' ('{VideoTitle}') because it is members-only (statistics.viewCount is absent while other statistics are present).",
+            video.Id,
+            video.Snippet?.Title);
+        return true;
     }
 
     private record PlaylistItemVideo(PlaylistItem PlaylistItem, Google.Apis.YouTube.v3.Data.Video VideoDetails);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/VideoExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/VideoExtensions.cs
@@ -12,6 +12,27 @@ public static class VideoExtensions
         return liveBroadcastContent != "live" && liveBroadcastContent != "upcoming";
     }
 
+    /// <summary>
+    /// Detects YouTube members-only (channel-membership-gated) videos.
+    /// The Data API exposes no explicit members-only flag: such videos stay publicly listed
+    /// (<c>status.privacyStatus == "public"</c>, real snippet/contentDetails, <c>publicStatsViewable == true</c>),
+    /// but YouTube omits <c>statistics.viewCount</c> for them while still returning the other statistics
+    /// (<c>likeCount</c>, <c>favoriteCount</c>, <c>commentCount</c>). Public videos ALWAYS include
+    /// <c>viewCount</c> — a brand-new upload with no views returns <c>"viewCount": "0"</c> (i.e.
+    /// <see cref="VideoStatistics.ViewCount"/> == <c>0</c>, not <c>null</c>). We therefore treat an
+    /// <b>absent</b> <c>viewCount</c> (property missing → <c>null</c>) on an otherwise-populated statistics
+    /// object as the members-only signal. A zero view count is deliberately NOT treated as members-only.
+    /// </summary>
+    /// <remarks>
+    /// Requires the <c>statistics</c> part to have been requested when fetching the video. When statistics
+    /// were not requested, <see cref="Google.Apis.YouTube.v3.Data.Video.Statistics"/> is <c>null</c> and this
+    /// returns <c>false</c> (never skips), so callers must request statistics for this check to take effect.
+    /// </remarks>
+    public static bool IsMembersOnly(this Google.Apis.YouTube.v3.Data.Video video)
+    {
+        return video.Statistics != null && video.Statistics.ViewCount == null;
+    }
+
     public static TimeSpan? GetLength(this Google.Apis.YouTube.v3.Data.Video video)
     {
         if (string.IsNullOrWhiteSpace(video.ContentDetails.Duration))


### PR DESCRIPTION
## Problem

Indexing **Preacher Boys Podcast** created Episode documents for **YouTube members-only** videos:

- `hjP4Spj5_ek` — https://www.youtube.com/watch?v=hjP4Spj5_ek
- `23K6im8c0-o` — https://www.youtube.com/watch?v=23K6im8c0-o

(User has already deleted these episodes. No production Cosmos writes are made by this change.)

## Root cause

Members-only videos are **not** private — they stay **publicly listed** (`status.privacyStatus == "public"`) with full, real `snippet` + `contentDetails`, including a genuine `duration`. Only playback is gated.

The indexer's YouTube paths only filtered on:
- duration present (`YouTubeVideoDurationMatcher.HasDuration`), and
- `IsCompletedPublicVideo()` — which, despite its name, only excludes `live`/`upcoming`.

So a members-only video with a real duration sailed through and became an Episode. Confirmed against both video IDs via the Data API.

## How members-only is detected

The YouTube Data API has **no** explicit members-only flag. The reliable signal (verified against both offending videos): request the `statistics` part — members-only videos **omit `statistics.viewCount`** while still returning `likeCount` / `favoriteCount` / `commentCount`; public videos **always** include `viewCount`.

| Video | privacyStatus | duration | `viewCount` |
|---|---|---|---|
| `hjP4Spj5_ek` (members) | public | PT27M36S | **absent** |
| `23K6im8c0-o` (members) | public | PT50M34S | **absent** |
| control public video | public | PT3M34S | present |

Importantly this keys off the `viewCount` property being **absent** (`ViewCount == null`), **not** `viewCount == 0`. A brand-new public upload with no views returns `"viewCount": "0"` (i.e. `ViewCount == 0`), so it is correctly **not** treated as members-only — avoiding false positives on new uploads.

## Change

- `VideoExtensions.IsMembersOnly(video)` — `Statistics != null && Statistics.ViewCount == null`. Returns `false` when statistics were not requested (never skips blindly).
- `YouTubeEpisodeProvider` — request the `statistics` part and skip members-only videos in all three episode-creation paths (channel search, channel uploads playlist, playlist), logging a **Warning** for each skip (mirrors the Spotify non-playable skip from #891).
- Focus is **do not create**. Enrichment/matching paths are unchanged.

## Tests (fictional names only)

- `VideoExtensionsTests` — members-only (viewCount absent) ⇒ true; **zero views ⇒ false**; viewCount present ⇒ false; statistics not requested ⇒ false.
- `YouTubeEpisodeProviderMembersOnlyRules` — a members-only upload is skipped (with Warning) while the public upload still produces an episode; a zero-view public upload is still created.

All affected tests pass (11/11).
