### PR TITLE
fix: title casing for apostrophes and non-Latin prefixes

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Text.Tests/TextSanitiserTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text.Tests/TextSanitiserTests.cs
@@ -231,6 +231,60 @@ public class TextSanitiserTests
     }
 
     [Theory]
+    [InlineData("The Object\u2019s", "The Object's")]
+    [InlineData("Person\u2019s Thing", "Person's Thing")]
+    [InlineData("Person\u2018s Thing", "Person's Thing")]
+    [InlineData("Person\u02BCs Thing", "Person's Thing")]
+    [InlineData("Person\u2032s Thing", "Person's Thing")]
+    [InlineData("Person\u00B4s Thing", "Person's Thing")]
+    public async Task SanitiseTitle_WithTypographicApostrophe_DoesNotCapitaliseFollowingLetter(
+        string input, string expected)
+    {
+        // arrange
+        // act
+        var result = await Sut.SanitiseTitle(input, null, [], []);
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("L'amour Topic", "l'Amour Topic")]
+    [InlineData("D'artagnan Topic", "d'Artagnan Topic")]
+    [InlineData("l'amour Topic", "l'Amour Topic")]
+    [InlineData("d'artagnan Topic", "d'Artagnan Topic")]
+    [InlineData("Something L'amour Topic", "Something l'Amour Topic")]
+    [InlineData("Something D'artagnan Topic", "Something d'Artagnan Topic")]
+    [InlineData("L\u2019amour Topic", "l'Amour Topic")]
+    [InlineData("D\u2019artagnan Topic", "d'Artagnan Topic")]
+    [InlineData("L\u2018amour Topic", "l'Amour Topic")]
+    [InlineData("D\u2018artagnan Topic", "d'Artagnan Topic")]
+    [InlineData("Something L\u2019amour Topic", "Something l'Amour Topic")]
+    [InlineData("Something D\u2019artagnan Topic", "Something d'Artagnan Topic")]
+    public async Task SanitiseTitle_WithRomanceElision_LowercasesParticleAndCapitalisesFollowingLetter(
+        string input, string expected)
+    {
+        // arrange
+        // act
+        var result = await Sut.SanitiseTitle(input, null, [], []);
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Don't Stop")]
+    [InlineData("Didn't Stop")]
+    [InlineData("It's Fine")]
+    [InlineData("I'd Agree")]
+    public async Task SanitiseTitle_WithEnglishContraction_DoesNotApplyRomanceElision(string expected)
+    {
+        // arrange
+        // act
+        var result = await Sut.SanitiseTitle(expected, null, [], []);
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData("1st Something")]
     [InlineData("2nd Something")]
     [InlineData("3rd Something")]
@@ -258,6 +312,33 @@ public class TextSanitiserTests
         // arrange
         // act
         var result = await Sut.SanitiseTitle(expected, null, [], []);
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("日本語 Title Topic", "日本語 Title Topic")]
+    [InlineData("完全に日本語だけ", "完全に日本語だけ")]
+    [InlineData("한글 Title Topic", "한글 Title Topic")]
+    [InlineData("Épisode Spécial", "Épisode Spécial")]
+    public async Task SanitiseTitle_WithNonAsciiLetters_PreservesLeadingLetters(
+        string input, string expected)
+    {
+        // arrange
+        // act
+        var result = await Sut.SanitiseTitle(input, null, [], []);
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("*** Title", "Title")]
+    [InlineData("🔥 Title", "Title")]
+    public async Task SanitiseTitle_WithJunkPrefix_StripsPrefix(string input, string expected)
+    {
+        // arrange
+        // act
+        var result = await Sut.SanitiseTitle(input, null, [], []);
         // assert
         result.Should().Be(expected);
     }

--- a/Class-Libraries/RedditPodcastPoster.Text/Sanitisers/StringSanitizer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text/Sanitisers/StringSanitizer.cs
@@ -9,6 +9,12 @@ public static class StringSanitizer
         title = title.Replace("&amp;", "&");
         title = title.Replace("&#8217;", "'");
         title = title.Replace("&#39;", "'");
+        // Typographic / lookalike apostrophes: ToTitleCase capitalises the following letter (e.g. ’s → ’S)
+        title = title.Replace('\u2018', '\''); // left single quotation mark
+        title = title.Replace('\u2019', '\''); // right single quotation mark
+        title = title.Replace('\u02BC', '\''); // modifier letter apostrophe
+        title = title.Replace('\u2032', '\''); // prime
+        title = title.Replace('\u00B4', '\''); // acute accent
         title = title.Replace("\n", " ");
         title = title.Replace("\r", " ");
         title = title.Replace("&lt;", "<");

