### PR TITLE
Emit flat search-suggestions match index

### DIFF
--- a/Console-Apps/ExportSearchSuggestions/Program.cs
+++ b/Console-Apps/ExportSearchSuggestions/Program.cs
@@ -11,9 +11,9 @@ using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 
 // Read-only, narrow-scope export for the flix search-typeahead prototype.
 // Pulls ONLY: Subject.Name + Subject.Aliases (AssociatedSubjects deliberately excluded)
-// and Podcast.Name. Never writes to Cosmos. Not a full-catalog dump (see CosmosDbDownloader
-// for that) - this intentionally emits a single small JSON file with just the two fields
-// the flix search box needs for typeahead.
+// and Podcast.Name. Emits a flat match index: { type, canonical, searchText, alias? }
+// with searchText already lowercase. Never writes to Cosmos. Not a full-catalog dump
+// (see CosmosDbDownloader for that).
 
 var builder = Host.CreateApplicationBuilder(args);
 
@@ -39,7 +39,28 @@ var outputPath = args.FirstOrDefault(a => !a.StartsWith("--"))
                   ?? "search-suggestions.json";
 
 Console.WriteLine("Reading subjects (name + aliases only; associated-subjects excluded)...");
-var subjects = new List<SubjectSuggestion>();
+var entries = new List<SuggestionEntry>();
+var seen = new HashSet<string>(StringComparer.Ordinal);
+
+void Add(string type, string canonical, string sourceText, string? alias = null)
+{
+    var trimmedCanonical = canonical.Trim();
+    var searchText = sourceText.Trim().ToLowerInvariant();
+    if (trimmedCanonical.Length == 0 || searchText.Length == 0)
+    {
+        return;
+    }
+
+    var key = $"{type}\0{trimmedCanonical}\0{searchText}";
+    if (!seen.Add(key))
+    {
+        return;
+    }
+
+    entries.Add(new SuggestionEntry(type, trimmedCanonical, searchText, alias));
+}
+
+var subjectCount = 0;
 await foreach (var subject in subjectRepository.GetAll())
 {
     if (string.IsNullOrWhiteSpace(subject.Name))
@@ -47,24 +68,26 @@ await foreach (var subject in subjectRepository.GetAll())
         continue;
     }
 
-    var aliases = (subject.Aliases ?? Array.Empty<string>())
-        .Select(a => a.Trim())
-        .Where(a => a.Length > 0)
-        .Distinct(StringComparer.OrdinalIgnoreCase)
-        .OrderBy(a => a, StringComparer.OrdinalIgnoreCase)
-        .ToArray();
+    subjectCount++;
+    var name = subject.Name.Trim();
+    Add("subject", name, name);
 
-    subjects.Add(new SubjectSuggestion(subject.Name.Trim(), aliases));
+    foreach (var rawAlias in subject.Aliases ?? Array.Empty<string>())
+    {
+        var alias = rawAlias.Trim();
+        if (alias.Length == 0)
+        {
+            continue;
+        }
+
+        Add("subject", name, alias, alias);
+    }
 }
 
-subjects = subjects
-    .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
-    .ToList();
-
-Console.WriteLine($"Read {subjects.Count} subjects.");
+Console.WriteLine($"Read {subjectCount} subjects.");
 
 Console.WriteLine("Reading podcast names only...");
-var podcastNames = new List<string>();
+var podcastCount = 0;
 await foreach (var podcast in podcastRepository.GetAll())
 {
     if (string.IsNullOrWhiteSpace(podcast.Name))
@@ -77,35 +100,40 @@ await foreach (var podcast in podcastRepository.GetAll())
         continue;
     }
 
-    podcastNames.Add(podcast.Name.Trim());
+    podcastCount++;
+    var name = podcast.Name.Trim();
+    Add("podcast", name, name);
 }
 
-podcastNames = podcastNames
-    .Distinct(StringComparer.OrdinalIgnoreCase)
-    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+Console.WriteLine($"Read {podcastCount} podcast names.");
+
+entries = entries
+    .OrderBy(e => e.SearchText, StringComparer.Ordinal)
+    .ThenBy(e => e.Type, StringComparer.Ordinal)
+    .ThenBy(e => e.Canonical, StringComparer.Ordinal)
     .ToList();
 
