### PR TITLE
feat(homepage): include non-English episode language in homepage payload

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Models/PodcastResult.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Models/PodcastResult.cs
@@ -53,4 +53,7 @@ public class PodcastResult
     [JsonPropertyName("knownTerms")]
     [JsonPropertyOrder(271)]
     public string[]? KnownTerms { get; set; } = null;
+
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
 }

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/HomepagePublisher.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/HomepagePublisher.cs
@@ -106,7 +106,8 @@ public class HomepagePublisher(
                     Length = episode.Length,
                     Subjects = episode.Subjects.Count > 0 ? episode.Subjects.ToArray() : null,
                     Images = episode.Images,
-                    KnownTerms = podcast?.KnownTerms
+                    KnownTerms = podcast?.KnownTerms,
+                    Language = episode.Language
                 };
             })
             .OrderByDescending(x => x.Release)
@@ -156,7 +157,8 @@ public class HomepagePublisher(
                 Urls = episode.Urls,
                 Length = episode.Length,
                 Subjects = episode.Subjects,
-                Images = episode.Images
+                Images = episode.Images,
+                Language = episode.Language ?? episode.PodcastLanguage
             });
         }
 
@@ -236,8 +238,29 @@ public class HomepagePublisher(
             InternetArchive = x.InternetArchive,
             Length = TimeSpan.FromSeconds(Math.Round(x.Length.TotalSeconds)),
             Subjects = x.Subjects != null && x.Subjects.Any() ? x.Subjects : null,
-            Image = x.Images?.YouTube ?? x.Images?.Spotify ?? x.Images?.Apple ?? x.Images?.Other
+            Image = x.Images?.YouTube ?? x.Images?.Spotify ?? x.Images?.Apple ?? x.Images?.Other,
+            Language = NormaliseHomepageLanguage(x.Language)
         };
+    }
+
+    /// <summary>
+    /// Omit English (and empty) so the homepage payload only carries non-English tags.
+    /// </summary>
+    private static string? NormaliseHomepageLanguage(string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return null;
+        }
+
+        var trimmed = language.Trim();
+        if (trimmed.StartsWith("en", StringComparison.OrdinalIgnoreCase) &&
+            (trimmed.Length == 2 || trimmed[2] is '-' or '_'))
+        {
+            return null;
+        }
+
+        return trimmed;
     }
 
     private async Task<PodcastResult> Sanitise(PodcastResult podcastResult)
@@ -317,5 +340,6 @@ public class HomepagePublisher(
         public TimeSpan Length { get; init; }
         public List<string> Subjects { get; init; } = [];
         public EpisodeImages? Images { get; init; }
+        public string? Language { get; init; }
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Models/HomePage/RecentEpisode.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/HomePage/RecentEpisode.cs
@@ -55,4 +55,10 @@ public class RecentEpisode
 
     [JsonPropertyName("image")]
     public Uri? Image { get; set; } = null;
+
+    /// <summary>
+    /// IETF language tag when non-English. Null/absent means English (or unknown treated as English).
+    /// </summary>
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
 }


### PR DESCRIPTION
## Summary
- Surface each episode's IETF language tag on the homepage recent-episode JSON, falling back to the podcast's language when the episode has none set.
- Omit the tag for English (`en`, `en-*`, `en_*`) and empty/unknown values so the payload only carries non-English tags, keeping existing consumers backward-compatible.

## Changes
- `RecentEpisode.cs`: add optional `language` (IETF tag) JSON property.
- `PodcastResult.cs`: add internal `Language` carrier field used while building the homepage payload.
- `HomepagePublisher.cs`: populate `Language` from `episode.Language ?? episode.PodcastLanguage`, and normalise/omit English before emitting `RecentEpisode.Language`.

## Test plan
- [x] `dotnet build` of `RedditPodcastPoster.ContentPublisher` succeeds.
- [ ] Verify `homepage` R2 JSON includes `language` for a known non-English episode after deploy.