--- a/Class-Libraries/RedditPodcastPoster.Text/Sanitisers/TextSanitiser.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text/Sanitisers/TextSanitiser.cs
@@ -13,6 +13,7 @@ public partial class TextSanitiser(
     : ITextSanitiser
 {
     private static readonly Regex OApostrophe = CreateOApostrophe();
+    private static readonly Regex RomanceElisionApostrophe = CreateRomanceElisionApostrophe();
     private static readonly Regex HashtagOrAtSymbols = GenerateHashTagAtSymbolPatter();
     private static readonly Regex InQuotes = GenerateInQuotes();
     private static readonly Regex InvalidTitlePrefix = GenerateInvalidTitlePrefix();
@@ -56,6 +57,7 @@ public partial class TextSanitiser(
         episodeTitle = HashtagOrAtSymbols.Replace(episodeTitle, "$1");
         episodeTitle = TextInfo.ToTitleCase(episodeTitle.ToLower());
         episodeTitle = RaiseOfApostropheLetter(episodeTitle);
+        episodeTitle = FixRomanceElisionApostrophe(episodeTitle);
         episodeTitle = LowerPostAsteriskLetters(episodeTitle);
         foreach (var term in LowerCaseTerms.Expressions)
         {
@@ -117,6 +119,22 @@ public partial class TextSanitiser(
             var index = match.Index;
             var length = match.Length;
             var pre = match.Groups["pre"].Value;
+            var post = match.Groups["post"].Value;
+            text = text.Substring(0, index) + pre + "'" + TextInfo.ToTitleCase(post.ToLower()) +
+                   text.Substring(index + length);
+        }
+
+        return text;
+    }
+
+    public string FixRomanceElisionApostrophe(string text)
+    {
+        var matches = RomanceElisionApostrophe.Matches(text);
+        foreach (Match match in matches)
+        {
+            var index = match.Index;
+            var length = match.Length;
+            var pre = match.Groups["pre"].Value.ToLower();
             var post = match.Groups["post"].Value;
             text = text.Substring(0, index) + pre + "'" + TextInfo.ToTitleCase(post.ToLower()) +
                    text.Substring(index + length);
@@ -227,7 +245,7 @@ public partial class TextSanitiser(
         return input;
     }
 
-    [GeneratedRegex(@"(?'prefix'^[^a-zA-Z\d""\$\┬ú\'\(]+)(?'after'.*$)", RegexOptions.Compiled)]
+    [GeneratedRegex(@"(?'prefix'^[^\p{L}\p{N}""\$\u00A3\'\(]+)(?'after'.*$)", RegexOptions.Compiled)]
     private static partial Regex GenerateInvalidTitlePrefix();
 
     [GeneratedRegex(@"[#@](\w+)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-GB")]
@@ -244,6 +262,9 @@ public partial class TextSanitiser(
 
     [GeneratedRegex(@"\b(?'pre'O)'\b(?'post'\w+)\b", RegexOptions.Compiled)]
     private static partial Regex CreateOApostrophe();
+
+    [GeneratedRegex(@"\b(?'pre'[LlDd])'\b(?'post'\w+)\b", RegexOptions.Compiled)]
+    private static partial Regex CreateRomanceElisionApostrophe();
 
     [GeneratedRegex(@"\bS\d+ ?E\d+\b", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
     private static partial Regex GenerateSeasonEpisode();


### PR DESCRIPTION
## Summary
- Normalise typographic/lookalike apostrophes (U+2018/2019/02BC/2032/00B4) to ASCII `'` before `ToTitleCase`, so possessives no longer become `'S`.
- Keep leading Unicode letters/numbers in titles (CJK, accented Latin); still strip junk prefixes like `***` / emoji.
- Apply French/Spanish `l'` / `d'` elision casing (`l'Amour`, `d'Artagnan`) without mangling English contractions.

## Test plan
- [x] `TextSanitiserTests` — typographic apostrophe possessives
- [x] `TextSanitiserTests` — romance elision (start + mid-title, ASCII + curly)
- [x] `TextSanitiserTests` — English contractions unchanged
- [x] `TextSanitiserTests` — non-ASCII leading letters preserved; junk prefixes stripped
- [ ] Spot-check an X post of a title with curly `'s` and a non-Latin leading title after deploy

Made with [Cursor](https://cursor.com)