### PR TITLE
feat(api): dual Auth0 issuer trust with staging feature switch

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Auth0/Configuration/Auth0ValidationOptions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Auth0/Configuration/Auth0ValidationOptions.cs
@@ -1,8 +1,53 @@
 namespace RedditPodcastPoster.Auth0.Configuration;
 
+/// <summary>
+/// Optional staging Auth0 trust for api-preview. Bound from <c>auth0__Staging__*</c>.
+/// </summary>
+public class Auth0StagingValidationOptions
+{
+    /// <summary>
+    /// When false (default), staging issuer is ignored even if Domain/Issuer are set.
+    /// </summary>
+    public bool Trust { get; set; }
+
+    /// <summary>Auth0 custom domain (e.g. auth-staging.cultpodcasts.com).</summary>
+    public string? Domain { get; set; }
+
+    /// <summary>Issuer URL including trailing slash (e.g. https://auth-staging.cultpodcasts.com/).</summary>
+    public string? Issuer { get; set; }
+}
+
 public class Auth0ValidationOptions
 {
     public required string Audience { get; set; }
     public required string Domain { get; set; }
     public required string Issuer { get; set; }
+
+    /// <summary>Staging Auth0 settings (<c>auth0__Staging__Domain</c>, etc.).</summary>
+    public Auth0StagingValidationOptions? Staging { get; set; }
+
+    public bool TrustsStagingIssuer =>
+        Staging is { Trust: true } &&
+        !string.IsNullOrWhiteSpace(Staging.Domain) &&
+        !string.IsNullOrWhiteSpace(Staging.Issuer);
+
+    public IReadOnlyList<string> GetTrustedIssuers()
+    {
+        if (!TrustsStagingIssuer)
+        {
+            return [Issuer];
+        }
+
+        return [Issuer, Staging!.Issuer!];
+    }
+
+    public IReadOnlyList<string> GetTrustedDomains()
+    {
+        if (!TrustsStagingIssuer)
+        {
+            return [Domain];
+        }
+
+        return [Domain, Staging!.Domain!];
+    }
 }

--- a/Class-Libraries/RedditPodcastPoster.Auth0/Factories/SigningKeysFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Auth0/Factories/SigningKeysFactory.cs
@@ -13,16 +13,20 @@ public class SigningKeysFactory(IOptions<Auth0ValidationOptions> auth0Validation
                                                        throw new ArgumentNullException(
                                                            $"Missing '{nameof(Auth0ValidationOptions)}'.");
 
-    // Implement IAsyncFactory<T>.Create() as a public method to avoid explicit interface resolution
     public async Task<ICollection<SecurityKey>?> Create()
     {
-        var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
-            $"https://{_options.Domain}/.well-known/openid-configuration",
-            new OpenIdConnectConfigurationRetriever(),
-            new HttpDocumentRetriever());
+        var keys = new List<SecurityKey>();
+        foreach (var domain in _options.GetTrustedDomains())
+        {
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                $"https://{domain}/.well-known/openid-configuration",
+                new OpenIdConnectConfigurationRetriever(),
+                new HttpDocumentRetriever());
 
-        var discoveryDocument = await configurationManager.GetConfigurationAsync();
-        var signingKeys = discoveryDocument.SigningKeys;
-        return signingKeys;
+            var discoveryDocument = await configurationManager.GetConfigurationAsync();
+            keys.AddRange(discoveryDocument.SigningKeys);
+        }
+
+        return keys;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Auth0/Validators/Auth0TokenValidator.cs
+++ b/Class-Libraries/RedditPodcastPoster.Auth0/Validators/Auth0TokenValidator.cs
@@ -19,10 +19,11 @@ public class Auth0TokenValidator(
     public async Task<ValidatedToken?> GetClaimsPrincipalAsync(string auth0Bearer)
     {
         var securityKeys = await securityKeysProvider.GetAsync();
+        var trustedIssuers = _options.GetTrustedIssuers();
         var validationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,
-            ValidIssuer = _options.Issuer,
+            ValidIssuers = trustedIssuers,
             ValidateAudience = true,
             ValidAudience = _options.Audience,
             ValidateIssuerSigningKey = true,
@@ -40,7 +41,10 @@ public class Auth0TokenValidator(
                 return null;
             }
 
-            logger.LogInformation("Token valid.");
+            logger.LogInformation(
+                "Token valid. TrustedIssuers={TrustedIssuerCount}, TrustStagingIssuer={TrustStagingIssuer}.",
+                trustedIssuers.Count,
+                _options.TrustsStagingIssuer);
             return new ValidatedToken(claimsPrincipal, token);
         }
         catch (Exception e)

--- a/Class-Libraries/RedditPodcastPoster.Auth0/Validators/Auth0ValidationOptionsValidator.cs
+++ b/Class-Libraries/RedditPodcastPoster.Auth0/Validators/Auth0ValidationOptionsValidator.cs
@@ -25,6 +25,21 @@ public class Auth0ValidationOptionsValidator : IValidateOptions<Auth0ValidationO
                 $"{nameof(Auth0ValidationOptions)}.{nameof(Auth0ValidationOptions.Issuer)} must not be null or empty (config key: auth0__Issuer).");
         }
 