-Console.WriteLine($"Read {podcastNames.Count} podcast names.");
-
-var corpus = new SuggestionsCorpus(
-    DateTime.UtcNow,
-    subjects.ToArray(),
-    podcastNames.ToArray());
+var corpus = new SuggestionsCorpus(DateTime.UtcNow, entries.ToArray());
 
 var json = JsonSerializer.Serialize(corpus, new JsonSerializerOptions
 {
     WriteIndented = true,
-    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
 });
 
 await File.WriteAllTextAsync(outputPath, json);
-Console.WriteLine($"Wrote suggestions corpus to '{Path.GetFullPath(outputPath)}'.");
+Console.WriteLine(
+    $"Wrote flat suggestions index ({entries.Count} entries) to '{Path.GetFullPath(outputPath)}'.");
 
 return 0;
 
-record SubjectSuggestion(string Name, string[] Aliases);
+record SuggestionEntry(
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("canonical")] string Canonical,
+    [property: JsonPropertyName("searchText")] string SearchText,
+    [property: JsonPropertyName("alias")] string? Alias);
 
 record SuggestionsCorpus(
     [property: JsonPropertyName("generatedAtUtc")] DateTime GeneratedAtUtc,
-    [property: JsonPropertyName("subjects")] SubjectSuggestion[] Subjects,
-    [property: JsonPropertyName("podcasts")] string[] Podcasts);
+    [property: JsonPropertyName("entries")] SuggestionEntry[] Entries);

--- a/Console-Apps/README.md
+++ b/Console-Apps/README.md
@@ -399,7 +399,7 @@ RemoveEpisodes restore removed-episodes-log.txt
 
 ### ExportSearchSuggestions
 
-**Purpose:** Read-only, narrow export for the flix search-typeahead prototype. Reads only Subjects (`name` + `aliases`, `associatedSubjects` deliberately excluded) and Podcasts (`name` only, non-removed) via the existing repository `GetAll()` abstractions, and projects straight to a single small JSON file — never writes to disk per-document like `CosmosDbDownloader`, never writes to Cosmos.
+**Purpose:** Read-only, narrow export for the flix search-typeahead prototype. Reads only Subjects (`name` + `aliases`, `associatedSubjects` deliberately excluded) and Podcasts (`name` only, non-removed) via the existing repository `GetAll()` abstractions, and projects straight to a single small **flat match-index** JSON file (`entries[]` with `type`, `canonical`, lowercase `searchText`, optional `alias`) — never writes to disk per-document like `CosmosDbDownloader`, never writes to Cosmos.
 
 **Run:** `dotnet run --project Console-Apps/ExportSearchSuggestions -- [output-path]` · PATH: `ExportSearchSuggestions`
 
@@ -407,7 +407,7 @@ RemoveEpisodes restore removed-episodes-log.txt
 |-------|-------------|
 | `[output-path]` | Optional positional; JSON output path (default `search-suggestions.json`) |
 
-Consumed by the website repo (`cultpodcasts/docs/search-suggestions.md`) — copy the output into `src/assets/search-suggestions.json` on `design/visual-refresh-v1` and commit.
+Consumed by the website repo (`cultpodcasts/docs/search-suggestions.md`) — copy the output into `src/assets/search-suggestions.json` on `design/visual-refresh-v1` and commit. If you still have a legacy nested `{ subjects, podcasts }` file, convert with `node scripts/flatten-search-suggestions.mjs` in `cultpodcasts/`.
 
 ---
 


### PR DESCRIPTION
## Summary
- `ExportSearchSuggestions` now writes a flat `entries[]` corpus (`type`, `canonical`, lowercase `searchText`, optional `alias`) instead of nested `{ subjects, podcasts }`.
- Matches the website flix typeahead consumer on `design/visual-refresh-v1` (commit `f8df84f`).
- Docs updated in `Console-Apps/README.md`.

## Test plan
- [ ] `dotnet run --project Console-Apps/ExportSearchSuggestions -- search-suggestions.json`
- [ ] Confirm output has `entries` (not nested `subjects`/`podcasts`) and `searchText` is lowercase
- [ ] Copy into website `src/assets/search-suggestions.json` and spot-check typeahead