### PR TITLE
refactor(urlsubmission): finish nesting UrlSubmission into folders matching house style

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionEnrichmentRules.cs
@@ -8,8 +8,8 @@ using RedditPodcastPoster.Episodes.TestSupport.Assertions;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions;
-using RedditPodcastPoster.UrlSubmission;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
+using RedditPodcastPoster.UrlSubmission.Enrichers;
 using RedditPodcastPoster.UrlSubmission.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
@@ -9,8 +9,11 @@ using RedditPodcastPoster.People.Models;
 using RedditPodcastPoster.Subjects;
 using RedditPodcastPoster.Subjects.Models;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
+using RedditPodcastPoster.UrlSubmission.Enrichers;
 using RedditPodcastPoster.UrlSubmission.Factories;
+using RedditPodcastPoster.UrlSubmission.Matching;
 using RedditPodcastPoster.UrlSubmission.Models;
+using RedditPodcastPoster.UrlSubmission.Processors;
 
 namespace RedditPodcastPoster.UrlSubmission.Tests.BusinessRules.UrlSubmission;
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionPersistenceRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionPersistenceRules.cs
@@ -7,6 +7,7 @@ using RedditPodcastPoster.Models;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Factories;
 using RedditPodcastPoster.UrlSubmission.Models;
+using RedditPodcastPoster.UrlSubmission.Processors;
 
 namespace RedditPodcastPoster.UrlSubmission.Tests.BusinessRules.UrlSubmission;
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/EpisodeHelperTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/EpisodeHelperTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Moq.AutoMock;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
+using RedditPodcastPoster.UrlSubmission.Matching;
 using RedditPodcastPoster.UrlSubmission.Models;
 using Xunit;
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/UrlSubmissionDependencyInjectionTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/UrlSubmissionDependencyInjectionTests.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Episodes.Extensions;
 using RedditPodcastPoster.People;
+using RedditPodcastPoster.UrlSubmission.Enrichers;
 using RedditPodcastPoster.UrlSubmission.Extensions;