+        if (options.Staging is { Trust: true })
+        {
+            if (string.IsNullOrWhiteSpace(options.Staging.Domain))
+            {
+                return ValidateOptionsResult.Fail(
+                    $"{nameof(Auth0ValidationOptions)}.{nameof(Auth0ValidationOptions.Staging)}.{nameof(Auth0StagingValidationOptions.Domain)} must not be null or empty when Staging.Trust is true (config key: auth0__Staging__Domain).");
+            }
+
+            if (string.IsNullOrWhiteSpace(options.Staging.Issuer))
+            {
+                return ValidateOptionsResult.Fail(
+                    $"{nameof(Auth0ValidationOptions)}.{nameof(Auth0ValidationOptions.Staging)}.{nameof(Auth0StagingValidationOptions.Issuer)} must not be null or empty when Staging.Trust is true (config key: auth0__Staging__Issuer).");
+            }
+        }
+
         return ValidateOptionsResult.Success;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Persistence.Tests/Auth0ValidationOptionsValidatorTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Persistence.Tests/Auth0ValidationOptionsValidatorTests.cs
@@ -15,6 +15,14 @@ public class Auth0ValidationOptionsValidatorTests
     }
 
     [Fact]
+    public void Succeeds_when_Staging_Trust_is_true_and_staging_is_configured()
+    {
+        var options = ValidOptionsWithTrustedStaging();
+
+        _validator.Validate(null, options).Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
     public void Fails_when_Audience_is_blank()
     {
         var options = ValidOptions();
@@ -50,10 +58,70 @@ public class Auth0ValidationOptionsValidatorTests
         result.FailureMessage.Should().Contain("Issuer");
     }
 
+    [Fact]
+    public void Fails_when_Staging_Trust_true_but_Domain_blank()
+    {
+        var options = ValidOptionsWithTrustedStaging();
+        options.Staging!.Domain = " ";
+
+        var result = _validator.Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Staging");
+        result.FailureMessage.Should().Contain("Domain");
+    }
+
+    [Fact]
+    public void Fails_when_Staging_Trust_true_but_Issuer_blank()
+    {
+        var options = ValidOptionsWithTrustedStaging();
+        options.Staging!.Issuer = null;
+
+        var result = _validator.Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Staging");
+        result.FailureMessage.Should().Contain("Issuer");
+    }
+
+    [Fact]
+    public void GetTrustedIssuers_excludes_staging_when_Trust_is_false()
+    {
+        var options = ValidOptionsWithTrustedStaging();
+        options.Staging!.Trust = false;
+
+        options.GetTrustedIssuers().Should().Equal(options.Issuer);
+        options.GetTrustedDomains().Should().Equal(options.Domain);
+        options.TrustsStagingIssuer.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetTrustedIssuers_includes_staging_when_Trust_is_true()
+    {
+        var options = ValidOptionsWithTrustedStaging();
+
+        options.GetTrustedIssuers().Should().Equal(options.Issuer, options.Staging!.Issuer);
+        options.GetTrustedDomains().Should().Equal(options.Domain, options.Staging.Domain);
+        options.TrustsStagingIssuer.Should().BeTrue();
+    }
+
     private static Auth0ValidationOptions ValidOptions() => new()
     {
         Audience = "https://api.example.com",
         Domain = "example.auth0.com",
         Issuer = "https://example.auth0.com/"
+    };
+
+    private static Auth0ValidationOptions ValidOptionsWithTrustedStaging() => new()
+    {
+        Audience = "https://api.example.com",
+        Domain = "example.auth0.com",
+        Issuer = "https://example.auth0.com/",
+        Staging = new Auth0StagingValidationOptions
+        {
+            Trust = true,
+            Domain = "auth-staging.example.com",
+            Issuer = "https://auth-staging.example.com/"
+        }
     };
 }

--- a/Cloud/Api/appsettings.Development.json
+++ b/Cloud/Api/appsettings.Development.json
@@ -9,8 +9,14 @@
     "Audience": "https://api.cultpodcasts.com/"
   },
   "auth0": {
-    "Authority": "https://auth.cultpodcasts.com/",
-    "Audience": "https://api.cultpodcasts.com/"
+    "Audience": "https://api.cultpodcasts.com/",
+    "Domain": "auth.cultpodcasts.com",
+    "Issuer": "https://auth.cultpodcasts.com/",
+    "Staging": {
+      "Trust": false,
+      "Domain": "auth-staging.cultpodcasts.com",
+      "Issuer": "https://auth-staging.cultpodcasts.com/"
+    }
   },
   "indexer": {
     "ReleasedDaysAgo": 2,

--- a/Infrastructure/functions.bicep
+++ b/Infrastructure/functions.bicep
@@ -161,10 +161,16 @@ var api= {
     api__Endpoint: 'https://api.cultpodcasts.com'
 }
 
+var auth0StagingDomain= 'auth-staging.cultpodcasts.com'
+// Feature switch: set auth0__Staging__Trust to 'false' to reject staging Auth0 JWTs
+// (api-preview) without removing staging domain/issuer settings.
 var auth0= {
     auth0__Audience: auth0Audience
     auth0__Domain: auth0Domain
     auth0__Issuer: 'https://auth.cultpodcasts.com/'
+    auth0__Staging__Domain: auth0StagingDomain
+    auth0__Staging__Issuer: 'https://${auth0StagingDomain}/'
+    auth0__Staging__Trust: 'true'
 }
 
 var auth0Client= {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -156,7 +156,28 @@ Enforced in [`.cursor/rules/deployment.mdc`](../.cursor/rules/deployment.mdc) (a
 
 An agent session **wrongly deleted** `deploy-api.ps1` and `deploy-indexer.ps1` as "duplicates" and removed a session-created `deploy-discover.ps1` the user expected. **Never repeat.** All three thin wrappers were restored; see [`deploy-discover.ps1` history](#deploy-discoverps1-history) above.
 
-## When was prod last deployed? (authoritative — script deploys)
+## Auth0 validation on api-infra (prod + staging preview)
+
+`api-infra` validates Bearer JWTs with `RedditPodcastPoster.Auth0` (`auth0__*` app settings). Production issuer is `https://auth.cultpodcasts.com/`.
+
+Cloudflare **api-preview** uses staging Auth0 (`auth-staging.cultpodcasts.com`) and proxies the same token to `api-infra`. To accept those tokens:
+
+| Setting | Purpose |
+|---------|---------|
+| `auth0__Staging__Trust` | Feature switch — `true` to trust staging; `false` (or omit) rejects staging JWTs even if staging URLs are configured |
+| `auth0__Staging__Domain` | `auth-staging.cultpodcasts.com` (required when Trust is true) |
+| `auth0__Staging__Issuer` | `https://auth-staging.cultpodcasts.com/` (required when Trust is true) |
+
+Bicep sets the staging URLs and `auth0__Staging__Trust=true`. To disable staging trust without a code change:
+
+```powershell
+az functionapp config appsettings set -g AutomatedInfra -n api-infra --settings auth0__Staging__Trust=false
+az functionapp restart -g AutomatedInfra -n api-infra
+```
+
+Signing keys are loaded at process start — restart after flipping the switch.
+
+
 
 **Agents MUST use this before claiming prod is stale, current, or that a fix is/isn't live.**
 


### PR DESCRIPTION
## Summary
- `api-infra` can accept JWTs from production Auth0 and optionally staging (`auth-staging.cultpodcasts.com`) so Cloudflare api-preview curated calls work.
- Nested settings: `auth0__Staging__Trust` (feature switch), `auth0__Staging__Domain`, `auth0__Staging__Issuer`. When Trust is false, staging JWKS/issuer are ignored.
- Bicep + docs updated. Pre-deploy: api-infra already has nested staging settings with Trust=true. **Deploy api via local script** for the code to take effect (GH provision not required for this).

## Test plan
- [ ] `Auth0ValidationOptionsValidatorTests` pass
- [ ] `.\scripts\deploy-api.ps1` from this branch (or after merge)
- [ ] Staging preview: curator episode GET succeeds
- [ ] Set `auth0__Staging__Trust=false`, restart api-infra, confirm staging token rejected and prod still works