### PR TITLE
fix(search): make episode lang field retrievable

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Search/Models/EpisodeSearchRecord.cs
+++ b/Class-Libraries/RedditPodcastPoster.Search/Models/EpisodeSearchRecord.cs
@@ -58,6 +58,8 @@ public class EpisodeSearchRecord
     [SimpleField(IsSortable = false, IsFacetable = false, IsFilterable = false)]
     public string? Image { get; set; }
 
-    [SimpleField(IsFilterable = true, IsFacetable = true, IsHidden = true)]
+    // Retrievable so flix/search cards and episode pages can show language flags.
+    // Still filterable+facetable for subject language chips (English ≈ null).
+    [SimpleField(IsFilterable = true, IsFacetable = true)]
     public string? Lang { get; set; }
 }


### PR DESCRIPTION
## Summary
- Make search index `Lang` retrievable again (remove `IsHidden`) so flix episode pages and search/poster cards can show language flags.
- Live Azure index `cultpodcasts` already updated: `lang.retrievable=true` (verified `es` returned for Doctrinas Peligrosas).

## Test plan
- [ ] Confirm search docs include `lang` for non-English episodes
- [ ] Confirm subject-page `lang` filter/facets still work
- [ ] Confirm CreateSearchIndex recreates `lang` as retrievable if index is rebuilt

Made with [Cursor](https://cursor.com)