### PR TITLE
Add read-only ExportSearchSuggestions console tool

### DIFF
--- a/Console-Apps/ExportSearchSuggestions/ExportSearchSuggestions.csproj
+++ b/Console-Apps/ExportSearchSuggestions/ExportSearchSuggestions.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>e4eaaf12-4507-4875-857d-a8d4032107f3</UserSecretsId>
+    <AzureCosmosDisableNewtonsoftJsonCheck>true</AzureCosmosDisableNewtonsoftJsonCheck>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Configuration\RedditPodcastPoster.Configuration.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Persistence\RedditPodcastPoster.Persistence.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Subjects\RedditPodcastPoster.Subjects.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Console-Apps/ExportSearchSuggestions/Program.cs
+++ b/Console-Apps/ExportSearchSuggestions/Program.cs
@@ -1,0 +1,111 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.Persistence.Extensions;
+using RedditPodcastPoster.Subjects.Extensions;
+using RedditPodcastPoster.Persistence.Abstractions.Repositories;
+
+// Read-only, narrow-scope export for the flix search-typeahead prototype.
+// Pulls ONLY: Subject.Name + Subject.Aliases (AssociatedSubjects deliberately excluded)
+// and Podcast.Name. Never writes to Cosmos. Not a full-catalog dump (see CosmosDbDownloader
+// for that) - this intentionally emits a single small JSON file with just the two fields
+// the flix search box needs for typeahead.
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Environment.ContentRootPath = Directory.GetCurrentDirectory();
+
+builder.Configuration
+    .AddJsonFile("appsettings.json", true)
+    .AddEnvironmentVariables("RedditPodcastPoster_")
+    .AddCommandLine(args)
+    .AddSecrets(Assembly.GetExecutingAssembly());
+
+builder.Services
+    .AddLogging()
+    .AddRepositories()
+    .AddSubjectServices();
+
+using var host = builder.Build();
+
+var subjectRepository = host.Services.GetRequiredService<ISubjectRepository>();
+var podcastRepository = host.Services.GetRequiredService<IPodcastRepository>();
+
+var outputPath = args.FirstOrDefault(a => !a.StartsWith("--"))
+                  ?? "search-suggestions.json";
+
+Console.WriteLine("Reading subjects (name + aliases only; associated-subjects excluded)...");
+var subjects = new List<SubjectSuggestion>();
+await foreach (var subject in subjectRepository.GetAll())
+{
+    if (string.IsNullOrWhiteSpace(subject.Name))
+    {
+        continue;
+    }
+
+    var aliases = (subject.Aliases ?? Array.Empty<string>())
+        .Select(a => a.Trim())
+        .Where(a => a.Length > 0)
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .OrderBy(a => a, StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+    subjects.Add(new SubjectSuggestion(subject.Name.Trim(), aliases));
+}
+
+subjects = subjects
+    .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+    .ToList();
+
+Console.WriteLine($"Read {subjects.Count} subjects.");
+
+Console.WriteLine("Reading podcast names only...");
+var podcastNames = new List<string>();
+await foreach (var podcast in podcastRepository.GetAll())
+{
+    if (string.IsNullOrWhiteSpace(podcast.Name))
+    {
+        continue;
+    }
+
+    if (podcast.Removed == true)
+    {
+        continue;
+    }
+
+    podcastNames.Add(podcast.Name.Trim());
+}
+
+podcastNames = podcastNames
+    .Distinct(StringComparer.OrdinalIgnoreCase)
+    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+    .ToList();
+
+Console.WriteLine($"Read {podcastNames.Count} podcast names.");
+
+var corpus = new SuggestionsCorpus(
+    DateTime.UtcNow,
+    subjects.ToArray(),
+    podcastNames.ToArray());
+
+var json = JsonSerializer.Serialize(corpus, new JsonSerializerOptions
+{
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+});
+
+await File.WriteAllTextAsync(outputPath, json);
+Console.WriteLine($"Wrote suggestions corpus to '{Path.GetFullPath(outputPath)}'.");
+
+return 0;
+
+record SubjectSuggestion(string Name, string[] Aliases);
+
+record SuggestionsCorpus(
+    [property: JsonPropertyName("generatedAtUtc")] DateTime GeneratedAtUtc,
+    [property: JsonPropertyName("subjects")] SubjectSuggestion[] Subjects,
+    [property: JsonPropertyName("podcasts")] string[] Podcasts);

--- a/Console-Apps/README.md
+++ b/Console-Apps/README.md
@@ -397,6 +397,18 @@ RemoveEpisodes restore removed-episodes-log.txt
 
 **Run:** `dotnet run --project Console-Apps/CultPodcasts.DatabasePublisher` · PATH: `CultPodcasts.DatabasePublisher`
 
+### ExportSearchSuggestions
+
+**Purpose:** Read-only, narrow export for the flix search-typeahead prototype. Reads only Subjects (`name` + `aliases`, `associatedSubjects` deliberately excluded) and Podcasts (`name` only, non-removed) via the existing repository `GetAll()` abstractions, and projects straight to a single small JSON file — never writes to disk per-document like `CosmosDbDownloader`, never writes to Cosmos.
+
+**Run:** `dotnet run --project Console-Apps/ExportSearchSuggestions -- [output-path]` · PATH: `ExportSearchSuggestions`
+
+| Value | Description |
+|-------|-------------|
+| `[output-path]` | Optional positional; JSON output path (default `search-suggestions.json`) |
+
+Consumed by the website repo (`cultpodcasts/docs/search-suggestions.md`) — copy the output into `src/assets/search-suggestions.json` on `design/visual-refresh-v1` and commit.
+
 ---
 
 ## Ops utilities


### PR DESCRIPTION
## Summary
- New `Console-Apps/ExportSearchSuggestions` console tool: read-only, narrow export for the flix search-typeahead prototype.
- Pulls **only** `Subject.Name` + `Subject.Aliases` (`AssociatedSubjects` deliberately excluded) and `Podcast.Name` (non-removed), via the existing repository `GetAll()` abstractions, projecting straight to a single small JSON file in memory.
- Deliberately distinct from `CosmosDbDownloader` (full multi-container per-document dump) - this tool was never run in its place, and does not write to Cosmos.
- Consumed by the website repo on `design/visual-refresh-v1` (see `cultpodcasts/docs/search-suggestions.md`) as a committed static asset for typeahead.

## Test plan
- [x] `dotnet build Console-Apps/ExportSearchSuggestions` succeeds.
- [x] Ran locally read-only against production Cosmos (read-only `GetAll()` queries only); produced 704 subjects + 6152 podcast names, copied output into the website repo and deleted the local temp file.
- [ ] Reviewer: confirm no Cosmos writes anywhere in the new tool (`Program.cs` only calls `GetAll()` on `ISubjectRepository`/`IPodcastRepository`).
