### PR TITLE
style+docs: usings before namespace, folder=namespace ADR, IDE0130

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,8 +23,5 @@ dotnet_diagnostic.IDE0130.severity = warning
 # csharp_using_directive_placement is not a standard Roslyn option; usings-before-namespace is enforced by review/ADR.
 
 # Vendored / third-party sources — do not enforce our folder=namespace rule.
-[Third-Party/**.cs]
-dotnet_diagnostic.IDE0130.severity = none
-
 [Third-Party/**/*.cs]
 dotnet_diagnostic.IDE0130.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# EditorConfig for RedditPodcastPoster
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{csproj,props,targets,json,yml,yaml,md}]
+indent_size = 2
+
+[*.cs]
+# House rule: folder path under the project root matches namespace under RootNamespace
+# (see docs/adr/0001-folder-equals-namespace.md). IDE0130 = Namespace does not match folder structure.
+dotnet_style_namespace_match_folder = true
+dotnet_diagnostic.IDE0130.severity = warning
+
+# Prefer usings before file-scoped namespace (IDE0161 suggests file-scoped; ordering is a style convention).
+# csharp_using_directive_placement is not a standard Roslyn option; usings-before-namespace is enforced by review/ADR.
+
+# Vendored / third-party sources — do not enforce our folder=namespace rule.
+[Third-Party/**.cs]
+dotnet_diagnostic.IDE0130.severity = none
+
+[Third-Party/**/*.cs]
+dotnet_diagnostic.IDE0130.severity = none

--- a/Class-Libraries/RedditPodcastPoster.AI/Classifiers/EpisodeClassifier.cs
+++ b/Class-Libraries/RedditPodcastPoster.AI/Classifiers/EpisodeClassifier.cs
@@ -1,12 +1,11 @@
-using RedditPodcastPoster.AI.Configuration;
-
-namespace RedditPodcastPoster.AI.Classifiers;
-
 using Azure.AI.TextAnalytics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using RedditPodcastPoster.AI.Configuration;
 using RedditPodcastPoster.Models.Episodes;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
+
+namespace RedditPodcastPoster.AI.Classifiers;
 
 public class EpisodeClassifier(
     ISubjectRepository subjectRepository,

--- a/Class-Libraries/RedditPodcastPoster.AI/Classifiers/IEpisodeClassifier.cs
+++ b/Class-Libraries/RedditPodcastPoster.AI/Classifiers/IEpisodeClassifier.cs
@@ -1,6 +1,6 @@
-namespace RedditPodcastPoster.AI.Classifiers;
-
 using RedditPodcastPoster.Models.Episodes;
+
+namespace RedditPodcastPoster.AI.Classifiers;
 
 public interface IEpisodeClassifier
 {

--- a/Class-Libraries/RedditPodcastPoster.DependencyInjection.Abstractions/RedditPodcastPoster.DependencyInjection.Abstractions.csproj
+++ b/Class-Libraries/RedditPodcastPoster.DependencyInjection.Abstractions/RedditPodcastPoster.DependencyInjection.Abstractions.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Types intentionally use RedditPodcastPoster.DependencyInjection (not …Abstractions). See docs/adr/0001-folder-equals-namespace.md. -->
+    <RootNamespace>RedditPodcastPoster.DependencyInjection</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Services/IEpisodeSearchIndexerService.cs
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Services/IEpisodeSearchIndexerService.cs
@@ -1,9 +1,8 @@
 using RedditPodcastPoster.EntitySearchIndexer.Models;
-
-namespace RedditPodcastPoster.EntitySearchIndexer.Services;
-
 using RedditPodcastPoster.Models.Episodes;
 using RedditPodcastPoster.Models.Podcasts;
+
+namespace RedditPodcastPoster.EntitySearchIndexer.Services;
 
 public interface IEpisodeSearchIndexerService
 {

--- a/docs/adr/0001-folder-equals-namespace.md
+++ b/docs/adr/0001-folder-equals-namespace.md
@@ -1,0 +1,40 @@
+# ADR 0001: Folder equals namespace
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Related:** PRs #896–#909
+
+## Context
+
+Several assemblies had most `.cs` files at the project root, so namespaces were flat and hard to navigate. Over a series of PRs we nested types into folders that match sub-namespaces (Models, Durable hosts, smaller class libraries).
+
+We need a durable house rule so new code does not reintroduce top-heavy layouts, and so IDE/analyzers can flag drift.
+
+## Decision
+
+1. **Folder = namespace.** Under a project, the folder path relative to the project root must match the namespace under that project’s `RootNamespace` (default: assembly / project name). Example: `Episodes/Episode.cs` → `RedditPodcastPoster.Models.Episodes`.
+2. **Do not change `RootNamespace`** to invent a shorter namespace tree unless there is an intentional exception (see below). Prefer nesting folders instead.
+3. **DI registration** lives in `Extensions/` (typically `ServiceCollectionExtensions`), namespace `….Extensions`.
+4. **Usings before `namespace`.** All `using` directives appear above the file-scoped (or block) namespace declaration; no blank lines between usings.
+5. Prefer `using` directives over fully qualified type names; use aliases only for name collisions.
+6. **Durable Functions:** nested namespaces for hosts are fine; keep orchestration/activity/trigger **class names** and `[Function]` / `[DurableTask]` **names** stable (App Insights and Durable identity).
+7. **Cosmos entities:** do not rename CLR type names, `ModelType` enum values, or `[JsonPropertyName]` values solely for folder layout.
+
+### Enforcement
+
+- Roslyn **IDE0130** (`dotnet_style_namespace_match_folder`) is enabled as a **warning** in the repo `.editorconfig`.
+- Fix incrementally; do not treat IDE0130 as a CI error until the solution stays clean under normal development.
+
+### Intentional exceptions
+
+| Case | Approach |
+|------|----------|
+| `Third-Party/**` | IDE0130 suppressed in `.editorconfig` |
+| `RedditPodcastPoster.DependencyInjection.Abstractions` | Types intentionally live in `RedditPodcastPoster.DependencyInjection`; project sets `RootNamespace` to that value so folder=namespace still holds |
+| Durable **function class names** | May differ from folder leaf names only where renaming would break Durable/App Insights; namespaces still match folders |
+
+## Consequences
+
+- New types should be added under a domain/technical folder with a matching namespace.
+- Reviewers and agents can reject top-level dumps of many unrelated types.
+- Occasional IDE0130 warnings guide cleanup; suppressions must be justified and documented here or beside the code.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,7 @@
+# Architecture decision records
+
+Short records of structural decisions for this repo.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-folder-equals-namespace.md) | Folder equals namespace | Accepted |


### PR DESCRIPTION
## Summary
- Place remaining usings above `namespace` (3 files from #908 follow-up)
- ADR 0001: folder equals namespace house rule
- Enable IDE0130 as warning in root `.editorconfig`
- Set `RootNamespace` on DependencyInjection.Abstractions to match intentional `RedditPodcastPoster.DependencyInjection` types

## Test plan
- [x] Build DependencyInjection.Abstractions
- [ ] Spot-check IDE0130 warnings in IDE after merge
