### PR TITLE
refactor(subjects): finish nesting Subjects into folders matching house style

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Discovery/Adapters/EnrichedEpisodeResultAdapter.cs
+++ b/Class-Libraries/RedditPodcastPoster.Discovery/Adapters/EnrichedEpisodeResultAdapter.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Discovery.Models;
 using RedditPodcastPoster.Models;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Matching;
 
 namespace RedditPodcastPoster.Discovery.Adapters;
 

--- a/Class-Libraries/RedditPodcastPoster.Indexing/Indexer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Indexing/Indexer.cs
@@ -5,7 +5,7 @@ using RedditPodcastPoster.People;
 using RedditPodcastPoster.Persistence.Abstractions.Models;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 using RedditPodcastPoster.PodcastServices.Abstractions;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.Subjects.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Updaters;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/IndexingGuestEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/IndexingGuestEnrichmentRules.cs
@@ -10,7 +10,7 @@ using RedditPodcastPoster.Models;
 using RedditPodcastPoster.People;
 using RedditPodcastPoster.People.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.Subjects.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Updaters;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;

--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/CategorisePodcastLoggerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/CategorisePodcastLoggerRules.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using RedditPodcastPoster.Subjects.Categorisation;
 
 namespace RedditPodcastPoster.Subjects.Tests;
 

--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectEnricherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectEnricherTests.cs
@@ -3,6 +3,8 @@ using FluentAssertions;
 using Moq;
 using Moq.AutoMock;
 using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Subjects.Enrichers;
+using RedditPodcastPoster.Subjects.Matching;
 using RedditPodcastPoster.Subjects.Models;
 
 namespace RedditPodcastPoster.Subjects.Tests;