+using RedditPodcastPoster.UrlSubmission.Processors;
 
 namespace RedditPodcastPoster.UrlSubmission.Tests;
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Adaptors/ISubmitResultAdaptor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Adaptors/ISubmitResultAdaptor.cs
@@ -1,6 +1,6 @@
 ﻿using RedditPodcastPoster.UrlSubmission.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Adaptors;
 
 public interface ISubmitResultAdaptor
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Adaptors/SubmitResultAdaptor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Adaptors/SubmitResultAdaptor.cs
@@ -1,6 +1,6 @@
 ﻿using RedditPodcastPoster.UrlSubmission.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Adaptors;
 
 public class SubmitResultAdaptor : ISubmitResultAdaptor
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Enrichers/DescriptionHelper.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Enrichers/DescriptionHelper.cs
@@ -1,7 +1,7 @@
 ﻿using RedditPodcastPoster.Models;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Enrichers;
 
 public class DescriptionHelper : IDescriptionHelper
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Enrichers/EpisodeEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Enrichers/EpisodeEnricher.cs
@@ -7,7 +7,7 @@ using RedditPodcastPoster.Models;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Enrichers;
 
 public class EpisodeEnricher(
     IDescriptionHelper descriptionHelper,

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Enrichers/IDescriptionHelper.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Enrichers/IDescriptionHelper.cs
@@ -1,6 +1,6 @@
 ﻿using RedditPodcastPoster.UrlSubmission.Categorisation;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Enrichers;
 
 public interface IDescriptionHelper
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Enrichers/IEpisodeEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Enrichers/IEpisodeEnricher.cs
@@ -2,7 +2,7 @@
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Enrichers;
 
 public interface IEpisodeEnricher
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Extensions/ServiceCollectionExtensions.cs
@@ -3,8 +3,14 @@ using RedditPodcastPoster.People.Extensions;
 using RedditPodcastPoster.PodcastServices.Apple.Categorisers;
 using RedditPodcastPoster.PodcastServices.Spotify.Categorisers;
 using RedditPodcastPoster.PodcastServices.YouTube.Services;
+using RedditPodcastPoster.UrlSubmission.Adaptors;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
+using RedditPodcastPoster.UrlSubmission.Enrichers;
 using RedditPodcastPoster.UrlSubmission.Factories;
+using RedditPodcastPoster.UrlSubmission.Matching;
+using RedditPodcastPoster.UrlSubmission.Processors;
+using RedditPodcastPoster.UrlSubmission.Services;
+using RedditPodcastPoster.UrlSubmission.Submitters;
 
 namespace RedditPodcastPoster.UrlSubmission.Extensions;
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/EpisodeFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/EpisodeFactory.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using RedditPodcastPoster.Configuration;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
+using RedditPodcastPoster.UrlSubmission.Enrichers;
 
 namespace RedditPodcastPoster.UrlSubmission.Factories;
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Matching/EpisodeHelper.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Matching/EpisodeHelper.cs
@@ -3,7 +3,7 @@ using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Text;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Matching;
 
 public class EpisodeHelper : IEpisodeHelper
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Matching/IEpisodeHelper.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Matching/IEpisodeHelper.cs
@@ -1,7 +1,7 @@
 ﻿using RedditPodcastPoster.Models;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Matching;
 
 public interface IEpisodeHelper
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/DiscoverySubmitResultState.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/DiscoverySubmitResultState.cs
@@ -1,4 +1,4 @@
-﻿namespace RedditPodcastPoster.UrlSubmission;
+﻿namespace RedditPodcastPoster.UrlSubmission.Models;
 
 public enum DiscoverySubmitResultState
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitResultState.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Models/SubmitResultState.cs
@@ -1,4 +1,4 @@
-﻿namespace RedditPodcastPoster.UrlSubmission;
+﻿namespace RedditPodcastPoster.UrlSubmission.Models;
 
 public enum SubmitResultState
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/CategorisedItemProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/CategorisedItemProcessor.cs
@@ -5,7 +5,7 @@ using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Factories;
 using RedditPodcastPoster.UrlSubmission.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Processors;
 
 public class CategorisedItemProcessor(
     IPodcastProcessor podcastProcessor,

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/DiscoveryResultProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/DiscoveryResultProcessor.cs
@@ -12,7 +12,7 @@ using RedditPodcastPoster.UrlSubmission.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using Podcast = RedditPodcastPoster.Models.Podcast;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Processors;
 
 public class DiscoveryResultProcessor(
     IUrlCategoriser urlCategoriser,

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/ICategorisedItemProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/ICategorisedItemProcessor.cs
@@ -1,7 +1,7 @@
 ﻿using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Processors;
 
 public interface ICategorisedItemProcessor
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/IDiscoveryResultProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/IDiscoveryResultProcessor.cs
@@ -4,7 +4,7 @@ using RedditPodcastPoster.UrlSubmission.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using Podcast = RedditPodcastPoster.Models.Podcast;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Processors;
 
 public interface IDiscoveryResultProcessor
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/IPodcastProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/IPodcastProcessor.cs
@@ -1,7 +1,7 @@
 ﻿using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Processors;
 
 public interface IPodcastProcessor
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/PodcastProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/PodcastProcessor.cs
@@ -6,10 +6,12 @@ using RedditPodcastPoster.Subjects;
 using RedditPodcastPoster.Subjects.Models;
 using RedditPodcastPoster.Text;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
+using RedditPodcastPoster.UrlSubmission.Enrichers;
 using RedditPodcastPoster.UrlSubmission.Factories;
+using RedditPodcastPoster.UrlSubmission.Matching;
 using RedditPodcastPoster.UrlSubmission.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Processors;
 
 public class PodcastProcessor(
     IEpisodeHelper episodeHelper,

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Services/IPodcastService.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Services/IPodcastService.cs
@@ -2,7 +2,7 @@
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Services;
 
 public interface IPodcastService
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Services/PodcastService.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Services/PodcastService.cs
@@ -15,7 +15,7 @@ using RedditPodcastPoster.PodcastServices.Abstractions.Categorisers;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using Podcast = RedditPodcastPoster.Models.Podcast;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Services;
 
 public class PodcastService(
     IYouTubeServiceWrapper youTubeService,

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Submitters/DiscoveryUrlSubmitter.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Submitters/DiscoveryUrlSubmitter.cs
@@ -2,11 +2,14 @@
 using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.UrlSubmission.Adaptors;
 using RedditPodcastPoster.UrlSubmission.Models;
+using RedditPodcastPoster.UrlSubmission.Processors;
+using RedditPodcastPoster.UrlSubmission.Services;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using Podcast = RedditPodcastPoster.Models.Podcast;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Submitters;
 
 public class DiscoveryUrlSubmitter(
     IPodcastService podcastService,

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Submitters/IDiscoveryUrlSubmitter.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Submitters/IDiscoveryUrlSubmitter.cs
@@ -3,7 +3,7 @@ using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.UrlSubmission.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Submitters;
 
 public interface IDiscoveryUrlSubmitter
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Submitters/IUrlSubmitter.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Submitters/IUrlSubmitter.cs
@@ -2,7 +2,7 @@
 using RedditPodcastPoster.UrlSubmission.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Submitters;
 
 public interface IUrlSubmitter
 {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Submitters/UrlSubmitter.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Submitters/UrlSubmitter.cs
@@ -4,9 +4,11 @@ using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Models;
+using RedditPodcastPoster.UrlSubmission.Processors;
+using RedditPodcastPoster.UrlSubmission.Services;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
-namespace RedditPodcastPoster.UrlSubmission;
+namespace RedditPodcastPoster.UrlSubmission.Submitters;
 
 public class UrlSubmitter(
     IPodcastRepository podcastRepository,

--- a/Cloud/Api/Dtos/SubmitUrlResponse.cs
+++ b/Cloud/Api/Dtos/SubmitUrlResponse.cs
@@ -1,6 +1,5 @@
 using System.Text.Json.Serialization;
 using RedditPodcastPoster.People.Models;
-using RedditPodcastPoster.UrlSubmission;
 using RedditPodcastPoster.UrlSubmission.Models;
 
 namespace Api.Dtos;

--- a/Cloud/Api/Handlers/DiscoveryCurationHandler.cs
+++ b/Cloud/Api/Handlers/DiscoveryCurationHandler.cs
@@ -8,8 +8,8 @@ using RedditPodcastPoster.Auth0;
 using RedditPodcastPoster.EntitySearchIndexer;
 using RedditPodcastPoster.Episodes;
 using RedditPodcastPoster.PodcastServices.Abstractions;
-using RedditPodcastPoster.UrlSubmission;
 using RedditPodcastPoster.UrlSubmission.Models;
+using RedditPodcastPoster.UrlSubmission.Submitters;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
 namespace Api.Handlers;

--- a/Cloud/Api/Handlers/SubmitUrlHandler.cs
+++ b/Cloud/Api/Handlers/SubmitUrlHandler.cs
@@ -7,8 +7,8 @@ using RedditPodcastPoster.Auth0;
 using RedditPodcastPoster.EntitySearchIndexer;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 using RedditPodcastPoster.PodcastServices.Abstractions;
-using RedditPodcastPoster.UrlSubmission;
 using RedditPodcastPoster.UrlSubmission.Models;
+using RedditPodcastPoster.UrlSubmission.Submitters;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
 namespace Api.Handlers;

--- a/Console-Apps/SubmitUrl/SubmitUrlProcessor.cs
+++ b/Console-Apps/SubmitUrl/SubmitUrlProcessor.cs
@@ -3,8 +3,8 @@ using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.EntitySearchIndexer;
 using RedditPodcastPoster.InternetArchive;
 using RedditPodcastPoster.PodcastServices.Abstractions;
-using RedditPodcastPoster.UrlSubmission;
 using RedditPodcastPoster.UrlSubmission.Models;
+using RedditPodcastPoster.UrlSubmission.Submitters;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
 namespace SubmitUrl;


### PR DESCRIPTION
## Summary

Finishes nesting the partially-organised `UrlSubmission` class library so it is no longer top-heavy, continuing the folder-by-sub-namespace pattern from #896–#902.

Moves the 22 remaining root-level types into technical folders matching house style (folder = sub-namespace), mirroring `Persistence.Abstractions` (#902) and the existing `Categorisation`/`Extensions`/`Factories`/`Models` folders in this same assembly:

- **Processors/** — `CategorisedItemProcessor`, `PodcastProcessor`, `DiscoveryResultProcessor` (+ interfaces)
- **Enrichers/** — `EpisodeEnricher`, `DescriptionHelper` (+ interfaces)
- **Matching/** — `EpisodeHelper` (+ interface) — mirrors the `Matching` folder convention already used in `RedditPodcastPoster.Episodes`
- **Adaptors/** — `SubmitResultAdaptor` (+ interface) — spelling matches `RedditPodcastPoster.Common.Adaptors`
- **Services/** — `PodcastService` (+ interface)
- **Submitters/** — `UrlSubmitter`, `DiscoveryUrlSubmitter` (+ interfaces)
- `SubmitResultState` / `DiscoverySubmitResultState` enums moved into the existing **Models/** folder, matching how state enums are placed in other refactored assemblies

Root `.cs` count: **23 → 1**. Only `Constants.cs` remains at the assembly root, matching the same accepted "small cross-cutting leftover" pattern already used at the root of `PodcastServices.Abstractions` and `RedditPodcastPoster.Episodes`. Total file count unchanged at 45.

Public type names and the `AddUrlSubmission()` DI extension method are unchanged. Updated consumer usings across `Cloud/Api`, `Console-Apps/SubmitUrl`, and `RedditPodcastPoster.UrlSubmission.Tests` — several needed new explicit `using` directives because C#'s enclosing-namespace fallback lookup no longer reaches types once they move out of the assembly root namespace into new sibling sub-namespaces. No namespace collisions.

## Test plan

- `RedditPodcastPoster.UrlSubmission.Tests`: **58/58 passed**
- `Cloud/Api` build: green
- `Console-Apps/SubmitUrl` build: green
- `Console-Apps/EnrichExistingEpisodesFromPodcastServices` build: green
- No linter errors on touched files