### PR TITLE
fix: subject create continues when Reddit flair fails

### DIFF
--- a/Cloud/Api/Handlers/SubjectHandler.cs
+++ b/Cloud/Api/Handlers/SubjectHandler.cs
@@ -177,54 +177,64 @@ public class SubjectHandler(
 
     private async Task UseFlair(Subject subject, Guid flairId)
     {
-        var subredditFlairs = redditClient.Client
-            .Subreddit(_subredditSettings.SubredditName)
-            .Flairs
-            .GetLinkFlairV2();
-        var flair = subredditFlairs.SingleOrDefault(x => x.Id == flairId.ToString());
-        if (flair == null)
+        try
         {
-            throw new InvalidOperationException($"Unable to find subreddit-flair with id '{flairId}'.");
-        }
-
-        if (!flair.TextEditable)
-        {
-            var subjectsUsingFlair =
-                await subjectRepository.GetAllBy(x => x.RedditFlairTemplateId == flairId).ToListAsync();
-            if (subjectsUsingFlair.Count == 1)
-            {
-                var subjectUsingFlair = subjectsUsingFlair.Single();
-                subjectUsingFlair.RedditFlareText = flair.Text;
-                await subjectRepository.Save(subjectUsingFlair);
-                logger.LogInformation(
-                    "Adjusted subject '{subjectUsingFlairName}' with id '{subjectUsingFlairId}' to have  {nameofRedditFlareText}='{flairText}'.",
-                    subjectUsingFlair.Name, subjectUsingFlair.Id, nameof(subjectUsingFlair.RedditFlareText),
-                    flair.Text);
-            }
-
-            flair.TextEditable = true;
-            var updateResult = await redditClient.Client
+            var subredditFlairs = redditClient.Client
                 .Subreddit(_subredditSettings.SubredditName)
                 .Flairs
-                .UpdateLinkFlairTemplateV2Async(new FlairTemplateV2Input
-                {
-                    background_color = flair.BackgroundColor,
-                    flair_template_id = flair.Id,
-                    flair_type = flair.Type,
-                    text = flair.Text,
-                    text_color = flair.TextColor,
-                    text_editable = true
-                });
-            if (!updateResult.TextEditable)
+                .GetLinkFlairV2();
+            var flair = subredditFlairs.SingleOrDefault(x => x.Id == flairId.ToString());
+            if (flair == null)
             {
-                logger.LogError("Error updating flare '{flairText}' with id '{flairId}'.", flair.Text, flair.Id);
+                logger.LogError("Unable to find subreddit-flair with id '{flairId}'.", flairId);
+                return;
+            }
+
+            if (!flair.TextEditable)
+            {
+                var subjectsUsingFlair =
+                    await subjectRepository.GetAllBy(x => x.RedditFlairTemplateId == flairId).ToListAsync();
+                if (subjectsUsingFlair.Count == 1)
+                {
+                    var subjectUsingFlair = subjectsUsingFlair.Single();
+                    subjectUsingFlair.RedditFlareText = flair.Text;
+                    await subjectRepository.Save(subjectUsingFlair);
+                    logger.LogInformation(
+                        "Adjusted subject '{subjectUsingFlairName}' with id '{subjectUsingFlairId}' to have  {nameofRedditFlareText}='{flairText}'.",
+                        subjectUsingFlair.Name, subjectUsingFlair.Id, nameof(subjectUsingFlair.RedditFlareText),
+                        flair.Text);
+                }
+
+                flair.TextEditable = true;
+                var updateResult = await redditClient.Client
+                    .Subreddit(_subredditSettings.SubredditName)
+                    .Flairs
+                    .UpdateLinkFlairTemplateV2Async(new FlairTemplateV2Input
+                    {
+                        background_color = flair.BackgroundColor,
+                        flair_template_id = flair.Id,
+                        flair_type = flair.Type,
+                        text = flair.Text,
+                        text_color = flair.TextColor,
+                        text_editable = true
+                    });
+                if (!updateResult.TextEditable)
+                {
+                    logger.LogError("Error updating flare '{flairText}' with id '{flairId}'.", flair.Text, flair.Id);
+                }
+            }
+
+            subject.RedditFlairTemplateId = flairId;
+            if (!string.IsNullOrWhiteSpace(subject.RedditFlareText))
+            {
+                subject.RedditFlareText = subject.Name;
             }
         }
-
-        subject.RedditFlairTemplateId = flairId;
-        if (!string.IsNullOrWhiteSpace(subject.RedditFlareText))
+        catch (Exception ex)
         {
-            subject.RedditFlareText = subject.Name;
+            logger.LogError(ex,
+                "Failed to apply Reddit flair '{flairId}' for subject '{subjectName}'. Continuing without flair update.",
+                flairId, subject.Name);
         }
     }
 }

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Handlers/SubjectHandlerTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Handlers/SubjectHandlerTests.cs
@@ -1,0 +1,127 @@
+using System.Linq.Expressions;
+using System.Net;
+using Azure.Core.Serialization;
+using FluentAssertions;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.AutoMock;
+using Api.Dtos;
+using Api.Handlers;
+using Reddit.Exceptions;
+using RedditPodcastPoster.ContentPublisher.Publishers;
+using RedditPodcastPoster.Persistence.Abstractions.Repositories;
+using RedditPodcastPoster.Reddit.Clients;
+using RedditPodcastPoster.Reddit.Configuration;
+using RedditPodcastPoster.Subjects.Factories;
+using RedditPodcastPoster.Subjects.Services;
+using Xunit;
+using SubjectEntity = RedditPodcastPoster.Models.Subjects.Subject;
+
+namespace FunctionHost.Tests.Api.Handlers;
+
+public class SubjectHandlerTests
+{
+    private readonly AutoMocker _mocker = new();
+
+    public SubjectHandlerTests()
+    {
+        _mocker.Use(Options.Create(new SubredditSettings { SubredditName = "testsubreddit" }));
+    }
+
+    private SubjectHandler Sut => _mocker.CreateInstance<SubjectHandler>();
+
+    [Fact]
+    public async Task Put_WhenRedditFlairUpdateForbidden_StillCreatesSubject()
+    {
+        // arrange
+        var flairId = Guid.NewGuid();
+        var entity = new SubjectEntity("Topic") { Id = Guid.NewGuid() };
+        _mocker.GetMock<ISubjectFactory>()
+            .Setup(x => x.Create("Topic", null, null, null))
+            .ReturnsAsync(entity);
+        _mocker.GetMock<ISubjectService>()
+            .Setup(x => x.Match(It.IsAny<SubjectEntity>()))
+            .ReturnsAsync((SubjectEntity?)null);
+        _mocker.GetMock<IAdminRedditClient>()
+            .Setup(x => x.Client)
+            .Throws(new RedditForbiddenException("Reddit API returned Forbidden (403) response."));
+        var (req, _) = CreateRequestResponse("PUT");
+
+        // act
+        var result = await Sut.Put(
+            req.Object,
+            new Subject { Name = "Topic", RedditFlairTemplateId = flairId },
+            null,
+            CancellationToken.None);
+
+        // assert
+        result.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        _mocker.GetMock<ISubjectRepository>().Verify(
+            x => x.Save(It.Is<SubjectEntity>(s => s.RedditFlairTemplateId == flairId)),
+            Times.Once);
+        _mocker.GetMock<ISubjectsPublisher>().Verify(x => x.PublishSubjects(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Post_WhenRedditFlairUpdateForbidden_StillUpdatesSubject()
+    {
+        // arrange
+        var subjectId = Guid.NewGuid();
+        var flairId = Guid.NewGuid();
+        var existing = new SubjectEntity("Topic") { Id = subjectId };
+        _mocker.GetMock<ISubjectRepository>()
+            .Setup(x => x.GetBy(It.IsAny<Expression<Func<SubjectEntity, bool>>>()))
+            .ReturnsAsync(existing);
+        _mocker.GetMock<IAdminRedditClient>()
+            .Setup(x => x.Client)
+            .Throws(new RedditForbiddenException("Reddit API returned Forbidden (403) response."));
+        var (req, _) = CreateRequestResponse("POST");
+
+        // act
+        var result = await Sut.Post(
+            req.Object,
+            new SubjectChangeRequestWrapper(subjectId, new Subject { RedditFlairTemplateId = flairId }),
+            null,
+            CancellationToken.None);
+
+        // assert
+        result.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        existing.RedditFlairTemplateId.Should().Be(flairId);
+        _mocker.GetMock<ISubjectRepository>().Verify(x => x.Save(existing), Times.Once);
+    }
+
+    private static (Mock<HttpRequestData> Req, Mock<HttpResponseData> Response) CreateRequestResponse(
+        string method)
+    {
+        var services = new ServiceCollection();
+        services.Configure<WorkerOptions>(options =>
+        {
+            options.Serializer = new JsonObjectSerializer();
+        });
+        var serviceProvider = services.BuildServiceProvider();
+
+        var context = new Mock<FunctionContext>();
+        context.SetupGet(c => c.InstanceServices).Returns(serviceProvider);
+        var functionDefinition = new Mock<FunctionDefinition>();
+        functionDefinition.SetupGet(d => d.Name).Returns("TestFunction");
+        context.SetupGet(c => c.FunctionDefinition).Returns(functionDefinition.Object);
+        context.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+
+        var response = new Mock<HttpResponseData>(context.Object);
+        response.SetupProperty(r => r.StatusCode, HttpStatusCode.OK);
+        response.SetupProperty(r => r.Headers, new HttpHeadersCollection());
+        response.Setup(r => r.Body).Returns(new MemoryStream());
+
+        var req = new Mock<HttpRequestData>(context.Object);
+        req.Setup(r => r.CreateResponse()).Returns(response.Object);
+        req.Setup(r => r.Url).Returns(new Uri("https://localhost/api/subject"));
+        req.Setup(r => r.Method).Returns(method);
+        req.Setup(r => r.Headers).Returns(new HttpHeadersCollection());
+        req.Setup(r => r.Body).Returns(new MemoryStream());
+
+        return (req, response);
+    }
+}

--- a/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHost.Tests.csproj
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHost.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- Wrap `UseFlair` so Reddit failures (e.g. `RedditForbiddenException` on flair template update) are logged as errors instead of aborting subject create/update.
- Missing flair templates are also logged and skipped rather than throwing.

## Test plan
- [ ] Create a subject with a Reddit flair template id when Reddit returns 403 — subject should still be created; error logged in App Insights
- [ ] Update an existing subject flair under the same failure — subject update succeeds; error logged
- [ ] Happy path: editable flair update still works when Reddit succeeds

Made with [Cursor](https://cursor.com)