--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectServiceTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectServiceTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Moq.AutoMock;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions.Providers;
+using RedditPodcastPoster.Subjects.Services;
 
 namespace RedditPodcastPoster.Subjects.Tests;
 

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/CategoriseEpisodeDelta.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/CategoriseEpisodeDelta.cs
@@ -1,4 +1,4 @@
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Categorisation;
 
 /// <summary>
 /// Subject delta for one episode within a podcast-level categorise log line.

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/CategorisePodcastLogger.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/CategorisePodcastLogger.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Categorisation;
 
 /// <summary>
 /// Emits a stable Warning-level podcast categorise line so App Insights can show

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/Categoriser.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/Categoriser.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.Subjects.Models;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Categorisation;
 
 public class Categoriser(
     ISubjectEnricher subjectEnricher,

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/ICategoriser.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/ICategoriser.cs
@@ -1,6 +1,6 @@
 ﻿using RedditPodcastPoster.Models;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Categorisation;
 
 public interface ICategoriser
 {

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/IRecentPodcastEpisodeCategoriser.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/IRecentPodcastEpisodeCategoriser.cs
@@ -1,6 +1,6 @@
 ﻿using RedditPodcastPoster.Models;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Categorisation;
 
 public interface IRecentPodcastEpisodeCategoriser
 {

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/RecentPodcastEpisodeCategoriser.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/RecentPodcastEpisodeCategoriser.cs
@@ -7,7 +7,7 @@ using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Categorisation;
 
 public class RecentPodcastEpisodeCategoriser(
     ICategoriser categoriser,

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Cleansing/ISubjectCleanser.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Cleansing/ISubjectCleanser.cs
@@ -1,4 +1,4 @@
-﻿namespace RedditPodcastPoster.Subjects;
+﻿namespace RedditPodcastPoster.Subjects.Cleansing;
 
 public interface ISubjectCleanser
 {

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Cleansing/SubjectCleanser.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Cleansing/SubjectCleanser.cs
@@ -1,7 +1,8 @@
 ﻿using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Subjects.Services;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Cleansing;
 
 public class SubjectCleanser(
     ISubjectService subjectService,

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Enrichers/ISubjectEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Enrichers/ISubjectEnricher.cs
@@ -1,7 +1,7 @@
 ﻿using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Subjects.Models;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Enrichers;
 
 public interface ISubjectEnricher
 {

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Enrichers/SubjectEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Enrichers/SubjectEnricher.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Models;
+using RedditPodcastPoster.Subjects.Matching;
 using RedditPodcastPoster.Subjects.Models;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Enrichers;
 
 public class SubjectEnricher(
     ISubjectMatcher subjectMatcher,

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Extensions/ServiceCollectionExtensions.cs
@@ -2,8 +2,14 @@
 using RedditPodcastPoster.Persistence.Abstractions.Factories;
 using RedditPodcastPoster.Persistence.Abstractions.Providers;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
+using RedditPodcastPoster.Subjects.Categorisation;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.Subjects.Factories;
 using RedditPodcastPoster.Subjects.HashTags;
+using RedditPodcastPoster.Subjects.Matching;
+using RedditPodcastPoster.Subjects.Providers;
+using RedditPodcastPoster.Subjects.Repositories;
+using RedditPodcastPoster.Subjects.Services;
 
 namespace RedditPodcastPoster.Subjects.Extensions;
 

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Matching/ISubjectMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Matching/ISubjectMatcher.cs
@@ -1,7 +1,7 @@
 ﻿using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Subjects.Models;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Matching;
 
 public interface ISubjectMatcher
 {

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Matching/SubjectMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Matching/SubjectMatcher.cs
@@ -2,8 +2,9 @@
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Subjects.Extensions;
 using RedditPodcastPoster.Subjects.Models;
+using RedditPodcastPoster.Subjects.Services;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Matching;
 
 public class SubjectMatcher(
     ISubjectService subjectService,

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Providers/CachedSubjectProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Providers/CachedSubjectProvider.cs
@@ -3,7 +3,7 @@ using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions.Providers;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Providers;
 
 public class CachedSubjectProvider(
     ISubjectRepository subjectRepository,

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Providers/ICachedSubjectProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Providers/ICachedSubjectProvider.cs
@@ -1,5 +1,5 @@
 ﻿using RedditPodcastPoster.Persistence.Abstractions.Providers;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Providers;
 
 public interface ICachedSubjectProvider : ISubjectsProvider;

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Providers/IRecycledFlareIdProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Providers/IRecycledFlareIdProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace RedditPodcastPoster.Subjects;
+﻿namespace RedditPodcastPoster.Subjects.Providers;
 
 public interface IRecycledFlareIdProvider
 {

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Providers/RecycledFlareIdProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Providers/RecycledFlareIdProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace RedditPodcastPoster.Subjects;
+﻿namespace RedditPodcastPoster.Subjects.Providers;
 
 public class RecycledFlareIdProvider : IRecycledFlareIdProvider
 {

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Repositories/SubjectRepository.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Repositories/SubjectRepository.cs
@@ -6,7 +6,7 @@ using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions.Providers;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Repositories;
 
 public class SubjectRepository(
     Container subjectsContainer,

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Services/ISubjectService.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Services/ISubjectService.cs
@@ -1,7 +1,7 @@
 ﻿using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Subjects.Models;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Services;
 
 public interface ISubjectService
 {

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Services/SubjectService.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Services/SubjectService.cs
@@ -7,7 +7,7 @@ using RedditPodcastPoster.Subjects.Extensions;
 using RedditPodcastPoster.Subjects.Models;
 using RedditPodcastPoster.Text;
 
-namespace RedditPodcastPoster.Subjects;
+namespace RedditPodcastPoster.Subjects.Services;
 
 public class SubjectService(
     ISubjectsProvider subjectRepository,

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionGuestEnrichmentRules.cs
@@ -6,7 +6,7 @@ using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.People;
 using RedditPodcastPoster.People.Models;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.Subjects.Models;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Enrichers;

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
@@ -2,7 +2,7 @@
 using RedditPodcastPoster.Common.Podcasts;
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.People;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Models;
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/PodcastProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/PodcastProcessor.cs
@@ -2,7 +2,7 @@
 using RedditPodcastPoster.Models;
 using RedditPodcastPoster.People;
 using RedditPodcastPoster.People.Models;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.Subjects.Models;
 using RedditPodcastPoster.Text;
 using RedditPodcastPoster.UrlSubmission.Categorisation;

--- a/Cloud/Api/Handlers/EpisodeHandler.cs
+++ b/Cloud/Api/Handlers/EpisodeHandler.cs
@@ -33,7 +33,7 @@ using RedditPodcastPoster.PodcastServices.YouTube.Resolvers;
 using RedditPodcastPoster.Reddit.Managers;
 using RedditPodcastPoster.People;
 using RedditPodcastPoster.People.Models;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Providers;
 using RedditPodcastPoster.Text;
 using RedditPodcastPoster.Twitter;
 using RedditPodcastPoster.Twitter.Models;

--- a/Cloud/Api/Handlers/SubjectHandler.cs
+++ b/Cloud/Api/Handlers/SubjectHandler.cs
@@ -13,8 +13,8 @@ using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 using RedditPodcastPoster.Reddit.Clients;
 using RedditPodcastPoster.Reddit.Configuration;
-using RedditPodcastPoster.Subjects;
 using RedditPodcastPoster.Subjects.Factories;
+using RedditPodcastPoster.Subjects.Services;
 using Subject = RedditPodcastPoster.Models.Subject;
 
 namespace Api.Handlers;

--- a/Cloud/Indexer/Categoriser.cs
+++ b/Cloud/Indexer/Categoriser.cs
@@ -3,7 +3,7 @@ using Microsoft.DurableTask;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RedditPodcastPoster.Configuration;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Categorisation;
 
 namespace Indexer;
 

--- a/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHostTestSupport.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHostTestSupport.cs
@@ -8,7 +8,7 @@ using RedditPodcastPoster.Models;
 using RedditPodcastPoster.Persistence.Abstractions.Factories;
 using RedditPodcastPoster.Persistence.Abstractions.Providers;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Providers;
 
 namespace FunctionHost.Tests;
 

--- a/Console-Apps/AddAudioPodcast/AddAudioPodcastProcessor.cs
+++ b/Console-Apps/AddAudioPodcast/AddAudioPodcastProcessor.cs
@@ -10,7 +10,7 @@ using RedditPodcastPoster.PodcastServices.Apple.Enrichers;
 using RedditPodcastPoster.PodcastServices.Spotify;
 using RedditPodcastPoster.PodcastServices.Spotify.Client;
 using RedditPodcastPoster.PodcastServices.Spotify.Enrichers;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.Subjects.Models;
 using SpotifyAPI.Web;
 using System.Text.RegularExpressions;

--- a/Console-Apps/AddSubjectToSearchMatches/Processor.cs
+++ b/Console-Apps/AddSubjectToSearchMatches/Processor.cs
@@ -4,7 +4,7 @@ using RedditPodcastPoster.EntitySearchIndexer;
 using RedditPodcastPoster.Persistence.Abstractions.Providers;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 using RedditPodcastPoster.Search.Models;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Matching;
 using RedditPodcastPoster.Subjects.Models;
 
 namespace AddSubjectToSearchMatches;

--- a/Console-Apps/CategorisePodcastEpisodes/CategorisePodcastEpisodesProcessor.cs
+++ b/Console-Apps/CategorisePodcastEpisodes/CategorisePodcastEpisodesProcessor.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.EntitySearchIndexer;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Categorisation;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.Subjects.Models;
 
 namespace CategorisePodcastEpisodes;

--- a/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubePodcastProcessor.cs
+++ b/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubePodcastProcessor.cs
@@ -17,7 +17,7 @@ using RedditPodcastPoster.PodcastServices.YouTube.Extensions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 using RedditPodcastPoster.PodcastServices.YouTube.Video;
-using RedditPodcastPoster.Subjects;
+using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.Subjects.Models;
 using RedditPodcastPoster.Text.EliminationTerms;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;


### PR DESCRIPTION
## Summary

Finishes nesting the partially-organised `Subjects` class library so it is no longer top-heavy, continuing the folder-by-sub-namespace pattern from #896-#903.

Moves the 19 remaining root-level types (59% of 32 files) into technical folders matching house style (folder = sub-namespace), mirroring `Persistence.Abstractions` (#902) and `UrlSubmission` (#903), and leaving the existing `Extensions`/`Factories`/`HashTags`/`Models` folders in this assembly untouched:

- **Providers/** - `CachedSubjectProvider`, `RecycledFlareIdProvider` (+ interfaces)
- **Repositories/** - `SubjectRepository`
- **Enrichers/** - `SubjectEnricher` (+ interface)
- **Matching/** - `SubjectMatcher` (+ interface)
- **Services/** - `SubjectService` (+ interface)
- **Cleansing/** - `SubjectCleanser` (+ interface)
- **Categorisation/** - `Categoriser`, `RecentPodcastEpisodeCategoriser` (+ interfaces), `CategorisePodcastLogger`, `CategoriseEpisodeDelta`

Root `.cs` count: **19 -> 0** (32 files total, unchanged). No leftovers at the assembly root.

Public type names and the `AddSubjectServices()` / `AddCachedSubjectProvider()` / `AddSubjectProvider()` DI extension methods are unchanged. Updated consumer usings across `Cloud/Api`, `Cloud/Indexer`, `Cloud/Unit-Tests/FunctionHost.Tests`, `Console-Apps` (`AddAudioPodcast`, `AddSubjectToSearchMatches`, `CategorisePodcastEpisodes`, `EnrichYouTubeOnlyPodcasts`), `RedditPodcastPoster.Discovery`, `RedditPodcastPoster.Indexing`, `RedditPodcastPoster.UrlSubmission` (+ `.Tests`), `RedditPodcastPoster.PodcastServices.Tests`, and `RedditPodcastPoster.Subjects.Tests` - several needed new explicit `using` directives because C#'s enclosing-namespace fallback lookup no longer reaches types once they move out of the assembly root namespace into new sibling sub-namespaces. Consumers that only referenced `ISubjectRepository`/`ISubjectsProvider` (defined in `Persistence.Abstractions`) needed no changes. No namespace collisions (`Indexer.Categoriser` in `Cloud/Indexer` is a distinct type in its own namespace from the moved `RedditPodcastPoster.Subjects.Categorisation.Categoriser`).

Base includes #903 (`refactor(urlsubmission)`); branched from updated `main`. Did not touch `Persistence`, `ContentPublisher`, `Models`, or Durable hosts.

## Test plan

- `RedditPodcastPoster.Subjects.Tests`: **25/25 passed**
- `RedditPodcastPoster.UrlSubmission.Tests`: **58/58 passed**
- `RedditPodcastPoster.PodcastServices.Tests`: **57/57 passed**
- `FunctionHost.Tests`: **24/24 passed**
- Full solution build (`RedditPodcastPoster.slnx`): green, 0 errors
- No linter errors on touched files
