### PR TITLE
fix(indexing): Spotify ascending enrich, YouTube Arbitrary playlists, expensive-flag flips

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": "pwsh -NoProfile -File .cursor/hooks/unit-test-guardrails-after-edit.ps1",
+        "matcher": "Write|StrReplace|EditNotebook|TabWrite",
+        "timeout": 30
+      }
+    ],
+    "stop": [
+      {
+        "command": "pwsh -NoProfile -File .cursor/hooks/unit-test-guardrails-stop.ps1",
+        "timeout": 60,
+        "loop_limit": 3
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/unit-test-guardrails-after-edit.ps1
+++ b/.cursor/hooks/unit-test-guardrails-after-edit.ps1
@@ -1,0 +1,48 @@
+#Requires -Version 7
+<#
+  afterFileEdit: if the edited file is a test source, run guardrail scan and
+  append violations to .cursor/hooks/.unit-test-guardrail-failures.jsonl so the
+  stop hook can force a fix loop.
+#>
+$ErrorActionPreference = 'Stop'
+$stdin = [Console]::In.ReadToEnd()
+$payload = $null
+try { $payload = $stdin | ConvertFrom-Json } catch { }
+
+$filePath = $null
+if ($payload) {
+    foreach ($name in @('file_path', 'filePath', 'path')) {
+        if ($payload.PSObject.Properties.Name -contains $name -and $payload.$name) {
+            $filePath = [string]$payload.$name
+            break
+        }
+    }
+}
+
+if (-not $filePath) {
+    Write-Output '{}'
+    exit 0
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+Set-Location $repoRoot
+
+$script = Join-Path $repoRoot 'scripts\assert-unit-test-guardrails.ps1'
+$out = & pwsh -NoProfile -File $script -Path $filePath -Json 2>&1 | Out-String
+$result = $null
+try { $result = $out | ConvertFrom-Json } catch { }
+
+if ($result -and -not $result.ok -and $result.violations) {
+    $stateDir = Join-Path $PSScriptRoot '.state'
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    $stateFile = Join-Path $stateDir 'unit-test-guardrail-failures.jsonl'
+    $entry = [pscustomobject]@{
+        at         = [DateTime]::UtcNow.ToString('o')
+        file       = $filePath
+        violations = $result.violations
+    }
+    Add-Content -LiteralPath $stateFile -Value ($entry | ConvertTo-Json -Compress -Depth 6)
+}
+
+Write-Output '{}'
+exit 0

--- a/.cursor/hooks/unit-test-guardrails-stop.ps1
+++ b/.cursor/hooks/unit-test-guardrails-stop.ps1
@@ -1,0 +1,94 @@
+#Requires -Version 7
+<#
+  stop: if git-changed test files (or afterFileEdit failure log) violate
+  unit-test guardrails, emit followup_message so the agent must fix them.
+#>
+$ErrorActionPreference = 'Stop'
+$stdin = [Console]::In.ReadToEnd()
+$payload = $null
+try { $payload = $stdin | ConvertFrom-Json } catch { }
+
+$status = if ($payload -and $payload.status) { [string]$payload.status } else { 'completed' }
+$loopCount = 0
+if ($payload -and ($payload.PSObject.Properties.Name -contains 'loop_count')) {
+    $loopCount = [int]$payload.loop_count
+}
+
+if ($status -ne 'completed') {
+    Write-Output '{}'
+    exit 0
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+Set-Location $repoRoot
+
+$script = Join-Path $repoRoot 'scripts\assert-unit-test-guardrails.ps1'
+$jsonOut = & pwsh -NoProfile -File $script -GitChanged -Json 2>&1 | Out-String
+$result = $null
+try { $result = $jsonOut | ConvertFrom-Json } catch { }
+
+$violations = @()
+if ($result -and $result.violations) {
+    $violations = @($result.violations)
+}
+
+$stateFile = Join-Path $PSScriptRoot '.state\unit-test-guardrail-failures.jsonl'
+if (Test-Path -LiteralPath $stateFile) {
+    # Include recent after-edit findings still present on disk
+    Get-Content -LiteralPath $stateFile -ErrorAction SilentlyContinue | ForEach-Object {
+        try {
+            $row = $_ | ConvertFrom-Json
+            if ($row.violations) { $violations += @($row.violations) }
+        }
+        catch { }
+    }
+}
+
+# De-dupe by file:line:rule
+$unique = [System.Collections.Generic.List[object]]::new()
+$seen = New-Object 'System.Collections.Generic.HashSet[string]'
+foreach ($v in $violations) {
+    $key = '{0}:{1}:{2}' -f $v.file, $v.line, $v.rule
+    if ($seen.Add($key)) { $unique.Add($v) | Out-Null }
+}
+
+if ($unique.Count -eq 0) {
+    if (Test-Path -LiteralPath $stateFile) {
+        Remove-Item -LiteralPath $stateFile -Force -ErrorAction SilentlyContinue
+    }
+    Write-Output '{}'
+    exit 0
+}
+
+if ($loopCount -ge 3) {
+    $summary = ($unique | Select-Object -First 8 | ForEach-Object {
+            '{0}:{1} [{2}] {3}' -f $_.file, $_.line, $_.rule, $_.detail
+        }) -join "`n"
+    Write-Output (@{
+            followup_message = @"
+STOP: unit-test guardrail violations remain after $loopCount fix attempts. Do not claim the test work is done.
+
+$summary
+
+Read .cursor/rules/unit-tests.mdc and fix every violation, then re-run:
+pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged
+"@
+        } | ConvertTo-Json -Compress)
+    exit 0
+}
+
+$summary = ($unique | Select-Object -First 12 | ForEach-Object {
+        '{0}:{1} [{2}] {3}' -f $_.file, $_.line, $_.rule, $_.detail
+    }) -join "`n"
+
+Write-Output (@{
+        followup_message = @"
+Unit-test guardrail violations detected (unit-tests.mdc). Fix them before finishing.
+
+$summary
+
+Re-read .cursor/rules/unit-tests.mdc. Prefer DomainTestFixture specimens, Fact(DisplayName=...), Arrange/Act/Assert, and Moq over NotImplementedException doubles. Then run:
+pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged
+"@
+    } | ConvertTo-Json -Compress)
+exit 0

--- a/.cursor/rules/episodes-domain-changes.mdc
+++ b/.cursor/rules/episodes-domain-changes.mdc
@@ -8,7 +8,7 @@ alwaysApply: false
 
 Read before changing production code under `RedditPodcastPoster.Episodes/` (matching, merging, applying, adapters, release tolerance).
 
-**Related:** [unit-tests.mdc](unit-tests.mdc) (how to write rule tests), [plans/episode-domain-refactor/README.md](../../plans/episode-domain-refactor/README.md) §5 (rule catalog).
+**Related:** [unit-tests.mdc](unit-tests.mdc) (how to write rule tests), [unit-tests-enforcement.mdc](unit-tests-enforcement.mdc) (always-on + hooks/CI), [plans/episode-domain-refactor/README.md](../../plans/episode-domain-refactor/README.md) §5 (rule catalog).
 
 ---
 

--- a/.cursor/rules/unit-tests-enforcement.mdc
+++ b/.cursor/rules/unit-tests-enforcement.mdc
@@ -1,0 +1,31 @@
+---
+description: HARD — unit-test guardrails must be followed; read unit-tests.mdc before any test edit
+alwaysApply: true
+---
+
+# Unit-test guardrails (enforcement)
+
+**Before writing or editing any file under `*Tests/`, `*Tests.cs`, `FunctionHost.Tests`, or `Episodes.TestSupport`:**
+
+1. **MUST** read [unit-tests.mdc](unit-tests.mdc) in the same turn (full contract).
+2. Scope is **every** test in those trees — **not** only classes that already use `DomainTestFixture`. Handler/wiring/logger tests are included.
+3. **MUST NOT** finish a turn that introduced tests violating the contract.
+
+## Hard fails (also enforced by `scripts/assert-unit-test-guardrails.ps1`)
+
+| NEVER | Why |
+|-------|-----|
+| Production podcast/episode brand names in arrange/assert | Use scenario-shaped fixtures / generated titles |
+| `Guid.Parse("...")` / `new Guid("...")` filler | Use `_fixture.CreateGuid()` or specimen ids |
+| `[Fact]` / `[Theory]` without `DisplayName = "..."` | DisplayName is the authoritative rule text |
+| Missing `// Arrange` / `// Act` / `// Assert` | Required section comments |
+| `throw new NotImplementedException` in `BusinessRules/**` test doubles | Prefer Moq / focused fakes that implement only used members |
+| Raw `new Podcast` / `new Episode` filler when `DomainTestFixture` applies | Use fixture factories |
+
+## Stop checklist
+
+Before claiming test work done:
+
+- [ ] Re-read unit-tests.mdc arrange checklist
+- [ ] Ran `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged` (or CI equivalent) clean
+- [ ] `dotnet test` on affected test projects green

--- a/.cursor/rules/unit-tests.mdc
+++ b/.cursor/rules/unit-tests.mdc
@@ -1,12 +1,14 @@
 ---
 description: Hard guardrails for episode-domain business-rule unit tests (DomainTestFixture, DisplayName, lean arrange)
-globs: "**/*Tests/**/*.cs,Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/**,plans/episode-domain-refactor/**
+globs: "**/*Tests*/**/*.cs,**/*Tests.cs,**/FunctionHost.Tests/**/*.cs,Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/**,plans/episode-domain-refactor/**
 alwaysApply: false
 ---
 
 # Episode-domain unit test guardrails
 
-**Authoritative AI reference for business-rule tests.** Read before writing or editing tests under `*Tests/` that use `DomainTestFixture`.
+**Authoritative AI reference for business-rule / unit tests.** Read before writing or editing **any** test under `*Tests/`, `*Tests.cs`, `FunctionHost.Tests`, or `Episodes.TestSupport` — including handler, wiring, logger, and DI tests. This is **not** limited to classes that already use `DomainTestFixture`.
+
+Enforcement: [unit-tests-enforcement.mdc](unit-tests-enforcement.mdc) (always-on), `scripts/assert-unit-test-guardrails.ps1` (Cursor stop hook + CI).
 
 Context: [plans/episode-domain-refactor/README.md](../../plans/episode-domain-refactor/README.md) (architecture, rule catalog, coverage). This file is the **prescriptive** test-writing contract — not aspirational guidance.
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,3 +32,14 @@ jobs:
     - name: Episode domain coverage gate
       shell: pwsh
       run: ./scripts/coverage-gate.ps1 -NoBuild -Verbose
+    - name: Unit-test guardrails (changed test files)
+      shell: pwsh
+      run: |
+        $base = $env:GITHUB_BASE_REF
+        if ([string]::IsNullOrWhiteSpace($base)) {
+          ./scripts/assert-unit-test-guardrails.ps1 -GitChanged
+        }
+        else {
+          git fetch origin $base --depth=1
+          ./scripts/assert-unit-test-guardrails.ps1 -GitChanged -BaseRef "origin/$base"
+        }

--- a/.gitignore
+++ b/.gitignore
@@ -440,3 +440,6 @@ plan-blocks.md
 
 # Local production cookie (never commit)
 .cookie
+
+# Cursor hook scratch state (unit-test guardrail stop loop)
+.cursor/hooks/.state/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Cult Podcasts / RedditPodcastPoster — agent notes
+
+## Unit tests (HARD)
+
+Any agent (Cursor, Codex, Copilot, etc.) editing tests **MUST** follow:
+
+- [`.cursor/rules/unit-tests-enforcement.mdc`](.cursor/rules/unit-tests-enforcement.mdc) (always-on summary)
+- [`.cursor/rules/unit-tests.mdc`](.cursor/rules/unit-tests.mdc) (full contract)
+
+Mechanical check (local + CI):
+
+```powershell
+pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged
+# or against main:
+pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged -BaseRef origin/main
+```
+
+Cursor also runs this via `.cursor/hooks.json` on `stop` / `afterFileEdit`.
+
+## Catalogue & playlist pagination (HARD for related changes)
+
+Before changing Spotify paginators, YouTube playlist walks, expensive-query flags,
+`PlaylistOrder`, or `SkipExpensive*` gates, read:
+
+- [docs/catalogue-pagination.md](docs/catalogue-pagination.md) — Spotify + YouTube cold-start design, caps, flag lifecycle, test matrix
+- [docs/youtube-playlist-order.md](docs/youtube-playlist-order.md) — YouTube Arbitrary / curated depth
+
+Keep circuit-breaker and flag-flip **log message prefixes** stable (App Insights keys off them).
+Every behaviour change in those areas **MUST** ship with a `BusinessRules/**` test whose
+`DisplayName` states the rule.

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Logging/BlueskyPostLogger.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Logging/BlueskyPostLogger.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models.Episodes;
+
+namespace RedditPodcastPoster.Bluesky.Logging;
+
+/// <summary>
+/// Emits a stable Warning-level line when an episode is posted to Bluesky
+/// (or when the BlueskyPosted flag is set without a network post) so App Insights
+/// can answer provenance by episode-id. Warning is intentional: Information is sampled away.
+/// </summary>
+public static class BlueskyPostLogger
+{
+    public const string PostedMessagePrefix = "Bluesky posted:";
+    public const string FlagSetMessagePrefix = "BlueskyPosted flag set:";
+
+    public const string PostedMessageTemplate =
+        "Bluesky posted: episode-id='{EpisodeId}' title='{Title}' podcast-id='{PodcastId}' podcast-name='{PodcastName}' caller='{Caller}' spotify-url='{SpotifyUrl}' youtube-url='{YouTubeUrl}' apple-url='{AppleUrl}'";
+
+    public const string FlagSetMessageTemplate =
+        "BlueskyPosted flag set: episode-id='{EpisodeId}' title='{Title}' podcast-id='{PodcastId}' caller='{Caller}' network-post='false'";
+
+    public static void LogPosted(
+        ILogger logger,
+        PodcastEpisode podcastEpisode,
+        string caller)
+    {
+        logger.LogWarning(
+            PostedMessageTemplate,
+            podcastEpisode.Episode.Id,
+            podcastEpisode.Episode.Title,
+            podcastEpisode.Podcast.Id,
+            podcastEpisode.Podcast.Name,
+            caller,
+            podcastEpisode.Episode.Urls.Spotify,
+            podcastEpisode.Episode.Urls.YouTube,
+            podcastEpisode.Episode.Urls.Apple);
+    }
+
+    public static void LogFlagSetWithoutPost(
+        ILogger logger,
+        Episode episode,
+        Guid podcastId,
+        string caller)
+    {
+        logger.LogWarning(
+            FlagSetMessageTemplate,
+            episode.Id,
+            episode.Title,
+            podcastId,
+            caller);
+    }
+
+    public static string FormatPostedMessage(
+        PodcastEpisode podcastEpisode,
+        string caller)
+    {
+        return
+            $"{PostedMessagePrefix} episode-id='{podcastEpisode.Episode.Id}' title='{podcastEpisode.Episode.Title}' podcast-id='{podcastEpisode.Podcast.Id}' podcast-name='{podcastEpisode.Podcast.Name}' caller='{caller}' spotify-url='{podcastEpisode.Episode.Urls.Spotify}' youtube-url='{podcastEpisode.Episode.Urls.YouTube}' apple-url='{podcastEpisode.Episode.Urls.Apple}'";
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Posters/BlueskyPoster.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Posters/BlueskyPoster.cs
@@ -2,6 +2,7 @@ using System.Security.Authentication;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Bluesky.Client;
 using RedditPodcastPoster.Bluesky.Factories;
+using RedditPodcastPoster.Bluesky.Logging;
 using RedditPodcastPoster.Bluesky.Models;
 using RedditPodcastPoster.Models.Episodes;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
@@ -41,6 +42,10 @@ public class BlueskyPoster(
             }
 
             sendStatus = BlueskySendStatus.Success;
+            BlueskyPostLogger.LogPosted(
+                logger,
+                podcastEpisode,
+                caller: nameof(BlueskyPoster) + "." + nameof(Post));
             logger.LogInformation("Posted to bluesky: '{EmbedPostText}'.", embedPost.Text);
         }
         catch (HttpRequestException ex)

--- a/Class-Libraries/RedditPodcastPoster.Common/Episodes/EpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.Common/Episodes/EpisodeProvider.cs
@@ -29,36 +29,6 @@ public class EpisodeProvider(
             (newEpisodes, handled) = await RetrieveYouTubeEpisodes(podcast, episodes, indexingContext, newEpisodes);
         }
 
-        if (indexingContext.IndexSpotify &&
-            !indexingContext.SkipSpotifyUrlResolving &&
-            !string.IsNullOrWhiteSpace(podcast.SpotifyId) &&
-            podcast.ReleaseAuthority == Service.YouTube &&
-            podcast.YouTubePublishingDelay().Ticks < 0)
-        {
-            var (spotifyEpisodes, _) = await spotifyEpisodeRetrievalHandler.GetEpisodes(podcast, indexingContext);
-            if (spotifyEpisodes is { Count: > 0 })
-            {
-                newEpisodes = CombineDiscoveredEpisodes(newEpisodes, spotifyEpisodes);
-                logger.LogInformation(
-                    "Get Episodes for podcast '{podcastName}' merged {spotifyEpisodeCount} Spotify catalogue episodes for YouTube release authority merge.",
-                    podcast.Name, spotifyEpisodes.Count);
-            }
-        }
-
-        if (podcast.AppleId != null &&
-            podcast.ReleaseAuthority == Service.YouTube &&
-            podcast.YouTubePublishingDelay().Ticks < 0)
-        {
-            var (appleEpisodes, _) = await appleEpisodeRetrievalHandler.GetEpisodes(podcast, indexingContext);
-            if (appleEpisodes is { Count: > 0 })
-            {
-                newEpisodes = CombineDiscoveredEpisodes(newEpisodes, appleEpisodes);
-                logger.LogInformation(
-                    "Get Episodes for podcast '{podcastName}' merged {appleEpisodeCount} Apple catalogue episodes for YouTube release authority merge.",
-                    podcast.Name, appleEpisodes.Count);
-            }
-        }
-
         if (indexingContext.IndexSpotify && podcast.ReleaseAuthority is null or Service.Spotify &&
             !string.IsNullOrWhiteSpace(podcast.SpotifyId))
         {

--- a/Class-Libraries/RedditPodcastPoster.Common/Episodes/PodcastEpisodeFilter.cs
+++ b/Class-Libraries/RedditPodcastPoster.Common/Episodes/PodcastEpisodeFilter.cs
@@ -151,7 +151,7 @@ public class PodcastEpisodeFilter(
             .ToArray();
         if (!podcastEpisodes.Any())
         {
-            logger.LogWarning(
+            logger.LogInformation(
                 "No Podcast-Episode found ready to Bluesky for podcast '{PodcastName}' with podcast-id '{PodcastId}'. Candidate-episodes: {candidateCount}, released-since: '{releasedSince:u}', youTubeRefreshed: {youTubeRefreshed}, spotifyRefreshed: {spotifyRefreshed}.",
                 podcast.Name, podcast.Id, episodeArray.Length, since, youTubeRefreshed, spotifyRefreshed);
         }
@@ -186,7 +186,7 @@ public class PodcastEpisodeFilter(
             .ToArray();
         if (!podcastEpisodes.Any())
         {
-            logger.LogWarning(
+            logger.LogInformation(
                 "No Podcast-Episode found ready to Bluesky for podcast '{PodcastName}' with podcast-id '{PodcastId}'. Candidate-episodes: {candidateCount}, released-since: '{releasedSince:u}'.",
                 podcast.Name, podcast.Id, episodeArray.Length, since);
         }

--- a/Class-Libraries/RedditPodcastPoster.Common/Episodes/PodcastEpisodeFilter.cs
+++ b/Class-Libraries/RedditPodcastPoster.Common/Episodes/PodcastEpisodeFilter.cs
@@ -51,7 +51,7 @@ public class PodcastEpisodeFilter(
             .Where(x =>
                 x.Episode.Release >= since &&
                 x.Episode is { Removed: false, Ignored: false, Tweeted: false } &&
-                (x.Episode.Urls.YouTube != null || x.Episode.Urls.Spotify != null) &&
+                HasSocialPostableUrl(x.Podcast, x.Episode) &&
                 !x.Podcast.IsDelayedYouTubePublishing(x.Episode))
             .OrderByDescending(x => x.Episode.Release)
             .ToArray();
@@ -106,7 +106,7 @@ public class PodcastEpisodeFilter(
             .Where(x =>
                 x.Episode.Release >= since &&
                 x.Episode is { Removed: false, Ignored: false, Tweeted: false } &&
-                (x.Episode.Urls.YouTube != null || x.Episode.Urls.Spotify != null) &&
+                HasSocialPostableUrl(x.Podcast, x.Episode) &&
                 !x.Podcast.IsDelayedYouTubePublishing(x.Episode))
             .Where(x => EliminateItemsDueToIndexingErrors(x, youTubeRefreshed, spotifyRefreshed))
             .OrderByDescending(x => x.Episode.Release)
@@ -144,7 +144,7 @@ public class PodcastEpisodeFilter(
                 x.Episode.Release >= since &&
                 x.Episode.BlueskyPosted is null or false &&
                 x.Episode is { Removed: false, Ignored: false } &&
-                (x.Episode.Urls.YouTube != null || x.Episode.Urls.Spotify != null) &&
+                HasSocialPostableUrl(x.Podcast, x.Episode) &&
                 !x.Podcast.IsDelayedYouTubePublishing(x.Episode))
             .Where(x => EliminateItemsDueToIndexingErrors(x, youTubeRefreshed, spotifyRefreshed))
             .OrderByDescending(x => x.Episode.Release)
@@ -180,7 +180,7 @@ public class PodcastEpisodeFilter(
                 x.Episode.Release >= since &&
                 x.Episode.BlueskyPosted is null or false &&
                 x.Episode is { Removed: false, Ignored: false } &&
-                (x.Episode.Urls.YouTube != null || x.Episode.Urls.Spotify != null) &&
+                HasSocialPostableUrl(x.Podcast, x.Episode) &&
                 !x.Podcast.IsDelayedYouTubePublishing(x.Episode))
             .OrderByDescending(x => x.Episode.Release)
             .ToArray();
@@ -192,6 +192,20 @@ public class PodcastEpisodeFilter(
         }
 
         return Task.FromResult<IEnumerable<PodcastEpisode>>(podcastEpisodes);
+    }
+
+    /// <summary>
+    /// YouTube release-authority podcasts must have a YouTube URL before social posting.
+    /// Other authorities may post with Spotify or YouTube.
+    /// </summary>
+    private static bool HasSocialPostableUrl(Podcast podcast, Episode episode)
+    {
+        if (podcast.ReleaseAuthority == Service.YouTube)
+        {
+            return episode.Urls.YouTube != null;
+        }
+
+        return episode.Urls.YouTube != null || episode.Urls.Spotify != null;
     }
 
     private bool IsReadyToPost(Podcast podcast, Episode episode, DateTime since)

--- a/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fakes/InMemoryPodcastRepository.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fakes/InMemoryPodcastRepository.cs
@@ -86,6 +86,10 @@ public sealed class InMemoryPodcastRepository : IPodcastRepository
             AppleId = podcast.AppleId,
             YouTubeChannelId = podcast.YouTubeChannelId,
             YouTubePlaylistId = podcast.YouTubePlaylistId,
+            YouTubePlaylistIdHistory = podcast.YouTubePlaylistIdHistory?
+                .Select(x => new YouTubePlaylistIdHistoryEntry { Id = x.Id, ReplacedAt = x.ReplacedAt })
+                .ToList(),
+            YouTubePlaylistOrder = podcast.YouTubePlaylistOrder,
             YouTubePublicationOffset = podcast.YouTubePublicationOffset,
             ReleaseAuthority = podcast.ReleaseAuthority,
             IndexAllEpisodes = podcast.IndexAllEpisodes,

--- a/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
@@ -328,6 +328,10 @@ public sealed class DomainTestFixture
   public string CreateYouTubeChannelId() =>
     "UC" + CreateRandomString(_fixture, YouTubeIdAlphabet, 22);
 
+  /// <summary>YouTube playlist ID (PL prefix + 32 chars).</summary>
+  public string CreateYouTubePlaylistId() =>
+    "PL" + CreateRandomString(_fixture, YouTubeIdAlphabet, 32);
+
   /// <summary>Random Guid for generic test identity (podcast/episode ids not asserted).</summary>
   public Guid CreateGuid() => _fixture.Create<Guid>();
 

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -601,10 +601,10 @@ public class CatalogueMatchingRules
 
     [Fact(DisplayName =
         "When enriching a YouTube-discovered episode, FindCatalogueMatchByLength must not duration-snipe " +
-        "a catalogue row whose title shares no fuzzy or substring relationship with the stored episode.")]
+        "a catalogue row outside the expanded release window whose title shares no relationship.")]
     public void youtube_discovered_enrichment_does_not_duration_snipe_disjoint_titles()
     {
-        // Arrange — YouTube-authority enrichment: release window aligns but titles refer to different interviews
+        // Arrange — YouTube-authority enrichment: titles refer to different interviews; release is days apart
         const string storedTitle = "My Buddhist Guru Convinced Me Her Ab*se Was Enlightenment";
         const string catalogueTitle =
             "Growing Up On SISTER WIVES: The Dark Side of Parenting No One Talks About (ft. Mykelti Brown)";
@@ -637,6 +637,46 @@ public class CatalogueMatchingRules
 
         // Assert
         result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "When enriching a YouTube-discovered episode whose Spotify title is wholly different, " +
+        "FindCatalogueMatchByLength still matches the sole catalogue row with unique duration " +
+        "inside the expanded twelve-hour release window.")]
+    public void youtube_discovered_unique_duration_within_release_window_matches_without_title_confidence()
+    {
+        // Arrange — Virginia-style: Apple/YouTube title vs editorial Spotify rename; same length, same day
+        const string storedTitle = "Virginia | Ep 3: Mommy still loves you";
+        const string spotifyTitle = "Ep 3 — A restraining order that changed everything";
+        var sharedLength = TimeSpan.FromMinutes(58) + TimeSpan.FromSeconds(34);
+        var probeRelease = new DateTime(2026, 7, 24, 19, 0, 0, DateTimeKind.Utc);
+        var spotifyRelease = new DateTime(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = storedTitle;
+            e.Length = sharedLength;
+            e.Release = probeRelease;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+        });
+        var catalogueItem = _fixture.CreateEpisode(e =>
+        {
+            e.Title = spotifyTitle;
+            e.Length = sharedLength;
+            e.Release = spotifyRelease;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+        });
+        var podcast = _fixture.CreatePodcast();
+
+        // Act
+        var result = _matcher.FindCatalogueMatchByLength(
+            probe,
+            [catalogueItem],
+            podcast,
+            episodeMatchRegex: null,
+            new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
+
+        // Assert
+        result.Should().BeSameAs(catalogueItem);
     }
 
     [Fact(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
@@ -215,15 +215,41 @@ public sealed partial class EpisodePlatformMatcher
             .Where(x => HasCatalogueTitleConfidence(probe.Title, x.Title))
             .ToList();
 
-        if (titleConfidentCandidates.Count == 0)
+        if (titleConfidentCandidates.Count > 0)
+        {
+            var titleConfidentMatch = FindYouTubeDiscoveredCatalogueMatchByDuration(
+                titleConfidentCandidates,
+                probe.Length,
+                probe.Release);
+            if (titleConfidentMatch != null)
+            {
+                return titleConfidentMatch;
+            }
+        }
+
+        // Titles can diverge across platforms (e.g. editorial Spotify rename) while release and
+        // duration still uniquely identify the episode. Accept only a sole duration match that
+        // also falls inside the expanded YouTube-discovered release window — never a bare
+        // unique-duration snipe across weeks.
+        return FindUniqueDurationWithinReleaseWindow(probe, sampleList);
+    }
+
+    private static Episode? FindUniqueDurationWithinReleaseWindow(
+        Episode probe,
+        IList<Episode> sampleList)
+    {
+        if (probe.Release == DateTime.MinValue || probe.Length <= TimeSpan.Zero)
         {
             return null;
         }
 
-        return FindYouTubeDiscoveredCatalogueMatchByDuration(
-            titleConfidentCandidates,
-            probe.Length,
-            probe.Release);
+        var matches = sampleList
+            .Where(x =>
+                Math.Abs((x.Length - probe.Length).Ticks) < CatalogueYouTubeDiscoveredDurationThreshold &&
+                Math.Abs((x.Release - probe.Release).Ticks) < CatalogueYouTubeDiscoveredReleaseThreshold.Ticks)
+            .ToList();
+
+        return matches.Count == 1 ? matches[0] : null;
     }
 
     private static bool HasCatalogueTitleConfidence(string probeTitle, string candidateTitle)

--- a/Class-Libraries/RedditPodcastPoster.Models/Podcasts/PlaylistOrder.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Podcasts/PlaylistOrder.cs
@@ -1,0 +1,14 @@
+namespace RedditPodcastPoster.Models.Podcasts;
+
+/// <summary>
+/// Declared ordering of a podcast's YouTube playlist. Absent (null) means order is probed from the
+/// playlist head each windowed pass. <see cref="Arbitrary"/> marks manually curated playlists where
+/// position carries no date information: new items may appear at either end, so the playlist must be
+/// walked in full and filtered by added-at date. See docs/youtube-playlist-order.md.
+/// </summary>
+public enum PlaylistOrder
+{
+    ReverseChronological,
+    Ascending,
+    Arbitrary
+}

--- a/Class-Libraries/RedditPodcastPoster.Models/Podcasts/Podcast.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Podcasts/Podcast.cs
@@ -99,6 +99,15 @@ public class Podcast
     [JsonPropertyOrder(140)]
     public string YouTubePlaylistId { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Declared playlist ordering. Null: probe head order each pass (default). Arbitrary: manually
+    /// curated playlist where position carries no date information — full walk + added-at filter.
+    /// </summary>
+    [JsonPropertyName("youTubePlaylistOrder")]
+    [JsonPropertyOrder(150)]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public PlaylistOrder? YouTubePlaylistOrder { get; set; }
+
     [JsonPropertyName("youTubePublicationOffset")]
     [JsonPropertyOrder(151)]
     public long? YouTubePublicationOffset { get; set; }
@@ -181,6 +190,11 @@ public class Podcast
     public bool HasExpensiveYouTubePlaylistQuery()
     {
         return YouTubePlaylistQueryIsExpensive.HasValue && YouTubePlaylistQueryIsExpensive.Value;
+    }
+
+    public bool HasArbitraryYouTubePlaylistOrder()
+    {
+        return YouTubePlaylistOrder == PlaylistOrder.Arbitrary;
     }
 
     public bool HasYouTubeChannelSearchForbidden()

--- a/Class-Libraries/RedditPodcastPoster.Models/Podcasts/Podcast.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Podcasts/Podcast.cs
@@ -100,6 +100,14 @@ public class Podcast
     public string YouTubePlaylistId { get; set; } = string.Empty;
 
     /// <summary>
+    /// Former YouTube playlist ids (id + UTC replaced-at), newest last. Populated when
+    /// <see cref="YouTubePlaylistId"/> changes through the playlist-id change helper.
+    /// </summary>
+    [JsonPropertyName("youTubePlaylistIdHistory")]
+    [JsonPropertyOrder(141)]
+    public List<YouTubePlaylistIdHistoryEntry>? YouTubePlaylistIdHistory { get; set; }
+
+    /// <summary>
     /// Declared playlist ordering. Null: probe head order each pass (default). Arbitrary: manually
     /// curated playlist where position carries no date information — full walk + added-at filter.
     /// </summary>

--- a/Class-Libraries/RedditPodcastPoster.Models/Podcasts/YouTubePlaylistIdHistoryEntry.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Podcasts/YouTubePlaylistIdHistoryEntry.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace RedditPodcastPoster.Models.Podcasts;
+
+/// <summary>
+/// A former <see cref="Podcast.YouTubePlaylistId"/> retained when the configured playlist is swapped
+/// so operators can recover if the new playlist was wrong.
+/// </summary>
+public class YouTubePlaylistIdHistoryEntry
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>UTC instant when this id stopped being the active <see cref="Podcast.YouTubePlaylistId"/>.</summary>
+    [JsonPropertyName("replacedAt")]
+    public DateTime ReplacedAt { get; set; }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Enriching/ISpotifyEnrichmentSideEffect.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Enriching/ISpotifyEnrichmentSideEffect.cs
@@ -4,5 +4,8 @@ namespace RedditPodcastPoster.PodcastServices.Abstractions.Enriching;
 
 public interface ISpotifyEnrichmentSideEffect
 {
-    void OnFindComplete(Podcast podcast, bool isExpensiveQuery);
+    /// <param name="isExpensiveQuery">
+    /// Catalogue-order probe: true = oldest-first, false = newest-first, null = inconclusive (do not change flag).
+    /// </param>
+    void OnFindComplete(Podcast podcast, bool? isExpensiveQuery);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Categorisers/SpotifyUrlCategoriserRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Categorisers/SpotifyUrlCategoriserRules.cs
@@ -54,6 +54,38 @@ public class SpotifyUrlCategoriserRules
     }
 
     [Fact(DisplayName =
+        "When the matching podcast has an expensive Spotify query, SkipExpensiveSpotifyQueries is set, and ReleasedSince " +
+        "is present, Resolve still returns null without calling FindEpisode because MatchOtherServices has no " +
+        "ReleasedSince carve-out — unlike SpotifyPodcastEpisodesProvider discovery, which still date-paginates.")]
+    public async Task Resolve_short_circuits_even_when_released_since_is_set()
+    {
+        // Arrange — intentional divergence from provider discovery (see docs/catalogue-pagination.md)
+        var podcast = _fixture.CreatePodcast(p =>
+        {
+            p.SpotifyEpisodesQueryIsExpensive = true;
+            p.SpotifyId = _fixture.CreateSpotifyId();
+        });
+        var criteria = CreateCriteria();
+        var resolver = new Mock<ISpotifyEpisodeResolver>(MockBehavior.Strict);
+        var sut = CreateSut(resolver.Object);
+        var indexingContext = new IndexingContext(
+            ReleasedSince: DomainTestFixture.UtcDateDaysAgo(2),
+            SkipExpensiveSpotifyQueries: true);
+
+        // Act
+        var result = await sut.Resolve(criteria, podcast, indexingContext);
+
+        // Assert
+        result.Should().BeNull();
+        resolver.Verify(
+            x => x.FindEpisode(
+                It.IsAny<FindSpotifyEpisodeRequest>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<Func<SimpleEpisode, bool>?>()),
+            Times.Never);
+    }
+
+    [Fact(DisplayName =
         "When SkipExpensiveSpotifyQueries is false for an expensive podcast, Resolve still attempts FindEpisode " +
         "because API submit and discovery curation allow expensive Spotify matching.")]
     public async Task Resolve_calls_find_episode_when_expensive_queries_allowed()

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyEpisodeEnricherCatalogueReleaseReducerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyEpisodeEnricherCatalogueReleaseReducerRules.cs
@@ -64,7 +64,7 @@ public class SpotifyEpisodeEnricherCatalogueReleaseReducerRules
             EpisodeDomainTestServices.CreatePlatformMatcher(),
             new SpotifyEpisodeAdapter(),
             EpisodeDomainTestServices.CreateEnrichmentApplicator(),
-            new SpotifyExpensiveQuerySideEffect(),
+            new SpotifyExpensiveQuerySideEffect(NullLogger<SpotifyExpensiveQuerySideEffect>.Instance),
             _htmlSanitiser,
             NullLogger<SpotifyEpisodeEnricher>.Instance);
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyEpisodeEnricherCatalogueRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyEpisodeEnricherCatalogueRules.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using RedditPodcastPoster.Episodes.Adapters;
 using RedditPodcastPoster.Episodes.TestSupport;
@@ -86,6 +87,41 @@ public class SpotifyEpisodeEnricherCatalogueRules
         episode.SpotifyId.Should().BeNullOrWhiteSpace();
         episode.Urls.Spotify.Should().BeNull();
         enrichmentContext.SpotifyUrlUpdated.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "When no Spotify catalogue match is found, the enricher emits a Warning with episode-id " +
+        "and rejection context so App Insights can explain enrich misses.")]
+    public async Task enrich_logs_warning_with_rejection_context_when_no_catalogue_match()
+    {
+        // Arrange
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.Name = "Virginia I The Age & SMH Investigates";
+        var episode = _fixture.CreateYouTubeCatalogueEpisode(b => b.WithDuration(TimeSpan.FromMinutes(58)));
+        episode.Id = Guid.Parse("f58f1992-c8e6-4ba0-a3a0-fd4b83d261bd");
+        episode.Title = "Virginia | Ep 3: Mommy still loves you";
+        episode.SpotifyId = string.Empty;
+        episode.Urls.Spotify = null;
+        var logger = new CapturingLogger<SpotifyEpisodeEnricher>();
+        var sut = CreateEnricher(
+            new CapturingSpotifyEpisodeResolver([], expectedSpotifyId: string.Empty),
+            logger);
+        var enrichmentContext = new EnrichmentContext();
+
+        // Act
+        await sut.Enrich(
+            new EnrichmentRequest(podcast, [episode], episode),
+            new IndexingContext(),
+            enrichmentContext);
+
+        // Assert
+        var miss = logger.Warnings.Should().ContainSingle(m => m.Contains("Spotify enrich miss")).Subject;
+        miss.Should().Contain($"episode-id='{episode.Id}'");
+        miss.Should().Contain($"podcast-id='{podcast.Id}'");
+        miss.Should().Contain($"spotify-show-id='{podcast.SpotifyId}'");
+        miss.Should().Contain("youtube-discovered=");
+        miss.Should().Contain("expected-release=");
+        miss.Should().Contain("length=");
     }
 
     [Fact(DisplayName =
@@ -189,15 +225,17 @@ public class SpotifyEpisodeEnricherCatalogueRules
         enrichmentContext.SpotifyUrlUpdated.Should().BeFalse();
     }
 
-    private SpotifyEpisodeEnricher CreateEnricher(ISpotifyEpisodeResolver resolver) =>
+    private SpotifyEpisodeEnricher CreateEnricher(
+        ISpotifyEpisodeResolver resolver,
+        ILogger<SpotifyEpisodeEnricher>? logger = null) =>
         new(
             resolver,
             EpisodeDomainTestServices.CreatePlatformMatcher(),
             new SpotifyEpisodeAdapter(),
             EpisodeDomainTestServices.CreateEnrichmentApplicator(),
-            new SpotifyExpensiveQuerySideEffect(),
+            new SpotifyExpensiveQuerySideEffect(NullLogger<SpotifyExpensiveQuerySideEffect>.Instance),
             _htmlSanitiser,
-            NullLogger<SpotifyEpisodeEnricher>.Instance);
+            logger ?? NullLogger<SpotifyEpisodeEnricher>.Instance);
 
     private FullEpisode CreateFullEpisode(
         string spotifyId,
@@ -276,6 +314,28 @@ public class SpotifyEpisodeEnricherCatalogueRules
         {
             FindEpisodeInvoked = true;
             return Task.FromResult(new FindEpisodeResponse(null));
+        }
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<string> Warnings { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(formatter(state, exception));
+            }
         }
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyExpensiveQuerySideEffectRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Enrichers/SpotifyExpensiveQuerySideEffectRules.cs
@@ -9,13 +9,12 @@ using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using RedditPodcastPoster.PodcastServices.Spotify.Enrichers;
 using RedditPodcastPoster.PodcastServices.Spotify.Models;
 using RedditPodcastPoster.PodcastServices.Spotify.Resolvers;
-using RedditPodcastPoster.Text;
 using RedditPodcastPoster.Text.Sanitisers;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Enrichers;
 
 /// <summary>
-/// Spotify expensive-query side-effect rules â€” podcast flag persistence after FindEpisode.
+/// Spotify expensive-query side-effect rules — podcast flag persistence after FindEpisode.
 /// </summary>
 public class SpotifyExpensiveQuerySideEffectRules
 {
@@ -49,13 +48,13 @@ public class SpotifyExpensiveQuerySideEffectRules
     }
 
     [Fact(DisplayName =
-        "When Spotify FindEpisode does not report an expensive query, the side-effect leaves " +
-        "SpotifyEpisodesQueryIsExpensive unset because no throttling signal was returned.")]
-    public async Task non_expensive_query_does_not_set_podcast_flag()
+        "When Spotify FindEpisode reports a newest-first catalogue, the side-effect clears " +
+        "SpotifyEpisodesQueryIsExpensive because ascending order can flip back.")]
+    public async Task non_expensive_query_clears_podcast_flag()
     {
         // Arrange
         var podcast = _fixture.CreatePodcast();
-        podcast.SpotifyEpisodesQueryIsExpensive = false;
+        podcast.SpotifyEpisodesQueryIsExpensive = true;
         var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(
             podcast,
             DomainTestFixture.UtcDaysAgo(5),
@@ -75,17 +74,44 @@ public class SpotifyExpensiveQuerySideEffectRules
         podcast.SpotifyEpisodesQueryIsExpensive.Should().BeFalse();
     }
 
-    private SpotifyEpisodeEnricher CreateEnricher(bool isExpensiveQuery) =>
+    [Fact(DisplayName =
+        "When Spotify FindEpisode returns an inconclusive order probe, the side-effect leaves " +
+        "SpotifyEpisodesQueryIsExpensive unchanged because a thin sample must not invent order.")]
+    public async Task inconclusive_query_leaves_podcast_flag()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        podcast.SpotifyEpisodesQueryIsExpensive = true;
+        var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(
+            podcast,
+            DomainTestFixture.UtcDaysAgo(5),
+            _fixture.CreateDuration(),
+            _fixture.CreateTitle());
+        episode.SpotifyId = string.Empty;
+        episode.Urls.Spotify = null;
+        var sut = CreateEnricher(isExpensiveQuery: null);
+
+        // Act
+        await sut.Enrich(
+            new EnrichmentRequest(podcast, [episode], episode),
+            new IndexingContext(),
+            new EnrichmentContext());
+
+        // Assert
+        podcast.SpotifyEpisodesQueryIsExpensive.Should().BeTrue();
+    }
+
+    private SpotifyEpisodeEnricher CreateEnricher(bool? isExpensiveQuery) =>
         new(
             new ExpensiveQueryOnlySpotifyEpisodeResolver(isExpensiveQuery),
             EpisodeDomainTestServices.CreatePlatformMatcher(),
             new SpotifyEpisodeAdapter(),
             EpisodeDomainTestServices.CreateEnrichmentApplicator(),
-            new SpotifyExpensiveQuerySideEffect(),
+            new SpotifyExpensiveQuerySideEffect(NullLogger<SpotifyExpensiveQuerySideEffect>.Instance),
             new HtmlSanitiser(NullLogger<HtmlSanitiser>.Instance),
             NullLogger<SpotifyEpisodeEnricher>.Instance);
 
-    private sealed class ExpensiveQueryOnlySpotifyEpisodeResolver(bool isExpensiveQuery) : ISpotifyEpisodeResolver
+    private sealed class ExpensiveQueryOnlySpotifyEpisodeResolver(bool? isExpensiveQuery) : ISpotifyEpisodeResolver
     {
         public Task<FindEpisodeResponse> FindEpisode(
             FindSpotifyEpisodeRequest request,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SearchResultFinderCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SearchResultFinderCatalogueWrapperRules.cs
@@ -86,7 +86,8 @@ public class SearchResultFinderCatalogueWrapperRules
 
     [Fact(DisplayName =
         "When enriching a YouTube-discovered episode via the Spotify finder, a sole catalogue row " +
-        "within five minutes of duration but with a disjoint title must not be selected.")]
+        "within five minutes of duration but outside the expanded release window and with a " +
+        "disjoint title must not be selected.")]
     public void find_by_length_youtube_enrichment_does_not_duration_snipe_disjoint_title()
     {
         // Arrange — wrong-week YouTube (~59:40) must not claim this week's Spotify (~62:39) on duration alone
@@ -119,6 +120,41 @@ public class SearchResultFinderCatalogueWrapperRules
 
         // Assert
         result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "When enriching a YouTube-discovered episode via the Spotify finder, a sole catalogue row " +
+        "with unique duration inside the twelve-hour release window is selected even when titles diverge.")]
+    public void find_by_length_youtube_enrichment_accepts_unique_duration_within_release_window()
+    {
+        // Arrange
+        const string youTubeTitle = "Virginia | Ep 3: Mommy still loves you";
+        const string spotifyTitle = "Ep 3 — A restraining order that changed everything";
+        var length = TimeSpan.FromMinutes(58) + TimeSpan.FromSeconds(34);
+        var matchingId = _fixture.CreateSpotifyId();
+        var episodes = new List<SimpleEpisode>
+        {
+            new()
+            {
+                Id = matchingId,
+                Name = spotifyTitle,
+                DurationMs = (int)length.TotalMilliseconds,
+                ReleaseDate = "2026-07-24"
+            }
+        };
+
+        // Act — probe release within 12h of Spotify midnight UTC
+        var result = _sut.FindMatchingEpisodeByLength(
+            youTubeTitle,
+            length,
+            episodes,
+            releaseAuthority: Service.Spotify,
+            released: new DateTime(2026, 7, 24, 10, 0, 0, DateTimeKind.Utc),
+            enrichingYouTubeDiscoveredEpisode: true);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(matchingId);
     }
 
     [Fact(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Logging/SpotifyNonPlayableSkipLoggerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Logging/SpotifyNonPlayableSkipLoggerRules.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.PodcastServices.Spotify.Logging;
+using RedditPodcastPoster.PodcastServices.Spotify.Models;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Logging;
+
+public class SpotifyNonPlayableSkipLoggerRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "When restrictions.reason is market, Log emits Error with the market-unavailable prefix " +
+        "because market blocks must not be silent Warning-level skips.")]
+    public void market_restriction_logs_error()
+    {
+        // Arrange
+        var logger = new CapturingLogger();
+        var episode = new FullEpisodeWithRestrictions
+        {
+            Id = _fixture.CreateSpotifyId(),
+            Name = "Virginia | Ep 3: Mommy still loves you",
+            IsPlayable = false,
+            Restrictions = new Dictionary<string, string>
+            {
+                ["reason"] = SpotifyNonPlayableSkipLogger.MarketRestrictionReason
+            }
+        };
+
+        // Act
+        SpotifyNonPlayableSkipLogger.Log(logger, episode, "GB");
+
+        // Assert
+        logger.Errors.Should().ContainSingle(m =>
+            m.Contains(SpotifyNonPlayableSkipLogger.MarketUnavailableMessagePrefix) &&
+            m.Contains(episode.Id) &&
+            m.Contains("market='GB'") &&
+            m.Contains("restrictions.reason='market'"));
+        logger.Warnings.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName =
+        "When restrictions.reason is payment_required, Log emits Warning (not Error) " +
+        "because paywall skips are expected catalogue filtering.")]
+    public void payment_required_logs_warning()
+    {
+        // Arrange
+        var logger = new CapturingLogger();
+        var episode = new SimpleEpisodeWithRestrictions
+        {
+            Id = _fixture.CreateSpotifyId(),
+            Name = _fixture.CreateTitle(),
+            IsPlayable = false,
+            Restrictions = new Dictionary<string, string> { ["reason"] = "payment_required" }
+        };
+
+        // Act
+        SpotifyNonPlayableSkipLogger.Log(logger, episode, "GB");
+
+        // Assert
+        logger.Warnings.Should().ContainSingle(m =>
+            m.Contains(episode.Id) &&
+            m.Contains("payment_required") &&
+            m.Contains("market='GB'"));
+        logger.Errors.Should().BeEmpty();
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = [];
+        public List<string> Errors { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var message = formatter(state, exception);
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(message);
+            }
+            else if (logLevel == LogLevel.Error)
+            {
+                Errors.Add(message);
+            }
+        }
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Models/SpotifyExpensiveQueryFlagRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Models/SpotifyExpensiveQueryFlagRules.cs
@@ -1,0 +1,192 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.Spotify.Models;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Models;
+
+public class SpotifyExpensiveQueryFlagRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "A conclusive ascending probe sets SpotifyEpisodesQueryIsExpensive true " +
+        "because oldest-first catalogues must use the end-jump pagination path.")]
+    public void Conclusive_ascending_sets_true()
+    {
+        var podcast = _fixture.CreatePodcast(p => p.SpotifyEpisodesQueryIsExpensive = false);
+
+        var changed = SpotifyExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive: true,
+            orderSampleSize: SpotifyExpensiveQueryFlag.MinimumOrderSampleSize);
+
+        changed.Should().BeTrue();
+        podcast.SpotifyEpisodesQueryIsExpensive.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "A conclusive newest-first probe clears SpotifyEpisodesQueryIsExpensive " +
+        "because Spotify catalogues are known to flip back from ascending order.")]
+    public void Conclusive_newest_first_clears_true()
+    {
+        var podcast = _fixture.CreatePodcast(p => p.SpotifyEpisodesQueryIsExpensive = true);
+
+        var changed = SpotifyExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive: false,
+            orderSampleSize: SpotifyExpensiveQueryFlag.MinimumOrderSampleSize,
+            NullLogger.Instance);
+
+        changed.Should().BeTrue();
+        podcast.SpotifyEpisodesQueryIsExpensive.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "An inconclusive single-episode probe leaves SpotifyEpisodesQueryIsExpensive unchanged " +
+        "because one release date cannot distinguish catalogue order.")]
+    public void Inconclusive_sample_does_not_clear_flag()
+    {
+        var podcast = _fixture.CreatePodcast(p => p.SpotifyEpisodesQueryIsExpensive = true);
+
+        var changed = SpotifyExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive: false,
+            orderSampleSize: 1);
+
+        changed.Should().BeFalse();
+        podcast.SpotifyEpisodesQueryIsExpensive.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "A null probe leaves SpotifyEpisodesQueryIsExpensive unchanged " +
+        "because skipped pagination must not invent a catalogue-order measurement.")]
+    public void Null_probe_does_not_change_flag()
+    {
+        var podcast = _fixture.CreatePodcast(p => p.SpotifyEpisodesQueryIsExpensive = true);
+
+        var changed = SpotifyExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive: null,
+            orderSampleSize: SpotifyExpensiveQueryFlag.MinimumOrderSampleSize);
+
+        changed.Should().BeFalse();
+        podcast.SpotifyEpisodesQueryIsExpensive.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "Successive conclusive probes flip SpotifyEpisodesQueryIsExpensive in both directions repeatedly, logging each flip " +
+        "because a show that switches catalogue order more than once must never latch on a stale value.")]
+    public void Conclusive_probes_round_trip_in_both_directions()
+    {
+        var podcast = _fixture.CreatePodcast(p => p.SpotifyEpisodesQueryIsExpensive = false);
+        var logger = new CapturingLogger();
+
+        var observed = new List<(bool Changed, bool? Value)>();
+        foreach (var measured in new[] { true, false, true, false })
+        {
+            var changed = ApplyConclusive(podcast, measured, logger);
+            observed.Add((changed, podcast.SpotifyEpisodesQueryIsExpensive));
+        }
+
+        observed.Should().Equal(
+            (true, true),
+            (true, false),
+            (true, true),
+            (true, false));
+        logger.Warnings.Should().HaveCount(4);
+        logger.Warnings.Should().OnlyContain(x =>
+            x.StartsWith(SpotifyExpensiveQueryFlag.FlagFlippedMessagePrefix));
+    }
+
+    [Fact(DisplayName =
+        "Repeating the same conclusive probe reports no change and logs nothing " +
+        "because a steady catalogue order must not emit a flip per indexer pass.")]
+    public void Repeated_conclusive_probe_is_idempotent()
+    {
+        var podcast = _fixture.CreatePodcast(p => p.SpotifyEpisodesQueryIsExpensive = false);
+        var logger = new CapturingLogger();
+
+        var firstChange = ApplyConclusive(podcast, measuredExpensive: true, logger);
+        var secondChange = ApplyConclusive(podcast, measuredExpensive: true, logger);
+        var thirdChange = ApplyConclusive(podcast, measuredExpensive: true, logger);
+
+        firstChange.Should().BeTrue();
+        secondChange.Should().BeFalse();
+        thirdChange.Should().BeFalse();
+        podcast.SpotifyEpisodesQueryIsExpensive.Should().BeTrue();
+        logger.Warnings.Should().ContainSingle();
+    }
+
+    [Fact(DisplayName =
+        "An inconclusive probe between two conclusive probes preserves the flag and does not block the later flip " +
+        "because a thin sample must pause measurement rather than reset it.")]
+    public void Inconclusive_probe_between_flips_preserves_round_trip()
+    {
+        var podcast = _fixture.CreatePodcast(p => p.SpotifyEpisodesQueryIsExpensive = false);
+        var logger = new CapturingLogger();
+
+        ApplyConclusive(podcast, measuredExpensive: true, logger);
+        var inconclusiveChange = SpotifyExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive: false,
+            orderSampleSize: SpotifyExpensiveQueryFlag.MinimumOrderSampleSize - 1,
+            logger);
+        var afterInconclusive = podcast.SpotifyEpisodesQueryIsExpensive;
+        var laterChange = ApplyConclusive(podcast, measuredExpensive: false, logger);
+
+        inconclusiveChange.Should().BeFalse();
+        afterInconclusive.Should().BeTrue();
+        laterChange.Should().BeTrue();
+        podcast.SpotifyEpisodesQueryIsExpensive.Should().BeFalse();
+        logger.Warnings.Should().HaveCount(2);
+    }
+
+    [Fact(DisplayName =
+        "An unmeasured podcast adopts its first conclusive probe in either direction " +
+        "because a null flag is absence of measurement, not a measured newest-first result.")]
+    public void Unmeasured_flag_adopts_first_conclusive_probe()
+    {
+        var ascending = _fixture.CreatePodcast(p => p.SpotifyEpisodesQueryIsExpensive = null);
+        var newestFirst = _fixture.CreatePodcast(p => p.SpotifyEpisodesQueryIsExpensive = null);
+
+        var ascendingChange = ApplyConclusive(ascending, measuredExpensive: true);
+        var newestFirstChange = ApplyConclusive(newestFirst, measuredExpensive: false);
+
+        ascendingChange.Should().BeTrue();
+        ascending.SpotifyEpisodesQueryIsExpensive.Should().BeTrue();
+        newestFirstChange.Should().BeTrue();
+        newestFirst.SpotifyEpisodesQueryIsExpensive.Should().BeFalse();
+    }
+
+    private static bool ApplyConclusive(Podcast podcast, bool measuredExpensive, ILogger? logger = null) =>
+        SpotifyExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive,
+            SpotifyExpensiveQueryFlag.MinimumOrderSampleSize,
+            logger);
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/AscendingEpisodePaginatorRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/AscendingEpisodePaginatorRules.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.PodcastServices.Spotify.Paginators;
+using RedditPodcastPoster.PodcastServices.Spotify.Tests.Support;
+using SpotifyAPI.Web;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Paginators;
+
+public class AscendingEpisodePaginatorRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "An ascending Spotify catalogue jumps directly to its final page and walks backwards to ReleasedSince " +
+        "because recent episodes are at the end and paging forward from offset zero wastes quota.")]
+    public async Task Jumps_to_final_page_then_walks_back_to_cutoff()
+    {
+        // Arrange — 103 episodes means the final 50-item page begins at offset 100.
+        const string firstHref =
+            "https://api.spotify.com/v1/shows/show/episodes?market=GB&limit=50&offset=0";
+        const string finalUrl =
+            "https://api.spotify.com/v1/shows/show/episodes?market=GB&limit=50&offset=100";
+        const string previousUrl =
+            "https://api.spotify.com/v1/shows/show/episodes?market=GB&limit=50&offset=50";
+
+        var recentOne = CreateEpisode("recent-1", daysAgo: 1);
+        var recentTwo = CreateEpisode("recent-2", daysAgo: 2);
+        var old = CreateEpisode("old", daysAgo: 30);
+        var firstPage = new Paging<SimpleEpisode>
+        {
+            Href = firstHref,
+            Items = [CreateEpisode("oldest", daysAgo: 3000)],
+            Limit = 50,
+            Offset = 0,
+            Total = 103,
+            Next = "https://api.spotify.com/v1/shows/show/episodes?market=GB&limit=50&offset=50"
+        };
+        var connector = new FakeSpotifyApiConnector(new Dictionary<string, object>
+        {
+            [finalUrl] = new Paging<SimpleEpisode>
+            {
+                Href = finalUrl,
+                Items = [recentTwo, recentOne],
+                Limit = 50,
+                Offset = 100,
+                Total = 103,
+                Previous = previousUrl
+            },
+            [previousUrl] = new Paging<SimpleEpisode>
+            {
+                Href = previousUrl,
+                Items = [old],
+                Limit = 50,
+                Offset = 50,
+                Total = 103,
+                Previous = firstHref
+            }
+        });
+        var sut = CreateSut(DomainTestFixture.UtcDateDaysAgo(3));
+
+        // Act
+        var results = await sut.Paginate(firstPage, connector).ToListAsync();
+
+        // Assert
+        results.Select(x => x.Id).Should().BeEquivalentTo(recentOne.Id, recentTwo.Id);
+        connector.RequestedUrls.Should().Equal(finalUrl, previousUrl);
+        connector.RequestedUrls.Should().NotContain(firstHref);
+    }
+
+    [Fact(DisplayName =
+        "An exact multiple catalogue size jumps to total minus limit " +
+        "because offset equal to total would be an empty page.")]
+    public async Task Exact_multiple_uses_last_non_empty_offset()
+    {
+        const string firstHref =
+            "https://api.spotify.com/v1/shows/show/episodes?limit=50&offset=0";
+        const string finalUrl =
+            "https://api.spotify.com/v1/shows/show/episodes?limit=50&offset=50";
+        var recent = CreateEpisode("recent", daysAgo: 1);
+        var firstPage = new Paging<SimpleEpisode>
+        {
+            Href = firstHref,
+            Items = [CreateEpisode("oldest", daysAgo: 3000)],
+            Limit = 50,
+            Offset = 0,
+            Total = 100
+        };
+        var connector = new FakeSpotifyApiConnector(new Dictionary<string, object>
+        {
+            [finalUrl] = new Paging<SimpleEpisode>
+            {
+                Href = finalUrl,
+                Items = [recent, CreateEpisode("old", daysAgo: 30)],
+                Limit = 50,
+                Offset = 50,
+                Total = 100,
+                Previous = firstHref
+            }
+        });
+        var sut = CreateSut(DomainTestFixture.UtcDateDaysAgo(3));
+
+        var results = await sut.Paginate(firstPage, connector).ToListAsync();
+
+        results.Select(x => x.Id).Should().Equal(recent.Id);
+        connector.RequestedUrls.Should().Equal(finalUrl);
+    }
+
+    private static AscendingEpisodePaginator CreateSut(DateTime releasedSince) =>
+        new(
+            releasedSince,
+            NullLogger<AscendingEpisodePaginator>.Instance,
+            new SimpleEpisodePaginator(
+                releasedSince,
+                isInReverseOrder: false,
+                NullLogger<SimpleEpisodePaginator>.Instance));
+
+    private SimpleEpisode CreateEpisode(string id, int daysAgo) =>
+        new()
+        {
+            Id = id,
+            Name = _fixture.CreateTitle(),
+            ReleaseDate = DomainTestFixture.UtcDateDaysAgo(daysAgo).ToString("yyyy-MM-dd"),
+            Type = ItemType.Episode
+        };
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/AscendingEpisodePaginatorRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/AscendingEpisodePaginatorRules.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.PodcastServices.Spotify.Paginators;
@@ -9,6 +10,9 @@ namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Pagina
 
 public class AscendingEpisodePaginatorRules
 {
+    private const string CataloguePath = "https://api.spotify.com/v1/shows/show/episodes";
+    private const int PageLimit = 50;
+
     private readonly DomainTestFixture _fixture = new();
 
     [Fact(DisplayName =
@@ -16,25 +20,21 @@ public class AscendingEpisodePaginatorRules
         "because recent episodes are at the end and paging forward from offset zero wastes quota.")]
     public async Task Jumps_to_final_page_then_walks_back_to_cutoff()
     {
-        // Arrange — 103 episodes means the final 50-item page begins at offset 100.
-        const string firstHref =
-            "https://api.spotify.com/v1/shows/show/episodes?market=GB&limit=50&offset=0";
-        const string finalUrl =
-            "https://api.spotify.com/v1/shows/show/episodes?market=GB&limit=50&offset=100";
-        const string previousUrl =
-            "https://api.spotify.com/v1/shows/show/episodes?market=GB&limit=50&offset=50";
-
-        var recentOne = CreateEpisode("recent-1", daysAgo: 1);
-        var recentTwo = CreateEpisode("recent-2", daysAgo: 2);
-        var old = CreateEpisode("old", daysAgo: 30);
+        // Arrange — 103 episodes means the final 50-item page begins at offset 100
+        var firstHref = PageUrl(0);
+        var finalUrl = PageUrl(100);
+        var previousUrl = PageUrl(50);
+        var recentOne = CreateEpisode(daysAgo: 1);
+        var recentTwo = CreateEpisode(daysAgo: 2);
+        var beyondCutoff = CreateEpisode(daysAgo: 30);
         var firstPage = new Paging<SimpleEpisode>
         {
             Href = firstHref,
-            Items = [CreateEpisode("oldest", daysAgo: 3000)],
-            Limit = 50,
+            Items = [CreateEpisode(daysAgo: 3000)],
+            Limit = PageLimit,
             Offset = 0,
             Total = 103,
-            Next = "https://api.spotify.com/v1/shows/show/episodes?market=GB&limit=50&offset=50"
+            Next = previousUrl
         };
         var connector = new FakeSpotifyApiConnector(new Dictionary<string, object>
         {
@@ -42,7 +42,7 @@ public class AscendingEpisodePaginatorRules
             {
                 Href = finalUrl,
                 Items = [recentTwo, recentOne],
-                Limit = 50,
+                Limit = PageLimit,
                 Offset = 100,
                 Total = 103,
                 Previous = previousUrl
@@ -50,8 +50,8 @@ public class AscendingEpisodePaginatorRules
             [previousUrl] = new Paging<SimpleEpisode>
             {
                 Href = previousUrl,
-                Items = [old],
-                Limit = 50,
+                Items = [beyondCutoff],
+                Limit = PageLimit,
                 Offset = 50,
                 Total = 103,
                 Previous = firstHref
@@ -73,16 +73,15 @@ public class AscendingEpisodePaginatorRules
         "because offset equal to total would be an empty page.")]
     public async Task Exact_multiple_uses_last_non_empty_offset()
     {
-        const string firstHref =
-            "https://api.spotify.com/v1/shows/show/episodes?limit=50&offset=0";
-        const string finalUrl =
-            "https://api.spotify.com/v1/shows/show/episodes?limit=50&offset=50";
-        var recent = CreateEpisode("recent", daysAgo: 1);
+        // Arrange — 100 episodes at 50 per page means the newest page begins at offset 50
+        var firstHref = PageUrl(0);
+        var finalUrl = PageUrl(PageLimit);
+        var recent = CreateEpisode(daysAgo: 1);
         var firstPage = new Paging<SimpleEpisode>
         {
             Href = firstHref,
-            Items = [CreateEpisode("oldest", daysAgo: 3000)],
-            Limit = 50,
+            Items = [CreateEpisode(daysAgo: 3000)],
+            Limit = PageLimit,
             Offset = 0,
             Total = 100
         };
@@ -91,36 +90,213 @@ public class AscendingEpisodePaginatorRules
             [finalUrl] = new Paging<SimpleEpisode>
             {
                 Href = finalUrl,
-                Items = [recent, CreateEpisode("old", daysAgo: 30)],
-                Limit = 50,
-                Offset = 50,
+                Items = [recent, CreateEpisode(daysAgo: 30)],
+                Limit = PageLimit,
+                Offset = PageLimit,
                 Total = 100,
                 Previous = firstHref
             }
         });
         var sut = CreateSut(DomainTestFixture.UtcDateDaysAgo(3));
 
+        // Act
         var results = await sut.Paginate(firstPage, connector).ToListAsync();
 
+        // Assert
         results.Select(x => x.Id).Should().Equal(recent.Id);
         connector.RequestedUrls.Should().Equal(finalUrl);
     }
 
-    private static AscendingEpisodePaginator CreateSut(DateTime releasedSince) =>
+    [Fact(DisplayName =
+        "A backwards walk through pages that never leave the release window stops after MaxWalkBackPages fetches " +
+        "because reading back from the newest end needs far fewer pages than a forward crawl and must not burn Spotify quota.")]
+    public async Task Walk_back_stops_at_its_own_page_cap()
+    {
+        // Arrange — every page sits inside the window, so only the cap can end the walk
+        var (firstPage, pagesByUrl) = BuildInWindowAscendingCatalogue();
+        var connector = new FakeSpotifyApiConnector(pagesByUrl);
+        var sut = CreateSut(DomainTestFixture.UtcDateDaysAgo(3));
+
+        // Act
+        var results = await sut.Paginate(firstPage, connector).ToListAsync();
+
+        // Assert — the end jump plus MaxWalkBackPages backwards fetches, and no further page
+        connector.RequestedUrls.Should().HaveCount(AscendingEpisodePaginator.MaxWalkBackPages + 1);
+        results.Should().HaveCount(AscendingEpisodePaginator.MaxWalkBackPages + 1);
+    }
+
+    [Fact(DisplayName =
+        "When the backwards walk stops on its cap with earlier pages remaining the paginator logs an Error " +
+        "because a quota circuit-breaker trip can hide in-window episodes and must not be silent.")]
+    public async Task Logs_error_when_walk_back_cap_trips()
+    {
+        // Arrange
+        var (firstPage, pagesByUrl) = BuildInWindowAscendingCatalogue();
+        var logger = new CapturingLogger();
+        var sut = CreateSut(DomainTestFixture.UtcDateDaysAgo(3), logger);
+
+        // Act
+        await sut.Paginate(firstPage, new FakeSpotifyApiConnector(pagesByUrl)).ToListAsync();
+
+        // Assert — reported against the walk-back cap, not the forward-crawl cap
+        logger.Errors.Should().ContainSingle(m =>
+            m.StartsWith(SimpleEpisodePaginator.CircuitBreakerTrippedMessagePrefix) &&
+            m.Contains($"pages-fetched='{AscendingEpisodePaginator.MaxWalkBackPages}'") &&
+            m.Contains($"max-pages='{AscendingEpisodePaginator.MaxWalkBackPages}'") &&
+            m.Contains("walk-back='true'"));
+    }
+
+    [Fact(DisplayName =
+        "A backwards walk that reaches the release-window cutoff logs no circuit-breaker Error " +
+        "because leaving the window is the intended stop, not quota protection.")]
+    public async Task Does_not_log_error_when_walk_back_reaches_cutoff()
+    {
+        // Arrange — the page before the newest one falls outside the window
+        var firstHref = PageUrl(0);
+        var finalUrl = PageUrl(PageLimit);
+        var recent = CreateEpisode(daysAgo: 1);
+        var firstPage = new Paging<SimpleEpisode>
+        {
+            Href = firstHref,
+            Items = [CreateEpisode(daysAgo: 3000)],
+            Limit = PageLimit,
+            Offset = 0,
+            Total = PageLimit * 2
+        };
+        var connector = new FakeSpotifyApiConnector(new Dictionary<string, object>
+        {
+            [finalUrl] = new Paging<SimpleEpisode>
+            {
+                Href = finalUrl,
+                Items = [CreateEpisode(daysAgo: 30), recent],
+                Limit = PageLimit,
+                Offset = PageLimit,
+                Total = PageLimit * 2,
+                Previous = firstHref
+            }
+        });
+        var logger = new CapturingLogger();
+        var sut = CreateSut(DomainTestFixture.UtcDateDaysAgo(3), logger);
+
+        // Act
+        var results = await sut.Paginate(firstPage, connector).ToListAsync();
+
+        // Assert
+        results.Select(x => x.Id).Should().Equal(recent.Id);
+        logger.Errors.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName =
+        "When Spotify omits paging totals the ascending paginator hands over to the bounded forward walk " +
+        "because without Total and Limit there is no way to address the final page.")]
+    public async Task Falls_back_to_forward_walk_when_paging_metadata_is_missing()
+    {
+        // Arrange — no Total, so the end jump cannot be computed
+        var nextUrl = PageUrl(PageLimit);
+        var firstEpisode = CreateEpisode(daysAgo: 2);
+        var nextEpisode = CreateEpisode(daysAgo: 1);
+        var firstPage = new Paging<SimpleEpisode>
+        {
+            Href = PageUrl(0),
+            Items = [firstEpisode],
+            Limit = PageLimit,
+            Offset = 0,
+            Next = nextUrl
+        };
+        var connector = new FakeSpotifyApiConnector(new Dictionary<string, object>
+        {
+            [nextUrl] = new Paging<SimpleEpisode> { Items = [nextEpisode], Next = null }
+        });
+        var sut = CreateSut(DomainTestFixture.UtcDateDaysAgo(3));
+
+        // Act
+        var results = await sut.Paginate(firstPage, connector).ToListAsync();
+
+        // Assert — forward walk yields the first page too, and follows Next rather than Previous
+        results.Select(x => x.Id).Should().Equal(firstEpisode.Id, nextEpisode.Id);
+        connector.RequestedUrls.Should().Equal(nextUrl);
+    }
+
+    /// <summary>
+    /// Builds an ascending catalogue whose every page is inside the release window and links back to an
+    /// earlier page, so a backwards walk can only be stopped by the walk-back cap.
+    /// </summary>
+    private (Paging<SimpleEpisode> FirstPage, Dictionary<string, object> PagesByUrl)
+        BuildInWindowAscendingCatalogue()
+    {
+        var pageCount = AscendingEpisodePaginator.MaxWalkBackPages + 3;
+        var total = pageCount * PageLimit;
+        var pagesByUrl = new Dictionary<string, object>();
+        Paging<SimpleEpisode>? firstPage = null;
+
+        for (var pageIndex = 0; pageIndex < pageCount; pageIndex++)
+        {
+            var offset = pageIndex * PageLimit;
+            var page = new Paging<SimpleEpisode>
+            {
+                Href = PageUrl(offset),
+                Items = [CreateEpisode(daysAgo: 1)],
+                Limit = PageLimit,
+                Offset = offset,
+                Total = total,
+                Previous = pageIndex == 0 ? null : PageUrl(offset - PageLimit),
+                Next = pageIndex == pageCount - 1 ? null : PageUrl(offset + PageLimit)
+            };
+
+            if (pageIndex == 0)
+            {
+                firstPage = page;
+            }
+            else
+            {
+                pagesByUrl[PageUrl(offset)] = page;
+            }
+        }
+
+        return (firstPage!, pagesByUrl);
+    }
+
+    private static string PageUrl(int offset) => $"{CataloguePath}?limit={PageLimit}&offset={offset}";
+
+    private static AscendingEpisodePaginator CreateSut(
+        DateTime releasedSince,
+        ILogger<AscendingEpisodePaginator>? logger = null) =>
         new(
             releasedSince,
-            NullLogger<AscendingEpisodePaginator>.Instance,
+            logger ?? NullLogger<AscendingEpisodePaginator>.Instance,
             new SimpleEpisodePaginator(
                 releasedSince,
                 isInReverseOrder: false,
                 NullLogger<SimpleEpisodePaginator>.Instance));
 
-    private SimpleEpisode CreateEpisode(string id, int daysAgo) =>
+    private SimpleEpisode CreateEpisode(int daysAgo) =>
         new()
         {
-            Id = id,
+            Id = _fixture.CreateSpotifyId(),
             Name = _fixture.CreateTitle(),
             ReleaseDate = DomainTestFixture.UtcDateDaysAgo(daysAgo).ToString("yyyy-MM-dd"),
             Type = ItemType.Episode
         };
+
+    private sealed class CapturingLogger : ILogger<AscendingEpisodePaginator>
+    {
+        public List<string> Errors { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Error)
+            {
+                Errors.Add(formatter(state, exception));
+            }
+        }
+    }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/SimpleEpisodePaginatorRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/SimpleEpisodePaginatorRules.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.PodcastServices.Spotify.Paginators;
@@ -142,6 +143,76 @@ public class SimpleEpisodePaginatorRules
     }
 
     [Fact(DisplayName =
+        "When the ascending page cap stops a walk with pages remaining, SimpleEpisodePaginator logs an Error " +
+        "because a quota circuit-breaker trip can hide in-window episodes and must not be silent.")]
+    public async Task Logs_error_when_circuit_breaker_trips()
+    {
+        // Arrange — every page has a next link so the cap, not exhaustion, stops the walk
+        var pagesByUrl = new Dictionary<string, object>();
+        for (var i = 1; i <= SimpleEpisodePaginator.MaxPages + 1; i++)
+        {
+            var url = $"https://api.spotify.com/v1/shows/show/episodes?offset={i}";
+            pagesByUrl[url] = new Paging<SimpleEpisode>
+            {
+                Items = [CreateEpisode($"ep-{i}", daysAgo: i + 1)],
+                Next = $"https://api.spotify.com/v1/shows/show/episodes?offset={i + 1}"
+            };
+        }
+
+        var firstPage = new Paging<SimpleEpisode>
+        {
+            Items = [CreateEpisode("ep-0", daysAgo: 1)],
+            Next = "https://api.spotify.com/v1/shows/show/episodes?offset=1"
+        };
+        var logger = new CapturingLogger();
+        var sut = new SimpleEpisodePaginator(
+            DomainTestFixture.UtcDateDaysAgo(30),
+            isInReverseOrder: false,
+            logger);
+
+        // Act
+        await sut.Paginate(firstPage, new FakeSpotifyApiConnector(pagesByUrl)).ToListAsync();
+
+        // Assert
+        logger.Errors.Should().ContainSingle(m =>
+            m.StartsWith(SimpleEpisodePaginator.CircuitBreakerTrippedMessagePrefix) &&
+            m.Contains($"pages-fetched='{SimpleEpisodePaginator.MaxPages}'") &&
+            m.Contains($"max-pages='{SimpleEpisodePaginator.MaxPages}'"));
+    }
+
+    [Fact(DisplayName =
+        "When an ascending walk ends because the catalogue is exhausted, SimpleEpisodePaginator logs no circuit-breaker Error " +
+        "because reaching the end of the catalogue is not a quota-protection stop.")]
+    public async Task Does_not_log_error_when_catalogue_exhausted_within_cap()
+    {
+        // Arrange — two subsequent pages then no next link
+        var page1Url = "https://api.spotify.com/v1/shows/show/episodes?offset=1";
+        var page2Url = "https://api.spotify.com/v1/shows/show/episodes?offset=2";
+        var firstPage = new Paging<SimpleEpisode>
+        {
+            Items = [CreateEpisode("ep-0", daysAgo: 3)],
+            Next = page1Url
+        };
+        var connector = new FakeSpotifyApiConnector(new Dictionary<string, object>
+        {
+            [page1Url] = new Paging<SimpleEpisode> { Items = [CreateEpisode("ep-1", daysAgo: 2)], Next = page2Url },
+            [page2Url] = new Paging<SimpleEpisode> { Items = [CreateEpisode("ep-2", daysAgo: 1)], Next = null }
+        });
+        var logger = new CapturingLogger();
+        var sut = new SimpleEpisodePaginator(
+            DomainTestFixture.UtcDateDaysAgo(30),
+            isInReverseOrder: false,
+            logger);
+
+        // Act
+        var results = await sut.Paginate(firstPage, connector).ToListAsync();
+
+        // Assert
+        results.Should().HaveCount(3);
+        logger.Errors.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName =
         "When catalogue order is reverse-chronological, SimpleEpisodePaginator does not apply a page cap " +
         "and continues paging while episodes remain within the ReleasedSince window.")]
     public async Task Does_not_hard_cap_subsequent_pages_when_reverse_chronological()
@@ -185,4 +256,26 @@ public class SimpleEpisodePaginatorRules
             ReleaseDate = DomainTestFixture.UtcDateDaysAgo(daysAgo).ToString("yyyy-MM-dd"),
             Type = ItemType.Episode
         };
+
+    private sealed class CapturingLogger : ILogger<SimpleEpisodePaginator>
+    {
+        public List<string> Errors { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Error)
+            {
+                Errors.Add(formatter(state, exception));
+            }
+        }
+    }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/SimpleEpisodePaginatorRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/SimpleEpisodePaginatorRules.cs
@@ -248,6 +248,42 @@ public class SimpleEpisodePaginatorRules
         results.Select(x => x.Id).Should().Equal(ep0.Id, ep1.Id, ep2.Id, ep3.Id);
     }
 
+    [Fact(DisplayName =
+        "When catalogue order is reverse-chronological and a page's last episode falls before ReleasedSince, " +
+        "SimpleEpisodePaginator stops without fetching further pages because the date window — not MaxPages — " +
+        "is the early-stop for newest-first catalogues.")]
+    public async Task Reverse_chronological_stops_when_last_episode_falls_before_released_since()
+    {
+        // Arrange — page 0–1 in window; page 1's last item is out of window; page 2 must not be fetched
+        var page1Url = "https://api.spotify.com/v1/shows/show/episodes?offset=1";
+        var page2Url = "https://api.spotify.com/v1/shows/show/episodes?offset=2";
+        var inWindow = CreateEpisode("in-window", daysAgo: 1);
+        var outOfWindow = CreateEpisode("out-of-window", daysAgo: 10);
+        var shouldNotFetch = CreateEpisode("should-not-fetch", daysAgo: 11);
+        var firstPage = new Paging<SimpleEpisode>
+        {
+            Items = [inWindow],
+            Next = page1Url
+        };
+        var connector = new FakeSpotifyApiConnector(new Dictionary<string, object>
+        {
+            [page1Url] = new Paging<SimpleEpisode> { Items = [outOfWindow], Next = page2Url },
+            [page2Url] = new Paging<SimpleEpisode> { Items = [shouldNotFetch], Next = null }
+        });
+        var sut = new SimpleEpisodePaginator(
+            DomainTestFixture.UtcDateDaysAgo(7),
+            isInReverseOrder: true,
+            NullLogger<SimpleEpisodePaginator>.Instance);
+
+        // Act
+        var results = await sut.Paginate(firstPage, connector).ToListAsync();
+
+        // Assert — out-of-window item is not yielded; page 2 never fetched
+        results.Select(x => x.Id).Should().Equal(inWindow.Id);
+        results.Should().NotContain(x => x.Id == outOfWindow.Id);
+        results.Should().NotContain(x => x.Id == shouldNotFetch.Id);
+    }
+
     private SimpleEpisode CreateEpisode(string id, int daysAgo) =>
         new()
         {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/SpotifyEpisodePaginatorFactoryRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/SpotifyEpisodePaginatorFactoryRules.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedditPodcastPoster.PodcastServices.Spotify.Paginators;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Paginators;
+
+/// <summary>
+/// The factory is the single seam through which SpotifyQueryPaginator selects a date-window walk
+/// strategy, so each method must yield the paginator implementing that strategy.
+/// </summary>
+public class SpotifyEpisodePaginatorFactoryRules
+{
+    private readonly SpotifyEpisodePaginatorFactory _sut =
+        new(
+            NullLogger<SimpleEpisodePaginator>.Instance,
+            NullLogger<AscendingEpisodePaginator>.Instance);
+
+    [Fact(DisplayName =
+        "CreateReverseChronologicalPaginator returns a SimpleEpisodePaginator " +
+        "because newest-first catalogues stop paging via the ReleasedSince early-stop.")]
+    public void Reverse_chronological_creates_simple_episode_paginator()
+    {
+        var paginator = _sut.CreateReverseChronologicalPaginator(DateTime.UtcNow.Date.AddDays(-3));
+
+        paginator.Should().BeOfType<SimpleEpisodePaginator>();
+    }
+
+    [Fact(DisplayName =
+        "CreateAscendingEndJumpPaginator returns an AscendingEpisodePaginator " +
+        "because oldest-first catalogues must jump to the final page and walk backwards.")]
+    public void Ascending_end_jump_creates_ascending_episode_paginator()
+    {
+        var paginator = _sut.CreateAscendingEndJumpPaginator(DateTime.UtcNow.Date.AddDays(-3));
+
+        paginator.Should().BeOfType<AscendingEpisodePaginator>();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/SpotifyQueryPaginatorRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Paginators/SpotifyQueryPaginatorRules.cs
@@ -91,9 +91,9 @@ public class SpotifyQueryPaginatorRules
     }
 
     [Fact(DisplayName =
-        "When ReleasedSince is set and episodes are not reverse-chronological, PaginateEpisodes must not call PaginateAll " +
-        "because a date-scoped lookup must not pull the full catalogue (discovery timeouts).")]
-    public async Task Released_since_skips_paginate_all_even_when_expensive()
+        "When ReleasedSince is set and episodes are ascending, PaginateEpisodes uses the end-jump paginator " +
+        "because recent episodes are at the catalogue end and a date-scoped lookup must not walk from offset zero.")]
+    public async Task Released_since_uses_end_jump_paginator_when_expensive()
     {
         // Arrange â€” older episode before newer breaks reverse-time-order detection
         var older = CreateEpisode("episode-older", daysAgo: 10);
@@ -116,6 +116,7 @@ public class SpotifyQueryPaginatorRules
         // Assert
         wrapper.PaginateInvoked.Should().BeTrue();
         wrapper.PaginateAllInvoked.Should().BeFalse();
+        wrapper.CapturedPaginatorTypes.Should().Contain(typeof(AscendingEpisodePaginator));
         result.ExpensiveQueryFound.Should().BeTrue();
         result.Episodes.Should().OnlyContain(x => x.Id == newer.Id);
     }
@@ -206,11 +207,43 @@ public class SpotifyQueryPaginatorRules
         result.Episodes.Select(x => x.Id).Should().Equal(newer.Id);
     }
 
+    [Fact(DisplayName =
+        "When ReleasedSince is set and only one lead-in episode is available, ExpensiveQueryFound is null " +
+        "because a single release date cannot distinguish ascending from newest-first order.")]
+    public async Task Single_episode_order_probe_is_inconclusive()
+    {
+        // Arrange
+        var only = CreateEpisode("episode-only", daysAgo: 1);
+        var wrapper = new CapturingSpotifyClientWrapper
+        {
+            PaginateResult = new List<SimpleEpisode> { only }
+        };
+        var sut = CreateSut(wrapper);
+        var pagedEpisodes = new Paging<SimpleEpisode>
+        {
+            Items = new List<SimpleEpisode> { only },
+            Next = null
+        };
+
+        // Act
+        var result = await sut.PaginateEpisodes(
+            pagedEpisodes,
+            new IndexingContext(ReleasedSince: DomainTestFixture.UtcDateDaysAgo(3)));
+
+        // Assert
+        result.ExpensiveQueryFound.Should().BeNull();
+        result.Episodes.Select(x => x.Id).Should().Equal(only.Id);
+        wrapper.PaginateAllInvoked.Should().BeFalse();
+    }
+
     private SpotifyQueryPaginator CreateSut(ISpotifyClientWrapper wrapper) =>
         new(
             wrapper,
             NullLogger<SpotifyQueryPaginator>.Instance,
-            NullLogger<SimpleEpisodePaginator>.Instance);
+            new SpotifyEpisodePaginatorFactory(
+                NullLogger<SimpleEpisodePaginator>.Instance,
+                NullLogger<AscendingEpisodePaginator>.Instance),
+            new NullEpisodesLeadInPaginator());
 
     private SimpleEpisode CreateEpisode(string id, int daysAgo) =>
         CreateEpisode(id, DomainTestFixture.UtcDateDaysAgo(daysAgo));
@@ -228,6 +261,7 @@ public class SpotifyQueryPaginatorRules
     {
         public IList<SimpleEpisode>? PaginateResult { get; init; }
         public IList<SimpleEpisode>? PaginateAllResult { get; init; }
+        public List<Type> CapturedPaginatorTypes { get; } = [];
 
         public Task<IList<T>?> Paginate<T>(
             IPaginatable<T> firstPage,
@@ -237,6 +271,11 @@ public class SpotifyQueryPaginatorRules
         {
             PaginateInvoked = true;
             PaginateCallCount++;
+            if (paginator != null)
+            {
+                CapturedPaginatorTypes.Add(paginator.GetType());
+            }
+
             return Task.FromResult(typeof(T) == typeof(SimpleEpisode)
                 ? (IList<T>?)(object)PaginateResult!
                 : null);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Providers/SpotifyPodcastEpisodesProviderRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Providers/SpotifyPodcastEpisodesProviderRules.cs
@@ -167,8 +167,8 @@ public class SpotifyPodcastEpisodesProviderRules
     }
 
     [Fact(DisplayName =
-        "When SkipExpensiveSpotifyQueries is set and the podcast has an expensive Spotify query, name-path GetAllEpisodes skips pagination " +
-        "because indexer secondary passes and guarded submit must not walk high-volume catalogues by podcast name.")]
+        "When SkipExpensiveSpotifyQueries is set with no ReleasedSince window and the podcast has an expensive Spotify query, " +
+        "name-path GetAllEpisodes skips pagination because an unbounded walk of a high-volume catalogue by podcast name burns Spotify quota.")]
     public async Task Name_path_skips_pagination_when_expensive_query_guard_set()
     {
         // Arrange
@@ -201,7 +201,6 @@ public class SpotifyPodcastEpisodesProviderRules
             Released: DomainTestFixture.UtcDateDaysAgo(1),
             HasExpensiveSpotifyEpisodesQuery: true);
         var indexingContext = new IndexingContext(
-            ReleasedSince: DomainTestFixture.UtcDateDaysAgo(2),
             SkipPodcastDiscovery: false,
             SkipExpensiveSpotifyQueries: true);
 
@@ -213,6 +212,64 @@ public class SpotifyPodcastEpisodesProviderRules
         paginator.Verify(
             x => x.PaginateEpisodes(It.IsAny<IPaginatable<SimpleEpisode>?>(), It.IsAny<IndexingContext>()),
             Times.Never);
+    }
+
+    [Fact(DisplayName =
+        "When SkipExpensiveSpotifyQueries is set with a ReleasedSince window, name-path GetAllEpisodes still paginates " +
+        "because ascending catalogues put the newest episodes last and skipping leaves only the oldest page.")]
+    public async Task Name_path_paginates_expensive_query_when_released_since_set()
+    {
+        // Arrange
+        var show = new SimpleShow { Id = _fixture.CreateSpotifyId(), Name = _fixture.CreateTitle() };
+        var oldest = CreateEpisode(_fixture.CreateSpotifyId(), daysAgo: 2000);
+        var recent = CreateEpisode(_fixture.CreateSpotifyId(), daysAgo: 1);
+        var wrapper = new Mock<ISpotifyClientWrapper>();
+        wrapper
+            .Setup(x => x.GetSimpleShows(It.IsAny<SearchRequest>(), It.IsAny<IndexingContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([show]);
+        wrapper
+            .Setup(x => x.GetShowEpisodes(
+                show.Id,
+                It.IsAny<ShowEpisodesRequest>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Paging<SimpleEpisode>
+            {
+                Items = [oldest],
+                Next = "https://api.spotify.com/v1/shows/x/episodes?offset=1"
+            });
+
+        var finder = new Mock<ISpotifySearchResultFinder>();
+        finder
+            .Setup(x => x.FindMatchingPodcasts(It.IsAny<string>(), It.IsAny<List<SimpleShow>?>()))
+            .Returns([show]);
+
+        var paginator = new Mock<ISpotifyQueryPaginator>();
+        paginator
+            .Setup(x => x.PaginateEpisodes(It.IsAny<IPaginatable<SimpleEpisode>?>(), It.IsAny<IndexingContext>()))
+            .ReturnsAsync(new PodcastEpisodesResult([oldest, recent]));
+
+        var sut = CreateSut(wrapper.Object, paginator.Object, finder.Object);
+        var request = new FindSpotifyEpisodeRequest(
+            PodcastSpotifyId: "",
+            PodcastName: show.Name,
+            EpisodeSpotifyId: "",
+            EpisodeTitle: _fixture.CreateTitle(),
+            Released: DomainTestFixture.UtcDateDaysAgo(1),
+            HasExpensiveSpotifyEpisodesQuery: true);
+        var indexingContext = new IndexingContext(
+            ReleasedSince: DomainTestFixture.UtcDateDaysAgo(2),
+            SkipPodcastDiscovery: false,
+            SkipExpensiveSpotifyQueries: true);
+
+        // Act
+        var result = await sut.GetAllEpisodes(request, indexingContext, Market.CountryCode);
+
+        // Assert
+        result.Episodes.Select(x => x.Id).Should().Contain(recent.Id);
+        paginator.Verify(
+            x => x.PaginateEpisodes(It.IsAny<IPaginatable<SimpleEpisode>?>(), It.IsAny<IndexingContext>()),
+            Times.Once);
     }
 
     [Fact(DisplayName =
@@ -258,8 +315,8 @@ public class SpotifyPodcastEpisodesProviderRules
     }
 
     [Fact(DisplayName =
-        "When SkipExpensiveSpotifyQueries is set and the known-id podcast has an expensive Spotify query, GetEpisodes returns only the first page " +
-        "because indexer secondary passes must not PaginateEpisodes over high-volume catalogues.")]
+        "When SkipExpensiveSpotifyQueries is set with no ReleasedSince window and the known-id podcast has an expensive Spotify query, " +
+        "GetEpisodes returns only the first page because an unbounded PaginateEpisodes over a high-volume catalogue burns Spotify quota.")]
     public async Task Known_id_path_returns_first_page_only_when_expensive_query_guard_set()
     {
         // Arrange
@@ -281,7 +338,6 @@ public class SpotifyPodcastEpisodesProviderRules
         var paginator = new Mock<ISpotifyQueryPaginator>();
         var sut = CreateSut(wrapper.Object, paginator.Object, Mock.Of<ISpotifySearchResultFinder>());
         var indexingContext = new IndexingContext(
-            ReleasedSince: DomainTestFixture.UtcDateDaysAgo(2),
             SkipPodcastDiscovery: true,
             SkipExpensiveSpotifyQueries: true);
 
@@ -295,6 +351,56 @@ public class SpotifyPodcastEpisodesProviderRules
         paginator.Verify(
             x => x.PaginateEpisodes(It.IsAny<IPaginatable<SimpleEpisode>?>(), It.IsAny<IndexingContext>()),
             Times.Never);
+    }
+
+    [Fact(DisplayName =
+        "When SkipExpensiveSpotifyQueries is set with a ReleasedSince window, known-id GetEpisodes still paginates " +
+        "because an expensive ascending catalogue returns the oldest episodes first and the in-window row is never on page one.")]
+    public async Task Known_id_path_paginates_expensive_query_when_released_since_set()
+    {
+        // Arrange
+        var showId = _fixture.CreateSpotifyId();
+        var oldest = CreateEpisode(_fixture.CreateSpotifyId(), daysAgo: 2000);
+        var recent = CreateEpisode(_fixture.CreateSpotifyId(), daysAgo: 1);
+        ShowEpisodesRequest? capturedRequest = null;
+        var wrapper = new Mock<ISpotifyClientWrapper>();
+        wrapper
+            .Setup(x => x.GetShowEpisodes(
+                showId,
+                It.IsAny<ShowEpisodesRequest>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, ShowEpisodesRequest, IndexingContext, CancellationToken>((_, request, _, _) =>
+                capturedRequest = request)
+            .ReturnsAsync(new Paging<SimpleEpisode>
+            {
+                Items = [oldest],
+                Next = "https://api.spotify.com/v1/shows/x/episodes?offset=5"
+            });
+
+        var paginator = new Mock<ISpotifyQueryPaginator>();
+        paginator
+            .Setup(x => x.PaginateEpisodes(It.IsAny<IPaginatable<SimpleEpisode>?>(), It.IsAny<IndexingContext>()))
+            .ReturnsAsync(new PodcastEpisodesResult([oldest, recent]));
+
+        var sut = CreateSut(wrapper.Object, paginator.Object, Mock.Of<ISpotifySearchResultFinder>());
+        var indexingContext = new IndexingContext(
+            ReleasedSince: DomainTestFixture.UtcDateDaysAgo(2),
+            SkipPodcastDiscovery: true,
+            SkipExpensiveSpotifyQueries: true);
+
+        // Act
+        var result = await sut.GetEpisodes(
+            new GetEpisodesRequest(new SpotifyPodcastId(showId), Market.CountryCode, HasExpensiveSpotifyEpisodesQuery: true),
+            indexingContext);
+
+        // Assert
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.Limit.Should().Be(50);
+        result.Episodes.Select(x => x.Id).Should().Contain(recent.Id);
+        paginator.Verify(
+            x => x.PaginateEpisodes(It.IsAny<IPaginatable<SimpleEpisode>?>(), It.IsAny<IndexingContext>()),
+            Times.Once);
     }
 
     [Fact(DisplayName =
@@ -321,7 +427,6 @@ public class SpotifyPodcastEpisodesProviderRules
 
         var sut = CreateSut(wrapper.Object, Mock.Of<ISpotifyQueryPaginator>(), Mock.Of<ISpotifySearchResultFinder>());
         var indexingContext = new IndexingContext(
-            ReleasedSince: DomainTestFixture.UtcDateDaysAgo(2),
             SkipPodcastDiscovery: true,
             SkipExpensiveSpotifyQueries: true);
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Resolvers/SpotifyEpisodeResolverRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Resolvers/SpotifyEpisodeResolverRules.cs
@@ -46,7 +46,7 @@ public class SpotifyEpisodeResolverRules
 
         // Assert
         result.FullEpisode.Should().BeNull();
-        result.IsExpensiveQuery.Should().BeFalse();
+        result.IsExpensiveQuery.Should().BeNull();
     }
 
     [Fact(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Resolvers/SpotifyPodcastResolverRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Resolvers/SpotifyPodcastResolverRules.cs
@@ -112,12 +112,11 @@ public class SpotifyPodcastResolverRules
     }
 
     [Fact(DisplayName =
-        "KNOWN: When the episodes provider reports ExpensiveQueryFound during episode-URL verification, FindPodcast still returns ExpensiveQueryFound=false " +
-        "because SpotifyPodcastWrapper's constructor accepts the flag but does not assign the init property.")]
-    public async Task Expensive_query_found_is_not_assigned_on_wrapper()
+        "When the episodes provider reports ExpensiveQueryFound during episode-URL verification, FindPodcast returns ExpensiveQueryFound=true " +
+        "because SpotifyPodcastWrapper now assigns the measured catalogue-order probe.")]
+    public async Task Expensive_query_found_is_assigned_on_wrapper()
     {
         // Arrange
-        // KNOWN: likely bug â€” SpotifyPodcastWrapper(ctor expensiveQueryFound) never sets ExpensiveQueryFound.
         var showName = _fixture.CreateTitle();
         var showId = _fixture.CreateSpotifyId();
         var candidate = new SimpleShow { Id = showId, Name = showName };
@@ -172,7 +171,7 @@ public class SpotifyPodcastResolverRules
         // Assert
         result.Should().NotBeNull();
         result!.Id.Should().Be(showId);
-        result.ExpensiveQueryFound.Should().BeFalse();
+        result.ExpensiveQueryFound.Should().BeTrue();
     }
 
     private static SpotifyPodcastResolver CreateSut(

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/SpotifyEpisodeRetrievalHandlerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/SpotifyEpisodeRetrievalHandlerRules.cs
@@ -42,7 +42,7 @@ public class SpotifyEpisodeRetrievalHandlerRules
 
     [Fact(DisplayName =
         "When the provider reports ExpensiveQueryFound, the handler sets SpotifyEpisodesQueryIsExpensive on the podcast " +
-        "because subsequent indexer passes must skip expensive pagination for that show.")]
+        "because subsequent indexer passes must use the ascending end-jump path for that show.")]
     public async Task Expensive_query_found_sets_podcast_flag()
     {
         // Arrange
@@ -75,6 +75,90 @@ public class SpotifyEpisodeRetrievalHandlerRules
     }
 
     [Fact(DisplayName =
+        "When the provider reports a newest-first catalogue, the handler clears SpotifyEpisodesQueryIsExpensive " +
+        "because Spotify shows are known to flip back from ascending order.")]
+    public async Task Newest_first_probe_clears_podcast_flag()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast(p =>
+        {
+            p.SpotifyId = _fixture.CreateSpotifyId();
+            p.SpotifyEpisodesQueryIsExpensive = true;
+        });
+        var provider = new Mock<ISpotifyEpisodeProvider>();
+        provider
+            .Setup(x => x.GetEpisodes(It.IsAny<GetEpisodesRequest>(), It.IsAny<IndexingContext>()))
+            .ReturnsAsync(new GetEpisodesResponse([], ExpensiveQueryFound: false));
+        var sut = new SpotifyEpisodeRetrievalHandler(
+            provider.Object,
+            NullLogger<SpotifyEpisodeRetrievalHandler>.Instance);
+
+        // Act
+        await sut.GetEpisodes(podcast, new IndexingContext(SkipPodcastDiscovery: true));
+
+        // Assert
+        podcast.SpotifyEpisodesQueryIsExpensive.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "Across successive indexer passes a flipping catalogue flips SpotifyEpisodesQueryIsExpensive each time and the stored flag drives the next request " +
+        "because a show that switches order must switch pagination strategy on the following pass.")]
+    public async Task Expensive_flag_round_trips_across_indexer_passes()
+    {
+        // Arrange — probes: ascending, newest-first, ascending
+        var podcast = _fixture.CreatePodcast(p =>
+        {
+            p.SpotifyId = _fixture.CreateSpotifyId();
+            p.SpotifyEpisodesQueryIsExpensive = false;
+        });
+        var provider = new SequencedSpotifyEpisodeProvider(true, false, true);
+        var sut = new SpotifyEpisodeRetrievalHandler(
+            provider,
+            NullLogger<SpotifyEpisodeRetrievalHandler>.Instance);
+
+        // Act
+        var storedFlags = new List<bool?>();
+        for (var pass = 0; pass < 3; pass++)
+        {
+            await sut.GetEpisodes(podcast, new IndexingContext(SkipPodcastDiscovery: true));
+            storedFlags.Add(podcast.SpotifyEpisodesQueryIsExpensive);
+        }
+
+        // Assert — each pass requests using the flag as it stood before that pass's probe
+        storedFlags.Should().Equal(true, false, true);
+        provider.RequestedExpensiveFlags.Should().Equal(false, true, false);
+    }
+
+    [Fact(DisplayName =
+        "An inconclusive probe between two conclusive probes leaves SpotifyEpisodesQueryIsExpensive intact " +
+        "because a pass that could not measure order must not reset the show's pagination strategy.")]
+    public async Task Inconclusive_pass_preserves_flag_between_flips()
+    {
+        // Arrange — probes: ascending, inconclusive, newest-first
+        var podcast = _fixture.CreatePodcast(p =>
+        {
+            p.SpotifyId = _fixture.CreateSpotifyId();
+            p.SpotifyEpisodesQueryIsExpensive = false;
+        });
+        var provider = new SequencedSpotifyEpisodeProvider(true, null, false);
+        var sut = new SpotifyEpisodeRetrievalHandler(
+            provider,
+            NullLogger<SpotifyEpisodeRetrievalHandler>.Instance);
+
+        // Act
+        var storedFlags = new List<bool?>();
+        for (var pass = 0; pass < 3; pass++)
+        {
+            await sut.GetEpisodes(podcast, new IndexingContext(SkipPodcastDiscovery: true));
+            storedFlags.Add(podcast.SpotifyEpisodesQueryIsExpensive);
+        }
+
+        // Assert
+        storedFlags.Should().Equal(true, true, false);
+        provider.RequestedExpensiveFlags.Should().Equal(false, true, true);
+    }
+
+    [Fact(DisplayName =
         "When SkipSpotifyUrlResolving is set, GetEpisodes still calls the provider but returns Handled=false even if episodes are returned " +
         "because rate-limit recovery must not mark Spotify as fully handled for the indexer pass.")]
     public async Task Skip_spotify_url_resolving_returns_not_handled()
@@ -101,5 +185,25 @@ public class SpotifyEpisodeRetrievalHandlerRules
         provider.Verify(
             x => x.GetEpisodes(It.IsAny<GetEpisodesRequest>(), It.IsAny<IndexingContext>()),
             Times.Once);
+    }
+
+    /// <summary>
+    /// Returns one catalogue-order probe per call and records the expensive-query flag each request
+    /// carried, so a test can observe the flag feeding back into the following pass.
+    /// </summary>
+    private sealed class SequencedSpotifyEpisodeProvider(params bool?[] probes) : ISpotifyEpisodeProvider
+    {
+        private int _call;
+
+        public List<bool> RequestedExpensiveFlags { get; } = [];
+
+        public Task<GetEpisodesResponse> GetEpisodes(
+            GetEpisodesRequest request,
+            IndexingContext indexingContext)
+        {
+            RequestedExpensiveFlags.Add(request.HasExpensiveSpotifyEpisodesQuery);
+            var probe = probes[Math.Min(_call++, probes.Length - 1)];
+            return Task.FromResult(new GetEpisodesResponse([], probe));
+        }
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Support/FakeSpotifyApiConnector.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Support/FakeSpotifyApiConnector.cs
@@ -7,12 +7,15 @@ namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.Support;
 /// </summary>
 internal sealed class FakeSpotifyApiConnector(IReadOnlyDictionary<string, object> pagesByUrl) : IAPIConnector
 {
+    public List<string> RequestedUrls { get; } = [];
+
 #pragma warning disable CS0067 // Required by IAPIConnector; never raised by this fake.
     public event EventHandler<IResponse>? ResponseReceived;
 #pragma warning restore CS0067
 
     Task<T> IAPIConnector.Get<T>(Uri uri, CancellationToken cancel)
     {
+        RequestedUrls.Add(uri.ToString());
         if (pagesByUrl.TryGetValue(uri.ToString(), out var page) && page is T typed)
         {
             return Task.FromResult(typed);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Categorisers/SpotifyUrlCategoriser.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Categorisers/SpotifyUrlCategoriser.cs
@@ -6,6 +6,7 @@ using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Abstractions.Extensions;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
 using RedditPodcastPoster.PodcastServices.Spotify.Factories;
+using RedditPodcastPoster.PodcastServices.Spotify.Logging;
 using RedditPodcastPoster.PodcastServices.Spotify.Models;
 using RedditPodcastPoster.PodcastServices.Spotify.Resolvers;
 using RedditPodcastPoster.Text;
@@ -98,11 +99,10 @@ public class SpotifyUrlCategoriser(
 
         if (!findEpisodeResponse.FullEpisode.IsSpotifyFree())
         {
-            logger.LogWarning(
-                "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
-                findEpisodeResponse.FullEpisode.Id,
-                findEpisodeResponse.FullEpisode.Name,
-                findEpisodeResponse.FullEpisode.GetSpotifyRestrictionReason());
+            SpotifyNonPlayableSkipLogger.Log(
+                logger,
+                findEpisodeResponse.FullEpisode,
+                Market.CountryCode);
             return null;
         }
 
@@ -150,11 +150,10 @@ public class SpotifyUrlCategoriser(
         {
             if (!findEpisodeResponse.FullEpisode.IsSpotifyFree())
             {
-                logger.LogWarning(
-                    "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
-                    findEpisodeResponse.FullEpisode.Id,
-                    findEpisodeResponse.FullEpisode.Name,
-                    findEpisodeResponse.FullEpisode.GetSpotifyRestrictionReason());
+                SpotifyNonPlayableSkipLogger.Log(
+                    logger,
+                    findEpisodeResponse.FullEpisode,
+                    Market.CountryCode);
                 throw new InvalidOperationException(
                     $"Spotify episode '{episodeId}' is not free/playable.");
             }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyEpisodeEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyEpisodeEnricher.cs
@@ -9,6 +9,7 @@ using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Abstractions.Enriching;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
 using RedditPodcastPoster.PodcastServices.Spotify.Factories;
+using RedditPodcastPoster.PodcastServices.Spotify.Logging;
 using RedditPodcastPoster.PodcastServices.Spotify.Mapping;
 using RedditPodcastPoster.PodcastServices.Spotify.Resolvers;
 using RedditPodcastPoster.Text;
@@ -68,11 +69,10 @@ public class SpotifyEpisodeEnricher(
         if (findEpisodeResult.FullEpisode != null &&
             !findEpisodeResult.FullEpisode.IsSpotifyFree())
         {
-            logger.LogWarning(
-                "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
-                findEpisodeResult.FullEpisode.Id,
-                findEpisodeResult.FullEpisode.Name,
-                findEpisodeResult.FullEpisode.GetSpotifyRestrictionReason());
+            SpotifyNonPlayableSkipLogger.Log(
+                logger,
+                findEpisodeResult.FullEpisode,
+                findSpotifyEpisodeRequest.Market ?? Market.CountryCode);
         }
         else if (findEpisodeResult.FullEpisode != null &&
             request.Episodes.All(x => x.SpotifyId != findEpisodeResult.FullEpisode.Id))
@@ -86,6 +86,22 @@ public class SpotifyEpisodeEnricher(
 
             var catalogueInput = findEpisodeResult.FullEpisode.ToCatalogueInput(htmlSanitiser);
             ApplyResolvedCandidate(request, spotifyAdapter.Adapt(catalogueInput), enrichmentContext);
+        }
+        else if (findEpisodeResult.FullEpisode == null)
+        {
+            logger.LogWarning(
+                "Spotify enrich miss: episode-id='{EpisodeId}' title='{Title}' podcast-id='{PodcastId}' podcast-name='{PodcastName}' spotify-show-id='{SpotifyShowId}' expected-release='{ExpectedRelease}' length='{Length}' youtube-discovered='{YouTubeDiscovered}' release-authority='{ReleaseAuthority}' delay='{Delay}' expensive-query='{ExpensiveQuery}'",
+                request.Episode.Id,
+                request.Episode.Title,
+                request.Podcast.Id,
+                request.Podcast.Name,
+                request.Podcast.SpotifyId,
+                findSpotifyEpisodeRequest.Released ?? request.Episode.Release,
+                request.Episode.Length,
+                findSpotifyEpisodeRequest.EnrichingYouTubeDiscoveredEpisode,
+                request.Podcast.ReleaseAuthority,
+                findSpotifyEpisodeRequest.YouTubePublishingDelay,
+                findEpisodeResult.IsExpensiveQuery);
         }
 
         enrichmentSideEffect.OnFindComplete(request.Podcast, findEpisodeResult.IsExpensiveQuery);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyExpensiveQuerySideEffect.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyExpensiveQuerySideEffect.cs
@@ -1,16 +1,20 @@
+using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Models.Podcasts;
-using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Abstractions.Enriching;
+using RedditPodcastPoster.PodcastServices.Spotify.Models;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Enrichers;
 
-public sealed class SpotifyExpensiveQuerySideEffect : ISpotifyEnrichmentSideEffect
+public sealed class SpotifyExpensiveQuerySideEffect(ILogger<SpotifyExpensiveQuerySideEffect> logger)
+    : ISpotifyEnrichmentSideEffect
 {
-    public void OnFindComplete(Podcast podcast, bool isExpensiveQuery)
+    public void OnFindComplete(Podcast podcast, bool? isExpensiveQuery)
     {
-        if (isExpensiveQuery)
-        {
-            podcast.SpotifyEpisodesQueryIsExpensive = true;
-        }
+        // Enrichment always receives a probe that already required a conclusive sample size, or null.
+        SpotifyExpensiveQueryFlag.Apply(
+            podcast,
+            isExpensiveQuery,
+            isExpensiveQuery.HasValue ? SpotifyExpensiveQueryFlag.MinimumOrderSampleSize : 0,
+            logger);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyPodcastEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Enrichers/SpotifyPodcastEnricher.cs
@@ -4,6 +4,8 @@ using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
 using RedditPodcastPoster.PodcastServices.Spotify.Factories;
+using RedditPodcastPoster.PodcastServices.Spotify.Logging;
+using RedditPodcastPoster.PodcastServices.Spotify.Models;
 using RedditPodcastPoster.PodcastServices.Spotify.Resolvers;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
@@ -30,9 +32,13 @@ public class SpotifyPodcastEnricher(
                     podcastShouldUpdate = true;
                 }
 
-                if (matchedPodcast.ExpensiveQueryFound)
+                if (matchedPodcast.ExpensiveQueryFound.HasValue)
                 {
-                    podcast.SpotifyEpisodesQueryIsExpensive = true;
+                    SpotifyExpensiveQueryFlag.Apply(
+                        podcast,
+                        matchedPodcast.ExpensiveQueryFound,
+                        SpotifyExpensiveQueryFlag.MinimumOrderSampleSize,
+                        logger);
                 }
             }
         }
@@ -51,11 +57,10 @@ public class SpotifyPodcastEnricher(
                     if (findEpisodeResponse.FullEpisode != null &&
                         !findEpisodeResponse.FullEpisode.IsSpotifyFree())
                     {
-                        logger.LogWarning(
-                            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
-                            findEpisodeResponse.FullEpisode.Id,
-                            findEpisodeResponse.FullEpisode.Name,
-                            findEpisodeResponse.FullEpisode.GetSpotifyRestrictionReason());
+                        SpotifyNonPlayableSkipLogger.Log(
+                            logger,
+                            findEpisodeResponse.FullEpisode,
+                            Market.CountryCode);
                     }
                     else if (!string.IsNullOrWhiteSpace(findEpisodeResponse.FullEpisode?.Id))
                     {
@@ -63,9 +68,13 @@ public class SpotifyPodcastEnricher(
                         podcastShouldUpdate = true;
                     }
 
-                    if (findEpisodeResponse.IsExpensiveQuery)
+                    if (findEpisodeResponse.IsExpensiveQuery.HasValue)
                     {
-                        podcast.SpotifyEpisodesQueryIsExpensive = true;
+                        SpotifyExpensiveQueryFlag.Apply(
+                            podcast,
+                            findEpisodeResponse.IsExpensiveQuery,
+                            SpotifyExpensiveQueryFlag.MinimumOrderSampleSize,
+                            logger);
                     }
                 }
             }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Extensions/ServiceCollectionExtensions.cs
@@ -46,6 +46,8 @@ public static class ServiceCollectionExtensions
                     (IPodcastPassApiCacheSource)sp.GetRequiredService<ISpotifyPodcastEpisodesProvider>())
                 .AddScoped<ISpotifyPodcastResolver, SpotifyPodcastResolver>()
                 .AddScoped<ISpotifyQueryPaginator, SpotifyQueryPaginator>()
+                .AddScoped<ISpotifyEpisodePaginatorFactory, SpotifyEpisodePaginatorFactory>()
+                .AddSingleton<NullEpisodesLeadInPaginator>()
                 .AddScoped<ISpotifySearchResultFinder, SpotifySearchResultFinder>()
                 .AddScoped<ISpotifySearcher, SpotifySearcher>()
                 .AddScoped<ISpotifyEpisodeRetrievalHandler, SpotifyEpisodeRetrievalHandler>();

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Logging/SpotifyNonPlayableSkipLogger.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Logging/SpotifyNonPlayableSkipLogger.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
+using SpotifyAPI.Web;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Logging;
+
+/// <summary>
+/// Logs when Spotify marks an episode non-playable for the requested market.
+/// Market unavailability is Error (must not be silent); other restrictions stay Warning.
+/// </summary>
+public static class SpotifyNonPlayableSkipLogger
+{
+    /// <summary>
+    /// Spotify <c>restrictions.reason</c> when the item is not available in the requested market.
+    /// </summary>
+    public const string MarketRestrictionReason = "market";
+
+    public const string MarketUnavailableMessagePrefix = "Spotify episode not available in market:";
+
+    public const string NonPlayableMessageTemplate =
+        "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}, market='{Market}').";
+
+    public const string MarketUnavailableMessageTemplate =
+        "Spotify episode not available in market: episode-id='{EpisodeId}' title='{EpisodeName}' market='{Market}' restrictions.reason='{RestrictionReason}'";
+
+    public static bool IsMarketUnavailable(string restrictionReason) =>
+        string.Equals(restrictionReason, MarketRestrictionReason, StringComparison.OrdinalIgnoreCase);
+
+    public static void Log(
+        ILogger logger,
+        SimpleEpisode episode,
+        string? market = null)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(episode);
+        Log(logger, episode.Id, episode.Name, episode.GetSpotifyRestrictionReason(), market);
+    }
+
+    public static void Log(
+        ILogger logger,
+        FullEpisode episode,
+        string? market = null)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(episode);
+        Log(logger, episode.Id, episode.Name, episode.GetSpotifyRestrictionReason(), market);
+    }
+
+    public static void Log(
+        ILogger logger,
+        string episodeId,
+        string episodeName,
+        string restrictionReason,
+        string? market = null)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        var resolvedMarket = string.IsNullOrWhiteSpace(market) ? Market.CountryCode : market;
+
+        if (IsMarketUnavailable(restrictionReason))
+        {
+            logger.LogError(
+                MarketUnavailableMessageTemplate,
+                episodeId,
+                episodeName,
+                resolvedMarket,
+                restrictionReason);
+            return;
+        }
+
+        logger.LogWarning(
+            NonPlayableMessageTemplate,
+            episodeId,
+            episodeName,
+            restrictionReason,
+            resolvedMarket);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/FindEpisodeResponse.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/FindEpisodeResponse.cs
@@ -2,4 +2,4 @@
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Models;
 
-public record FindEpisodeResponse(FullEpisode? FullEpisode, bool IsExpensiveQuery = false);
+public record FindEpisodeResponse(FullEpisode? FullEpisode, bool? IsExpensiveQuery = null);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/GetEpisodesResponse.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/GetEpisodesResponse.cs
@@ -1,6 +1,5 @@
-
 using RedditPodcastPoster.Models.Episodes;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Models;
 
-public record GetEpisodesResponse(IList<Episode>? Results, bool ExpensiveQueryFound=false);
+public record GetEpisodesResponse(IList<Episode>? Results, bool? ExpensiveQueryFound = null);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/PodcastEpisodesResult.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/PodcastEpisodesResult.cs
@@ -4,8 +4,11 @@ namespace RedditPodcastPoster.PodcastServices.Spotify.Models;
 
 public class PodcastEpisodesResult(
     IEnumerable<SimpleEpisode> episodes,
-    bool expensiveQueryFound = false)
+    bool? expensiveQueryFound = null)
 {
     public IEnumerable<SimpleEpisode> Episodes => episodes.Where(x => x?.Type == ItemType.Episode);
-    public bool ExpensiveQueryFound { get; } = expensiveQueryFound;
+    /// <summary>
+    /// Catalogue-order probe: true = oldest-first (expensive), false = newest-first, null = inconclusive.
+    /// </summary>
+    public bool? ExpensiveQueryFound { get; } = expensiveQueryFound;
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/SpotifyExpensiveQueryFlag.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/SpotifyExpensiveQueryFlag.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models.Podcasts;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Models;
+
+/// <summary>
+/// Applies a measured Spotify catalogue-order probe to <see cref="Podcast.SpotifyEpisodesQueryIsExpensive"/>.
+/// Spotify can flip a show between newest-first and oldest-first, so a conclusive probe both sets and clears
+/// the flag — sticky-true alone permanently misclassifies flipped shows.
+/// </summary>
+public static class SpotifyExpensiveQueryFlag
+{
+    /// <summary>
+    /// Minimum distinct lead-in episodes required before treating reverse-chrono vs ascending as conclusive.
+    /// A single episode cannot distinguish catalogue order.
+    /// </summary>
+    public const int MinimumOrderSampleSize = 2;
+
+    public const string FlagFlippedMessagePrefix = "Spotify expensive-query flag flipped:";
+
+    public const string FlagFlippedMessageTemplate =
+        "Spotify expensive-query flag flipped: podcast-id='{PodcastId}' podcast-name='{PodcastName}' spotify-id='{SpotifyId}' previous='{Previous}' measured='{Measured}'";
+
+    /// <summary>
+    /// Writes <paramref name="measuredExpensive"/> onto the podcast when the probe is conclusive.
+    /// Returns true when the stored flag value changed.
+    /// </summary>
+    public static bool Apply(
+        Podcast podcast,
+        bool? measuredExpensive,
+        int orderSampleSize,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(podcast);
+
+        if (!measuredExpensive.HasValue || orderSampleSize < MinimumOrderSampleSize)
+        {
+            return false;
+        }
+
+        var previous = podcast.SpotifyEpisodesQueryIsExpensive;
+        var measured = measuredExpensive.Value;
+        if (previous == measured)
+        {
+            return false;
+        }
+
+        podcast.SpotifyEpisodesQueryIsExpensive = measured;
+        logger?.LogWarning(
+            FlagFlippedMessageTemplate,
+            podcast.Id,
+            podcast.Name,
+            podcast.SpotifyId,
+            previous,
+            measured);
+        return true;
+    }
+
+    /// <summary>
+    /// Convenience overload when the caller only has a conclusive bool (sample already validated).
+    /// </summary>
+    public static bool Apply(
+        Podcast podcast,
+        bool measuredExpensive,
+        ILogger? logger = null) =>
+        Apply(podcast, measuredExpensive, MinimumOrderSampleSize, logger);
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/SpotifyPodcastWrapper.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/SpotifyPodcastWrapper.cs
@@ -5,15 +5,16 @@ namespace RedditPodcastPoster.PodcastServices.Spotify.Models;
 public class SpotifyPodcastWrapper
 {
     public SpotifyPodcastWrapper(FullShow? fullShow = null, SimpleShow? simpleShow = null,
-        bool expensiveQueryFound = false)
+        bool? expensiveQueryFound = null)
     {
         FullShow = fullShow;
         SimpleShow = simpleShow;
+        ExpensiveQueryFound = expensiveQueryFound;
     }
 
     public string Id => FullShow?.Id ?? SimpleShow?.Id ?? string.Empty;
 
     public FullShow? FullShow { get; init; }
     public SimpleShow? SimpleShow { get; init; }
-    public bool ExpensiveQueryFound { get; init; }
+    public bool? ExpensiveQueryFound { get; init; }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/AscendingEpisodePaginator.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/AscendingEpisodePaginator.cs
@@ -1,0 +1,152 @@
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Http;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Paginators;
+
+/// <summary>
+/// Reads an oldest-first Spotify catalogue from its newest end. Spotify paging responses expose
+/// Total and Limit, so a date-scoped lookup can jump directly to the final page and then walk
+/// backwards only while episodes remain inside the release window.
+/// </summary>
+public sealed class AscendingEpisodePaginator(
+    DateTime releasedSince,
+    ILogger<AscendingEpisodePaginator> logger,
+    IPaginator forwardFallbackPaginator) : IPaginator
+{
+    public Task<IList<T>> PaginateAll<T>(
+        IPaginatable<T> firstPage,
+        IAPIConnector connector,
+        CancellationToken cancel = new()) =>
+        throw new NotImplementedException();
+
+    public Task<IList<T>> PaginateAll<T, TNext>(
+        IPaginatable<T, TNext> firstPage,
+        Func<TNext, IPaginatable<T, TNext>> mapper,
+        IAPIConnector connector,
+        CancellationToken cancel = new()) =>
+        throw new NotImplementedException();
+
+    public async IAsyncEnumerable<T> Paginate<T>(
+        IPaginatable<T> firstPage,
+        IAPIConnector connector,
+        [EnumeratorCancellation] CancellationToken cancel = default)
+    {
+        ArgumentNullException.ThrowIfNull(firstPage);
+        ArgumentNullException.ThrowIfNull(connector);
+
+        if (firstPage is not Paging<T> firstPaging ||
+            firstPaging.Items == null ||
+            firstPaging.Total <= 0 ||
+            firstPaging.Limit <= 0)
+        {
+            logger.LogWarning(
+                "Spotify ascending pagination could not jump to catalogue end because paging metadata was unavailable; using bounded forward fallback.");
+
+            await foreach (var item in forwardFallbackPaginator.Paginate(firstPage, connector, cancel))
+            {
+                yield return item;
+            }
+
+            yield break;
+        }
+
+        var total = firstPaging.Total!.Value;
+        var limit = firstPaging.Limit!.Value;
+        var finalOffset = Math.Max(0, ((total - 1) / limit) * limit);
+        var page = firstPaging;
+        var pagesFetched = 0;
+
+        if (firstPaging.Offset != finalOffset)
+        {
+            var finalPageUri = BuildPageUri(firstPaging, finalOffset);
+            page = await connector.Get<Paging<T>>(finalPageUri, cancel).ConfigureAwait(false);
+            pagesFetched++;
+
+            logger.LogInformation(
+                "Spotify ascending pagination jumped to final page: total='{Total}' limit='{Limit}' offset='{Offset}'.",
+                total,
+                limit,
+                finalOffset);
+        }
+
+        while (true)
+        {
+            var crossedCutoff = false;
+            foreach (var item in page.Items ?? [])
+            {
+                if (item is not SimpleEpisode episode)
+                {
+                    continue;
+                }
+
+                if (episode.GetReleaseDate() >= releasedSince)
+                {
+                    yield return item;
+                }
+                else
+                {
+                    crossedCutoff = true;
+                }
+            }
+
+            // In a genuinely ascending catalogue every preceding page is older. Once this page
+            // contains an out-of-window episode, no earlier page can add an in-window result.
+            if (crossedCutoff || page.Previous == null)
+            {
+                yield break;
+            }
+
+            if (pagesFetched >= SimpleEpisodePaginator.MaxPages)
+            {
+                logger.LogError(
+                    SimpleEpisodePaginator.CircuitBreakerTrippedMessageTemplate,
+                    pagesFetched,
+                    SimpleEpisodePaginator.MaxPages,
+                    releasedSince,
+                    page.Previous);
+                yield break;
+            }
+
+            page = await connector.Get<Paging<T>>(
+                    new Uri(NormalizeShowEpisodesPath(page.Previous), UriKind.Absolute),
+                    cancel)
+                .ConfigureAwait(false);
+            pagesFetched++;
+        }
+    }
+
+    public IAsyncEnumerable<T> Paginate<T, TNext>(
+        IPaginatable<T, TNext> firstPage,
+        Func<TNext, IPaginatable<T, TNext>> mapper,
+        IAPIConnector connector,
+        CancellationToken cancel = new()) =>
+        throw new NotImplementedException();
+
+    private static Uri BuildPageUri<T>(Paging<T> page, int offset)
+    {
+        var source = page.Href ?? page.Next ??
+                     throw new InvalidOperationException(
+                         "Spotify paging response did not provide Href or Next for the final-page jump.");
+        source = NormalizeShowEpisodesPath(source);
+
+        var offsetPattern = new Regex(@"([?&])offset=\d+", RegexOptions.IgnoreCase);
+        source = offsetPattern.IsMatch(source)
+            ? offsetPattern.Replace(source, $"$1offset={offset}", 1)
+            : $"{source}{(source.Contains('?') ? '&' : '?')}offset={offset}";
+
+        var limit = page.Limit!.Value;
+        var limitPattern = new Regex(@"([?&])limit=\d+", RegexOptions.IgnoreCase);
+        source = limitPattern.IsMatch(source)
+            ? limitPattern.Replace(source, $"$1limit={limit}", 1)
+            : $"{source}&limit={limit}";
+
+        return new Uri(source, UriKind.Absolute);
+    }
+
+    private static string NormalizeShowEpisodesPath(string url) =>
+        url.Replace("/v1/show/", "/v1/shows/", StringComparison.OrdinalIgnoreCase);
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/AscendingEpisodePaginator.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/AscendingEpisodePaginator.cs
@@ -17,6 +17,18 @@ public sealed class AscendingEpisodePaginator(
     ILogger<AscendingEpisodePaginator> logger,
     IPaginator forwardFallbackPaginator) : IPaginator
 {
+    /// <summary>
+    /// Caps how many pages the backwards walk may fetch after the end jump. The walk starts at the
+    /// newest end of the catalogue and stops as soon as a page falls outside ReleasedSince, so an
+    /// indexing window only needs a handful of pages; a far smaller bound than the forward crawl in
+    /// <see cref="SimpleEpisodePaginator.MaxPages"/>, which must reach recent episodes from offset zero.
+    /// </summary>
+    public const int MaxWalkBackPages = 5;
+
+    public const string WalkBackCircuitBreakerTrippedMessageTemplate =
+        SimpleEpisodePaginator.CircuitBreakerTrippedMessagePrefix +
+        " pages-fetched='{PagesFetched}' max-pages='{MaxPages}' released-since='{ReleasedSince}' previous='{Previous}' walk-back='true'. Stopped to protect Spotify quota; in-window episodes may be missing.";
+
     public Task<IList<T>> PaginateAll<T>(
         IPaginatable<T> firstPage,
         IAPIConnector connector,
@@ -40,6 +52,8 @@ public sealed class AscendingEpisodePaginator(
 
         if (firstPage is not Paging<T> firstPaging ||
             firstPaging.Items == null ||
+            !firstPaging.Total.HasValue ||
+            !firstPaging.Limit.HasValue ||
             firstPaging.Total <= 0 ||
             firstPaging.Limit <= 0)
         {
@@ -58,13 +72,12 @@ public sealed class AscendingEpisodePaginator(
         var limit = firstPaging.Limit!.Value;
         var finalOffset = Math.Max(0, ((total - 1) / limit) * limit);
         var page = firstPaging;
-        var pagesFetched = 0;
+        var walkBackPages = 0;
 
         if (firstPaging.Offset != finalOffset)
         {
             var finalPageUri = BuildPageUri(firstPaging, finalOffset);
             page = await connector.Get<Paging<T>>(finalPageUri, cancel).ConfigureAwait(false);
-            pagesFetched++;
 
             logger.LogInformation(
                 "Spotify ascending pagination jumped to final page: total='{Total}' limit='{Limit}' offset='{Offset}'.",
@@ -100,12 +113,12 @@ public sealed class AscendingEpisodePaginator(
                 yield break;
             }
 
-            if (pagesFetched >= SimpleEpisodePaginator.MaxPages)
+            if (walkBackPages >= MaxWalkBackPages)
             {
                 logger.LogError(
-                    SimpleEpisodePaginator.CircuitBreakerTrippedMessageTemplate,
-                    pagesFetched,
-                    SimpleEpisodePaginator.MaxPages,
+                    WalkBackCircuitBreakerTrippedMessageTemplate,
+                    walkBackPages,
+                    MaxWalkBackPages,
                     releasedSince,
                     page.Previous);
                 yield break;
@@ -115,7 +128,7 @@ public sealed class AscendingEpisodePaginator(
                     new Uri(NormalizeShowEpisodesPath(page.Previous), UriKind.Absolute),
                     cancel)
                 .ConfigureAwait(false);
-            pagesFetched++;
+            walkBackPages++;
         }
     }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/ISpotifyEpisodePaginatorFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/ISpotifyEpisodePaginatorFactory.cs
@@ -1,0 +1,21 @@
+using SpotifyAPI.Web;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Paginators;
+
+/// <summary>
+/// Creates the date-window paginators used by <see cref="SpotifyQueryPaginator"/>, so the walk
+/// strategy (newest-first growth vs ascending end-jump) is chosen through one seam.
+/// </summary>
+public interface ISpotifyEpisodePaginatorFactory
+{
+    /// <summary>
+    /// Newest-first catalogue walk that stops once releases fall before <paramref name="releasedSince"/>.
+    /// </summary>
+    IPaginator CreateReverseChronologicalPaginator(DateTime? releasedSince);
+
+    /// <summary>
+    /// Oldest-first (expensive) catalogue walk that jumps to the final Spotify page and pages
+    /// backwards through the <paramref name="releasedSince"/> window.
+    /// </summary>
+    IPaginator CreateAscendingEndJumpPaginator(DateTime releasedSince);
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/NullEpisodesLeadInPaginator.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/NullEpisodesLeadInPaginator.cs
@@ -4,11 +4,24 @@ using SpotifyAPI.Web.Http;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Paginators;
 
+/// <summary>
+/// Lead-in paginator that yields a small sample of episodes (skipping null slots) so
+/// <see cref="SpotifyQueryPaginator"/> can probe catalogue order. Constants are fixed; register as a
+/// DI singleton — construction is not expensive, but there is no per-request state to parameterize.
+/// </summary>
 public class NullEpisodesLeadInPaginator(
     int maxConsecutiveNullEpisodes,
     int limit
 ) : IPaginator
 {
+    public const int DefaultMaxConsecutiveNullEpisodes = 40;
+    public const int DefaultLimit = 3;
+
+    public NullEpisodesLeadInPaginator()
+        : this(DefaultMaxConsecutiveNullEpisodes, DefaultLimit)
+    {
+    }
+
     public Task<IList<T>> PaginateAll<T>(IPaginatable<T> firstPage, IAPIConnector connector,
         CancellationToken cancel = new())
     {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/SimpleEpisodePaginator.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/SimpleEpisodePaginator.cs
@@ -12,9 +12,12 @@ public class SimpleEpisodePaginator(
     ILogger<SimpleEpisodePaginator> logger) : IPaginator
 {
     /// <summary>
-    /// Circuit breaker for unordered (expensive) date-scoped catalogue walks: caps subsequent page
-    /// fetches so an ascending high-volume catalogue cannot burn the Spotify quota. Tripping it is
+    /// Circuit breaker for forward (offset-zero upwards) date-scoped catalogue walks: caps subsequent
+    /// page fetches so an ascending high-volume catalogue cannot burn the Spotify quota. Tripping it is
     /// logged at Error via <see cref="CircuitBreakerTrippedMessagePrefix"/> because episodes may be missed.
+    /// This bound stays generous because a forward crawl starts at the oldest episode and must travel the
+    /// whole catalogue to reach recent ones; the ascending end-jump path walks backwards from the newest
+    /// page instead and uses the much smaller <see cref="AscendingEpisodePaginator.MaxWalkBackPages"/>.
     /// Reverse-chronological walks have no page cap and stop via ReleasedSince instead.
     /// </summary>
     public const int MaxPages = 20;
@@ -22,7 +25,8 @@ public class SimpleEpisodePaginator(
     public const string CircuitBreakerTrippedMessagePrefix = "Spotify pagination circuit-breaker tripped:";
 
     public const string CircuitBreakerTrippedMessageTemplate =
-        "Spotify pagination circuit-breaker tripped: pages-fetched='{PagesFetched}' max-pages='{MaxPages}' released-since='{ReleasedSince}' next='{Next}' reverse-chronological='false'. Stopped to protect Spotify quota; in-window episodes may be missing.";
+        CircuitBreakerTrippedMessagePrefix +
+        " pages-fetched='{PagesFetched}' max-pages='{MaxPages}' released-since='{ReleasedSince}' next='{Next}' reverse-chronological='false'. Stopped to protect Spotify quota; in-window episodes may be missing.";
 
     public Task<IList<T>> PaginateAll<T>(IPaginatable<T> firstPage, IAPIConnector connector,
         CancellationToken cancel = new())

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/SimpleEpisodePaginator.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/SimpleEpisodePaginator.cs
@@ -12,10 +12,17 @@ public class SimpleEpisodePaginator(
     ILogger<SimpleEpisodePaginator> logger) : IPaginator
 {
     /// <summary>
-    /// Cap subsequent page fetches for unordered (expensive) date-scoped catalogue walks.
+    /// Circuit breaker for unordered (expensive) date-scoped catalogue walks: caps subsequent page
+    /// fetches so an ascending high-volume catalogue cannot burn the Spotify quota. Tripping it is
+    /// logged at Error via <see cref="CircuitBreakerTrippedMessagePrefix"/> because episodes may be missed.
     /// Reverse-chronological walks have no page cap and stop via ReleasedSince instead.
     /// </summary>
     public const int MaxPages = 20;
+
+    public const string CircuitBreakerTrippedMessagePrefix = "Spotify pagination circuit-breaker tripped:";
+
+    public const string CircuitBreakerTrippedMessageTemplate =
+        "Spotify pagination circuit-breaker tripped: pages-fetched='{PagesFetched}' max-pages='{MaxPages}' released-since='{ReleasedSince}' next='{Next}' reverse-chronological='false'. Stopped to protect Spotify quota; in-window episodes may be missing.";
 
     public Task<IList<T>> PaginateAll<T>(IPaginatable<T> firstPage, IAPIConnector connector,
         CancellationToken cancel = new())
@@ -104,6 +111,16 @@ public class SimpleEpisodePaginator(
                     lastItem = episode;
                 }
             }
+        }
+
+        if (!isInReverseOrder && pagesFetched >= MaxPages && page.Next != null)
+        {
+            logger.LogError(
+                CircuitBreakerTrippedMessageTemplate,
+                pagesFetched,
+                MaxPages,
+                releasedSince,
+                page.Next);
         }
     }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/SpotifyEpisodePaginatorFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/SpotifyEpisodePaginatorFactory.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Logging;
+using SpotifyAPI.Web;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Paginators;
+
+public class SpotifyEpisodePaginatorFactory(
+    ILogger<SimpleEpisodePaginator> simpleEpisodePaginatorLogger,
+    ILogger<AscendingEpisodePaginator> ascendingEpisodePaginatorLogger) : ISpotifyEpisodePaginatorFactory
+{
+    public IPaginator CreateReverseChronologicalPaginator(DateTime? releasedSince) =>
+        new SimpleEpisodePaginator(releasedSince, isInReverseOrder: true, simpleEpisodePaginatorLogger);
+
+    public IPaginator CreateAscendingEndJumpPaginator(DateTime releasedSince) =>
+        new AscendingEpisodePaginator(
+            releasedSince,
+            ascendingEpisodePaginatorLogger,
+            new SimpleEpisodePaginator(releasedSince, isInReverseOrder: false, simpleEpisodePaginatorLogger));
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/SpotifyQueryPaginator.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Paginators/SpotifyQueryPaginator.cs
@@ -11,7 +11,8 @@ namespace RedditPodcastPoster.PodcastServices.Spotify.Paginators;
 public class SpotifyQueryPaginator(
     ISpotifyClientWrapper spotifyClientWrapper,
     ILogger<SpotifyQueryPaginator> logger,
-    ILogger<SimpleEpisodePaginator> simpleEpisodePaginatorLogger
+    ISpotifyEpisodePaginatorFactory paginatorFactory,
+    NullEpisodesLeadInPaginator nullEpisodesLeadInPaginator
 )
     : ISpotifyQueryPaginator
 {
@@ -44,16 +45,18 @@ public class SpotifyQueryPaginator(
         var existingPagedEpisodes = await spotifyClientWrapper.Paginate(
             pagedEpisodes,
             indexingContext,
-            new NullEpisodesLeadInPaginator(40, 3));
+            nullEpisodesLeadInPaginator);
 
         if (existingPagedEpisodes != null)
         {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            var orderSample = existingPagedEpisodes.Where(x => x != null).ToList();
             var currentMoment = DateTime.Now.AddDays(2);
             var isInReverseTimeOrder = true;
             var ctr = 0;
-            while (isInReverseTimeOrder && ctr < existingPagedEpisodes.Count)
+            while (isInReverseTimeOrder && ctr < orderSample.Count)
             {
-                var releaseDate = existingPagedEpisodes[ctr].GetReleaseDate();
+                var releaseDate = orderSample[ctr].GetReleaseDate();
                 isInReverseTimeOrder = currentMoment >= releaseDate;
                 if (isInReverseTimeOrder)
                 {
@@ -63,10 +66,15 @@ public class SpotifyQueryPaginator(
                 ctr++;
             }
 
-            var isExpensiveQueryFound = !isInReverseTimeOrder;
+            // A single episode cannot distinguish ascending vs reverse-chrono; leave the probe
+            // inconclusive so callers do not clear a previously measured expensive flag.
+            bool? isExpensiveQueryFound = orderSample.Count >= SpotifyExpensiveQueryFlag.MinimumOrderSampleSize
+                ? !isInReverseTimeOrder
+                : null;
 
-            logger.LogInformation("Running '{nameofPaginateEpisodes}'. isExpensiveQueryFound: {isExpensiveQueryFound}.",
-                nameof(PaginateEpisodes), isExpensiveQueryFound);
+            logger.LogInformation(
+                "Running '{nameofPaginateEpisodes}'. isExpensiveQueryFound: {isExpensiveQueryFound}. order-sample-size: {OrderSampleSize}.",
+                nameof(PaginateEpisodes), isExpensiveQueryFound, orderSample.Count);
 
             var episodes = existingPagedEpisodes;
 
@@ -87,28 +95,45 @@ public class SpotifyQueryPaginator(
             }
             else if (episodes.Any())
             {
-                var seenGrowth = true;
-                while (
-                    seenGrowth &&
-                    // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-                    episodes.Where(x => x != null).OrderByDescending(x => x.ReleaseDate).Last().GetReleaseDate() >=
-                    releasedSince
-                )
+                if (isInReverseTimeOrder)
                 {
-                    var preCount = episodes.Count;
+                    // Newest-first: keep paging while the oldest seen release is still in-window.
+                    var seenGrowth = true;
+                    while (
+                        seenGrowth &&
+                        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+                        episodes.Where(x => x != null).OrderByDescending(x => x.ReleaseDate).Last()
+                            .GetReleaseDate() >= releasedSince
+                    )
+                    {
+                        var preCount = episodes.Count;
+                        var items = await spotifyClientWrapper.Paginate(
+                            pagedEpisodes,
+                            indexingContext,
+                            paginatorFactory.CreateReverseChronologicalPaginator(releasedSince));
+                        if (items != null)
+                        {
+                            episodes = items.ToList();
+                            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                            seenGrowth = items != null && episodes.Count > preCount;
+                        }
+                    }
+                }
+                else
+                {
+                    // Oldest-first (expensive): use Spotify's Total/Limit metadata to jump directly
+                    // to the newest page, then walk backwards only through the ReleasedSince window.
+                    logger.LogInformation(
+                        "Running '{nameofPaginateEpisodes}'. Ascending catalogue with ReleasedSince; jumping to the final Spotify page and walking backwards.",
+                        nameof(PaginateEpisodes));
+
                     var items = await spotifyClientWrapper.Paginate(
                         pagedEpisodes,
                         indexingContext,
-                        new SimpleEpisodePaginator(
-                            releasedSince,
-                            isInReverseTimeOrder,
-                            simpleEpisodePaginatorLogger)
-                    );
+                        paginatorFactory.CreateAscendingEndJumpPaginator(releasedSince.Value));
                     if (items != null)
                     {
                         episodes = items.ToList();
-                        // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                        seenGrowth = items != null && episodes.Count > preCount;
                     }
                 }
             }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyEpisodeProvider.cs
@@ -5,6 +5,7 @@ using RedditPodcastPoster.Episodes.Factories;
 using RedditPodcastPoster.Models.Episodes;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
+using RedditPodcastPoster.PodcastServices.Spotify.Logging;
 using RedditPodcastPoster.PodcastServices.Spotify.Mapping;
 using RedditPodcastPoster.PodcastServices.Spotify.Models;
 using RedditPodcastPoster.Text;
@@ -33,25 +34,22 @@ public class SpotifyEpisodeProvider(
             episodes = episodes.Where(x => x.GetReleaseDate() >= indexingContext.ReleasedSince.Value);
         }
 
-        episodes = episodes.Where(IsFreeSpotifyEpisode).ToList();
+        var market = request.Market ?? Market.CountryCode;
+        episodes = episodes.Where(x => IsFreeSpotifyEpisode(x, market)).ToList();
 
         return new GetEpisodesResponse(
             episodes.Select(MapEpisode).ToList(),
             expensiveQueryFound);
     }
 
-    private bool IsFreeSpotifyEpisode(SpotifyAPI.Web.SimpleEpisode episode)
+    private bool IsFreeSpotifyEpisode(SpotifyAPI.Web.SimpleEpisode episode, string market)
     {
         if (episode.IsSpotifyFree())
         {
             return true;
         }
 
-        logger.LogWarning(
-            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
-            episode.Id,
-            episode.Name,
-            episode.GetSpotifyRestrictionReason());
+        SpotifyNonPlayableSkipLogger.Log(logger, episode, market);
         return false;
     }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyPodcastEpisodesProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyPodcastEpisodesProvider.cs
@@ -4,6 +4,7 @@ using RedditPodcastPoster.PodcastServices.Abstractions.Caches;
 using RedditPodcastPoster.PodcastServices.Spotify.Client;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
 using RedditPodcastPoster.PodcastServices.Spotify.Finders;
+using RedditPodcastPoster.PodcastServices.Spotify.Logging;
 using RedditPodcastPoster.PodcastServices.Spotify.Models;
 using RedditPodcastPoster.PodcastServices.Spotify.Paginators;
 using SpotifyAPI.Web;
@@ -29,7 +30,7 @@ public class SpotifyPodcastEpisodesProvider(
         FindSpotifyEpisodeRequest request,
         IndexingContext indexingContext, string market)
     {
-        var expensiveQueryFound = false;
+        var expensiveQueryFound = (bool?)null;
         EpisodeFetchResults[]? episodes = null;
         if (!string.IsNullOrWhiteSpace(request.PodcastSpotifyId))
         {
@@ -68,7 +69,12 @@ public class SpotifyPodcastEpisodesProvider(
             {
                 if (paging.Episodes != null)
                 {
-                    if (indexingContext.SkipExpensiveSpotifyQueries && request.HasExpensiveSpotifyEpisodesQuery)
+                    var skipUnboundedPagination =
+                        indexingContext.SkipExpensiveSpotifyQueries &&
+                        request.HasExpensiveSpotifyEpisodesQuery &&
+                        !indexingContext.ReleasedSince.HasValue;
+
+                    if (skipUnboundedPagination)
                     {
                         logger.LogInformation(
                             "{nameofGetAllEpisodes} - Skipping pagination of query results as {nameofSkipExpensiveSpotifyQueries} is set.",
@@ -76,14 +82,22 @@ public class SpotifyPodcastEpisodesProvider(
                     }
                     else
                     {
+                        if (indexingContext.SkipExpensiveSpotifyQueries &&
+                            request.HasExpensiveSpotifyEpisodesQuery &&
+                            indexingContext.ReleasedSince.HasValue)
+                        {
+                            logger.LogInformation(
+                                "{nameofGetAllEpisodes} - Expensive Spotify query flagged with ReleasedSince; running bounded date-scoped pagination.",
+                                nameof(GetAllEpisodes));
+                        }
+
                         var paginateEpisodeResponse =
                             await spotifyQueryPaginator.PaginateEpisodes(paging.Episodes, indexingContext);
                         var result = paginateEpisodeResponse.Episodes.GroupBy(x => x.Id).Select(x => x.First());
                         allEpisodes.Add(result.ToList());
-                        if (paginateEpisodeResponse.ExpensiveQueryFound)
-                        {
-                            expensiveQueryFound = true;
-                        }
+                        expensiveQueryFound = MergeExpensiveQueryFound(
+                            expensiveQueryFound,
+                            paginateEpisodeResponse.ExpensiveQueryFound);
                     }
                 }
                 else
@@ -103,7 +117,8 @@ public class SpotifyPodcastEpisodesProvider(
                             .Where(x => x != null && x.Any())
                             .SelectMany(x => x)
                             .GroupBy(x => x.Id)
-                            .Select(x => x.First())),
+                            .Select(x => x.First()),
+                        market),
                     expensiveQueryFound);
             }
         }
@@ -134,30 +149,46 @@ public class SpotifyPodcastEpisodesProvider(
 
         if (indexingContext.ReleasedSince.HasValue)
         {
-            showEpisodesRequest.Limit = 5;
+            // Expensive catalogues are oldest-first. Their first response supplies Total/Limit for
+            // AscendingEpisodePaginator's end jump, so use Spotify's maximum page size to minimise
+            // any backward walk through the ReleasedSince window.
+            showEpisodesRequest.Limit = request.HasExpensiveSpotifyEpisodesQuery ? 50 : 5;
         }
 
         var pagedEpisodes =
             await spotifyClientWrapper.GetShowEpisodes(request.SpotifyPodcastId.PodcastId, showEpisodesRequest,
                 indexingContext);
 
-        if (indexingContext.SkipExpensiveSpotifyQueries && request.HasExpensiveSpotifyEpisodesQuery)
+        if (indexingContext.SkipExpensiveSpotifyQueries &&
+            request.HasExpensiveSpotifyEpisodesQuery &&
+            !indexingContext.ReleasedSince.HasValue)
         {
             logger.LogInformation(
                 "{nameofGetEpisodes} - Skipping pagination of query results as {nameofSkipExpensiveSpotifyQueries} is set.",
                 nameof(GetEpisodes), nameof(indexingContext.SkipExpensiveSpotifyQueries));
-            return new PodcastEpisodesResult(TakeFreeEpisodes(pagedEpisodes?.Items ?? []));
+            return new PodcastEpisodesResult(TakeFreeEpisodes(pagedEpisodes?.Items ?? [], market));
+        }
+
+        if (indexingContext.SkipExpensiveSpotifyQueries &&
+            request.HasExpensiveSpotifyEpisodesQuery &&
+            indexingContext.ReleasedSince.HasValue)
+        {
+            // Ascending catalogues return oldest first; skipping leaves only that page and misses
+            // recent episodes. Date-scoped pagination is bounded (SimpleEpisodePaginator.MaxPages).
+            logger.LogInformation(
+                "{nameofGetEpisodes} - Expensive Spotify query flagged with ReleasedSince; running bounded date-scoped pagination.",
+                nameof(GetEpisodes));
         }
 
         var results = await spotifyQueryPaginator.PaginateEpisodes(pagedEpisodes, indexingContext);
         var freeResults = new PodcastEpisodesResult(
-            TakeFreeEpisodes(results.Episodes),
+            TakeFreeEpisodes(results.Episodes, market),
             results.ExpensiveQueryFound);
         _cache[request.SpotifyPodcastId.PodcastId] = freeResults;
         return freeResults;
     }
 
-    private List<SimpleEpisode> TakeFreeEpisodes(IEnumerable<SimpleEpisode> episodes)
+    private List<SimpleEpisode> TakeFreeEpisodes(IEnumerable<SimpleEpisode> episodes, string market)
     {
         var free = new List<SimpleEpisode>();
         foreach (var episode in episodes)
@@ -170,11 +201,7 @@ public class SpotifyPodcastEpisodesProvider(
 
             if (!episode.IsSpotifyFree())
             {
-                logger.LogWarning(
-                    "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
-                    episode.Id,
-                    episode.Name,
-                    episode.GetSpotifyRestrictionReason());
+                SpotifyNonPlayableSkipLogger.Log(logger, episode, market);
                 continue;
             }
 
@@ -183,4 +210,12 @@ public class SpotifyPodcastEpisodesProvider(
 
         return free;
     }
+
+    private static bool? MergeExpensiveQueryFound(bool? accumulated, bool? next) =>
+        (accumulated, next) switch
+        {
+            (true, _) or (_, true) => true,
+            (false, _) or (_, false) => false,
+            _ => null
+        };
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
@@ -4,6 +4,7 @@ using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Spotify.Client;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
 using RedditPodcastPoster.PodcastServices.Spotify.Finders;
+using RedditPodcastPoster.PodcastServices.Spotify.Logging;
 using RedditPodcastPoster.PodcastServices.Spotify.Models;
 using RedditPodcastPoster.PodcastServices.Spotify.Providers;
 using SpotifyAPI.Web;
@@ -40,7 +41,7 @@ public class SpotifyEpisodeResolver(
             fullEpisode = await spotifyClientWrapper.GetFullEpisode(request.EpisodeSpotifyId, episodeRequest, indexingContext);
             if (fullEpisode != null)
             {
-                return new FindEpisodeResponse(TakeIfFree(fullEpisode));
+                return new FindEpisodeResponse(TakeIfFree(fullEpisode, market));
             }
         }
 
@@ -72,21 +73,17 @@ public class SpotifyEpisodeResolver(
             fullEpisode = await spotifyClientWrapper.GetFullEpisode(matchingEpisode.Id, showRequest, indexingContext);
         }
 
-        return new FindEpisodeResponse(TakeIfFree(fullEpisode), podcastEpisodes.ExpensiveQueryFound);
+        return new FindEpisodeResponse(TakeIfFree(fullEpisode, market), podcastEpisodes.ExpensiveQueryFound);
     }
 
-    private FullEpisode? TakeIfFree(FullEpisode? episode)
+    private FullEpisode? TakeIfFree(FullEpisode? episode, string market)
     {
         if (episode == null || episode.IsSpotifyFree())
         {
             return episode;
         }
 
-        logger.LogWarning(
-            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
-            episode.Id,
-            episode.Name,
-            episode.GetSpotifyRestrictionReason());
+        SpotifyNonPlayableSkipLogger.Log(logger, episode, market);
         return null;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyPodcastResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyPodcastResolver.cs
@@ -31,7 +31,7 @@ public class SpotifyPodcastResolver(
 
         SimpleShow? matchingSimpleShow = null;
         FullShow? matchingFullShow = null;
-        var expensiveSpotifyEpisodesQueryFound = false;
+        var expensiveSpotifyEpisodesQueryFound = (bool?)null;
         if (!string.IsNullOrWhiteSpace(request.PodcastId))
         {
             var showRequest = new ShowRequest {Market = Market.CountryCode};
@@ -59,10 +59,13 @@ public class SpotifyPodcastResolver(
                             new GetEpisodesRequest(new SpotifyPodcastId(candidatePodcast.Id),
                                 showEpisodesRequest.Market), indexingContext);
 
-                        if (podcastEpisodes.ExpensiveQueryFound)
-                        {
-                            expensiveSpotifyEpisodesQueryFound = true;
-                        }
+                        expensiveSpotifyEpisodesQueryFound =
+                            (expensiveSpotifyEpisodesQueryFound, podcastEpisodes.ExpensiveQueryFound) switch
+                            {
+                                (true, _) or (_, true) => true,
+                                (false, _) or (_, false) => false,
+                                _ => null
+                            };
 
                         if (podcastEpisodes.Episodes.Any())
                         {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Search/SpotifySearcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Search/SpotifySearcher.cs
@@ -5,6 +5,7 @@ using RedditPodcastPoster.Models.Discovery;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Spotify.Client;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
+using RedditPodcastPoster.PodcastServices.Spotify.Logging;
 using RedditPodcastPoster.Text;
 using SpotifyAPI.Web;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
@@ -52,11 +53,7 @@ public class SpotifySearcher(
 
                 if (!hit.IsSpotifyFree())
                 {
-                    logger.LogWarning(
-                        "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
-                        hit.Id,
-                        hit.Name,
-                        hit.GetSpotifyRestrictionReason());
+                    SpotifyNonPlayableSkipLogger.Log(logger, hit, Market.CountryCode);
                     continue;
                 }
 
@@ -99,11 +96,7 @@ public class SpotifySearcher(
             return true;
         }
 
-        logger.LogWarning(
-            "Skipping Spotify episode '{EpisodeId}' ('{EpisodeName}') because it is not free/playable (IsPlayable=false, restrictions.reason={RestrictionReason}).",
-            episode.Id,
-            episode.Name,
-            episode.GetSpotifyRestrictionReason());
+        SpotifyNonPlayableSkipLogger.Log(logger, episode, Market.CountryCode);
         return false;
     }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/SpotifyEpisodeRetrievalHandler.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/SpotifyEpisodeRetrievalHandler.cs
@@ -11,9 +11,7 @@ namespace RedditPodcastPoster.PodcastServices.Spotify;
 
 public class SpotifyEpisodeRetrievalHandler(
     ISpotifyEpisodeProvider spotifyEpisodeProvider,
-#pragma warning disable CS9113 // Parameter is unread.
     ILogger<SpotifyEpisodeRetrievalHandler> logger
-#pragma warning restore CS9113 // Parameter is unread.
 ) : ISpotifyEpisodeRetrievalHandler
 {
     public async Task<EpisodeRetrievalHandlerResponse> GetEpisodes(Podcast podcast, IndexingContext indexingContext)
@@ -32,9 +30,13 @@ public class SpotifyEpisodeRetrievalHandler(
                 newEpisodes = getEpisodesResult.Results;
             }
 
-            if (getEpisodesResult.ExpensiveQueryFound)
+            if (getEpisodesResult.ExpensiveQueryFound.HasValue)
             {
-                podcast.SpotifyEpisodesQueryIsExpensive = true;
+                SpotifyExpensiveQueryFlag.Apply(
+                    podcast,
+                    getEpisodesResult.ExpensiveQueryFound,
+                    SpotifyExpensiveQueryFlag.MinimumOrderSampleSize,
+                    logger);
             }
 
             if (!indexingContext.SkipSpotifyUrlResolving)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/EpisodeProviderRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/EpisodeProviderRules.cs
@@ -10,17 +10,17 @@ using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 namespace RedditPodcastPoster.PodcastServices.Tests.BusinessRules.Indexing;
 
 /// <summary>
-/// Characterizes <see cref="Common.Episodes.EpisodeProvider"/> indexing discovery orchestration,
-/// including YouTube release authority catalogue merge passes for cross-platform matching.
+/// Characterizes <see cref="Common.Episodes.EpisodeProvider"/> indexing discovery orchestration.
+/// YouTube release authority must discover via YouTube only — Spotify/Apple catalogue is enrichment, not seed.
 /// </summary>
 public class EpisodeProviderRules
 {
     private readonly DomainTestFixture _fixture = new();
 
     [Fact(DisplayName =
-        "For YouTube release authority podcasts with negative publishing delay and a configured Apple id, " +
-        "indexing discovery must merge Apple catalogue episodes into the discovered set for cross-platform matching.")]
-    public async Task youtube_release_authority_negative_delay_merges_apple_catalogue_episodes()
+        "For YouTube release authority podcasts with negative publishing delay, indexing discovery must not " +
+        "merge Apple catalogue episodes as new creates — YouTube alone seeds; Apple attaches via enrichment.")]
+    public async Task youtube_release_authority_negative_delay_does_not_merge_apple_catalogue_episodes()
     {
         // Arrange
         var harness = new EpisodeProviderTestHarness();
@@ -44,73 +44,64 @@ public class EpisodeProviderRules
         var discovered = await sut.GetEpisodes(podcast, [], indexingContext);
 
         // Assert
-        discovered.Should().Contain(youTubeEpisode);
-        discovered.Should().Contain(appleEpisode);
+        discovered.Should().ContainSingle().Which.Should().BeSameAs(youTubeEpisode);
+        harness.AppleHandler.Verify(
+            x => x.GetEpisodes(It.IsAny<Podcast>(), It.IsAny<IndexingContext>()),
+            Times.Never);
     }
 
     [Fact(DisplayName =
         "For YouTube release authority podcasts with negative publishing delay, Apple catalogue discovery " +
-        "must run even when Spotify indexing is disabled â€” Apple merge supports cross-platform matching " +
-        "independently of Spotify URL resolution.")]
-    public async Task apple_catalogue_merge_pass_runs_when_index_spotify_false()
+        "must not run when Spotify indexing is disabled.")]
+    public async Task apple_catalogue_merge_pass_does_not_run_when_index_spotify_false()
     {
         // Arrange
         var harness = new EpisodeProviderTestHarness();
         var sut = harness.CreateSut();
         var podcast = CreateYouTubeAuthorityNegativeDelayPodcastWithApple();
-        var appleEpisode = _fixture.CreateAppleCatalogueEpisode();
         var indexingContext = IsolatedCatalogueMergeContext() with { IndexSpotify = false };
 
-        harness.AppleHandler
-            .Setup(x => x.GetEpisodes(podcast, indexingContext))
-            .ReturnsAsync(new EpisodeRetrievalHandlerResponse([appleEpisode], Handled: true));
-
         // Act
         var discovered = await sut.GetEpisodes(podcast, [], indexingContext);
 
         // Assert
         harness.AppleHandler.Verify(
-            x => x.GetEpisodes(podcast, indexingContext),
-            Times.Once);
+            x => x.GetEpisodes(It.IsAny<Podcast>(), It.IsAny<IndexingContext>()),
+            Times.Never);
         harness.SpotifyHandler.Verify(
             x => x.GetEpisodes(It.IsAny<Podcast>(), It.IsAny<IndexingContext>()),
             Times.Never);
-        discovered.Should().ContainSingle().Which.Should().BeSameAs(appleEpisode);
+        discovered.Should().BeEmpty();
     }
 
     [Fact(DisplayName =
         "For YouTube release authority podcasts with negative publishing delay, Apple catalogue discovery " +
-        "must still run when Spotify URL resolution is bypassed.")]
-    public async Task apple_catalogue_merge_pass_runs_when_skip_spotify_url_resolving()
+        "must not run when Spotify URL resolution is bypassed.")]
+    public async Task apple_catalogue_merge_pass_does_not_run_when_skip_spotify_url_resolving()
     {
         // Arrange
         var harness = new EpisodeProviderTestHarness();
         var sut = harness.CreateSut();
         var podcast = CreateYouTubeAuthorityNegativeDelayPodcastWithApple();
-        var appleEpisode = _fixture.CreateAppleCatalogueEpisode();
         var indexingContext = IsolatedCatalogueMergeContext() with { SkipSpotifyUrlResolving = true };
-
-        harness.AppleHandler
-            .Setup(x => x.GetEpisodes(podcast, indexingContext))
-            .ReturnsAsync(new EpisodeRetrievalHandlerResponse([appleEpisode], Handled: true));
 
         // Act
         var discovered = await sut.GetEpisodes(podcast, [], indexingContext);
 
         // Assert
         harness.AppleHandler.Verify(
-            x => x.GetEpisodes(podcast, indexingContext),
-            Times.Once);
+            x => x.GetEpisodes(It.IsAny<Podcast>(), It.IsAny<IndexingContext>()),
+            Times.Never);
         harness.SpotifyHandler.Verify(
             x => x.GetEpisodes(It.IsAny<Podcast>(), It.IsAny<IndexingContext>()),
             Times.Never);
-        discovered.Should().ContainSingle().Which.Should().BeSameAs(appleEpisode);
+        discovered.Should().BeEmpty();
     }
 
     [Fact(DisplayName =
         "For YouTube release authority podcasts with negative publishing delay and Spotify indexing enabled, " +
-        "indexing discovery must merge Spotify catalogue episodes alongside YouTube discovery.")]
-    public async Task youtube_release_authority_negative_delay_merges_spotify_catalogue_episodes()
+        "indexing discovery must not merge Spotify catalogue episodes as new creates.")]
+    public async Task youtube_release_authority_negative_delay_does_not_merge_spotify_catalogue_episodes()
     {
         // Arrange
         var harness = new EpisodeProviderTestHarness();
@@ -134,8 +125,10 @@ public class EpisodeProviderRules
         var discovered = await sut.GetEpisodes(podcast, [], indexingContext);
 
         // Assert
-        discovered.Should().Contain(youTubeEpisode);
-        discovered.Should().Contain(spotifyEpisode);
+        discovered.Should().ContainSingle().Which.Should().BeSameAs(youTubeEpisode);
+        harness.SpotifyHandler.Verify(
+            x => x.GetEpisodes(It.IsAny<Podcast>(), It.IsAny<IndexingContext>()),
+            Times.Never);
     }
 
     [Fact(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/PodcastEpisodeFilterRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Indexing/PodcastEpisodeFilterRules.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RedditPodcastPoster.Common.Episodes;
+using RedditPodcastPoster.Configuration.Options;
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
+
+namespace RedditPodcastPoster.PodcastServices.Tests.BusinessRules.Indexing;
+
+public class PodcastEpisodeFilterRules
+{
+    private static PodcastEpisodeFilter CreateSut() =>
+        new(
+            Options.Create(new DelayedYouTubePublication { EvaluationThreshold = TimeSpan.FromDays(7) }),
+            NullLogger<PodcastEpisodeFilter>.Instance);
+
+    [Fact(DisplayName =
+        "YouTube release-authority episodes with Spotify but no YouTube URL are not Bluesky-ready.")]
+    public async Task youtube_ra_spotify_only_not_bluesky_ready()
+    {
+        var sut = CreateSut();
+        var podcast = CreateYouTubeAuthorityPodcast();
+        var episode = CreateRecentEpisode(e =>
+        {
+            e.Urls.Spotify = new Uri("https://open.spotify.com/episode/abc");
+            e.Urls.YouTube = null;
+        });
+
+        var ready = await sut.GetMostRecentBlueskyReadyEpisodes(podcast, [episode], numberOfDays: 7);
+
+        ready.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName =
+        "YouTube release-authority episodes with a YouTube URL are Bluesky-ready.")]
+    public async Task youtube_ra_with_youtube_url_is_bluesky_ready()
+    {
+        var sut = CreateSut();
+        var podcast = CreateYouTubeAuthorityPodcast();
+        var episode = CreateRecentEpisode(e =>
+        {
+            e.Urls.YouTube = new Uri("https://www.youtube.com/watch?v=abc");
+            e.Urls.Spotify = null;
+        });
+
+        var ready = await sut.GetMostRecentBlueskyReadyEpisodes(podcast, [episode], numberOfDays: 7);
+
+        ready.Should().ContainSingle().Which.Episode.Id.Should().Be(episode.Id);
+    }
+
+    [Fact(DisplayName =
+        "Non-YouTube release-authority episodes remain Bluesky-ready with Spotify-only URLs.")]
+    public async Task spotify_ra_spotify_only_is_bluesky_ready()
+    {
+        var sut = CreateSut();
+        var podcast = new Podcast
+        {
+            Id = Guid.NewGuid(),
+            Name = "Audio Podcast",
+            ReleaseAuthority = Service.Spotify,
+            SpotifyId = "show123"
+        };
+        var episode = CreateRecentEpisode(e =>
+        {
+            e.Urls.Spotify = new Uri("https://open.spotify.com/episode/abc");
+            e.Urls.YouTube = null;
+        });
+
+        var ready = await sut.GetMostRecentBlueskyReadyEpisodes(podcast, [episode], numberOfDays: 7);
+
+        ready.Should().ContainSingle().Which.Episode.Id.Should().Be(episode.Id);
+    }
+
+    [Fact(DisplayName =
+        "YouTube release-authority episodes with Spotify but no YouTube URL are not tweet-ready.")]
+    public async Task youtube_ra_spotify_only_not_tweet_ready()
+    {
+        var sut = CreateSut();
+        var podcast = CreateYouTubeAuthorityPodcast();
+        var episode = CreateRecentEpisode(e =>
+        {
+            e.Urls.Spotify = new Uri("https://open.spotify.com/episode/abc");
+            e.Urls.YouTube = null;
+            e.Tweeted = false;
+        });
+
+        var ready = await sut.GetMostRecentUntweetedEpisodes(podcast, [episode], numberOfDays: 7);
+
+        ready.Should().BeEmpty();
+    }
+
+    private static Podcast CreateYouTubeAuthorityPodcast() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "YouTube RA Podcast",
+            ReleaseAuthority = Service.YouTube,
+            YouTubeChannelId = "UCxxxxxxxxxxxxxxxxxxxxxx",
+            SpotifyId = "show123",
+            YouTubePublicationOffset = TimeSpan.FromDays(-4).Ticks
+        };
+
+    private static Episode CreateRecentEpisode(Action<Episode> customize)
+    {
+        var episode = new Episode
+        {
+            Id = Guid.NewGuid(),
+            Title = "Recent episode",
+            Release = DateTime.UtcNow.AddHours(-2),
+            Length = TimeSpan.FromMinutes(40),
+            Urls = new ServiceUrls()
+        };
+        customize(episode);
+        return episode;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerRules.cs
@@ -1,0 +1,189 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.Abstractions.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Episode;
+using RedditPodcastPoster.PodcastServices.YouTube.Handlers;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Handlers;
+
+/// <summary>
+/// Indexer YouTube retrieval must keep YouTubePlaylistQueryIsExpensive in step with the playlist-order
+/// probe, because the stored flag chooses the pagination strategy for the following pass.
+/// </summary>
+public class YouTubeEpisodeRetrievalHandlerRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "Across successive indexer passes a flipping playlist flips YouTubePlaylistQueryIsExpensive each time " +
+        "because a playlist that switches order must switch pagination strategy on the following pass.")]
+    public async Task Expensive_flag_round_trips_across_indexer_passes()
+    {
+        // Arrange — probes: oldest-first, newest-first, oldest-first
+        var podcast = CreatePlaylistPodcast();
+        var requestedExpensiveFlags = new List<bool>();
+        var sut = CreateSut(requestedExpensiveFlags, true, false, true);
+
+        // Act
+        var storedFlags = await RunPasses(sut, podcast, passes: 3);
+
+        // Assert — each pass requests using the flag as it stood before that pass's probe
+        storedFlags.Should().Equal(true, false, true);
+        requestedExpensiveFlags.Should().Equal(false, true, false);
+    }
+
+    [Fact(DisplayName =
+        "An inconclusive probe between two conclusive probes leaves YouTubePlaylistQueryIsExpensive intact " +
+        "because a pass that could not measure order must not reset the playlist pagination strategy.")]
+    public async Task Inconclusive_pass_preserves_flag_between_flips()
+    {
+        // Arrange — probes: oldest-first, inconclusive, newest-first
+        var podcast = CreatePlaylistPodcast();
+        var requestedExpensiveFlags = new List<bool>();
+        var sut = CreateSut(requestedExpensiveFlags, true, null, false);
+
+        // Act
+        var storedFlags = await RunPasses(sut, podcast, passes: 3);
+
+        // Assert
+        storedFlags.Should().Equal(true, true, false);
+        requestedExpensiveFlags.Should().Equal(false, true, true);
+    }
+
+    [Fact(DisplayName =
+        "When the podcast declares an arbitrary YouTube playlist order, retrieval forwards Arbitrary to the " +
+        "provider and leaves YouTubePlaylistQueryIsExpensive untouched because curated playlists have no " +
+        "positional order to probe.")]
+    public async Task Arbitrary_order_forwards_playlist_order_and_leaves_expensive_flag_untouched()
+    {
+        // Arrange
+        var podcast = CreatePlaylistPodcast();
+        podcast.YouTubePlaylistOrder = PlaylistOrder.Arbitrary;
+        podcast.YouTubePlaylistQueryIsExpensive = false;
+        PlaylistOrder? forwardedOrder = null;
+        var provider = new Mock<IYouTubeEpisodeProvider>();
+        provider
+            .Setup(x => x.GetPlaylistEpisodes(
+                It.IsAny<YouTubePlaylistId>(),
+                It.IsAny<YouTubeChannelId>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<PlaylistOrder?>()))
+            .Callback<YouTubePlaylistId, YouTubeChannelId?, IndexingContext, bool, PlaylistOrder?>(
+                (_, _, _, _, playlistOrder) => forwardedOrder = playlistOrder)
+            .ReturnsAsync(new GetPlaylistEpisodesResponse([], IsExpensiveQuery: true));
+        var sut = new YouTubeEpisodeRetrievalHandler(
+            provider.Object,
+            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
+
+        // Act
+        var result = await sut.GetEpisodes(
+            podcast,
+            [],
+            new IndexingContext(DomainTestFixture.UtcDaysAgo(2), SkipExpensiveYouTubeQueries: true));
+
+        // Assert
+        result.Handled.Should().BeTrue();
+        forwardedOrder.Should().Be(PlaylistOrder.Arbitrary);
+        podcast.YouTubePlaylistQueryIsExpensive.Should().BeFalse(
+            "arbitrary-order walks never apply the expensive-query flag from a head-order probe");
+    }
+
+    [Fact(DisplayName =
+        "When the podcast declares an arbitrary YouTube playlist order and SkipExpensiveYouTubeQueries is set, " +
+        "retrieval still calls the playlist provider because the full walk is the only correct read of a " +
+        "curated playlist and is not gated by the expensive-query skip.")]
+    public async Task Arbitrary_order_still_calls_playlist_provider_when_expensive_queries_skipped()
+    {
+        // Arrange
+        var podcast = CreatePlaylistPodcast();
+        podcast.YouTubePlaylistOrder = PlaylistOrder.Arbitrary;
+        podcast.YouTubePlaylistQueryIsExpensive = true;
+        var provider = new Mock<IYouTubeEpisodeProvider>();
+        provider
+            .Setup(x => x.GetPlaylistEpisodes(
+                It.IsAny<YouTubePlaylistId>(),
+                It.IsAny<YouTubeChannelId>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<PlaylistOrder?>()))
+            .ReturnsAsync(new GetPlaylistEpisodesResponse([], IsExpensiveQuery: null));
+        var sut = new YouTubeEpisodeRetrievalHandler(
+            provider.Object,
+            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
+
+        // Act
+        var result = await sut.GetEpisodes(
+            podcast,
+            [],
+            new IndexingContext(DomainTestFixture.UtcDaysAgo(2), SkipExpensiveYouTubeQueries: true));
+
+        // Assert
+        result.Handled.Should().BeTrue();
+        provider.Verify(
+            x => x.GetPlaylistEpisodes(
+                It.IsAny<YouTubePlaylistId>(),
+                It.IsAny<YouTubeChannelId>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                PlaylistOrder.Arbitrary),
+            Times.Once);
+    }
+
+    private Podcast CreatePlaylistPodcast() =>
+        _fixture.CreatePodcast(p =>
+        {
+            p.YouTubeChannelId = _fixture.CreateYouTubeChannelId();
+            p.YouTubePlaylistId = _fixture.CreateYouTubePlaylistId();
+            p.YouTubePlaylistQueryIsExpensive = false;
+        });
+
+    private static async Task<List<bool?>> RunPasses(
+        YouTubeEpisodeRetrievalHandler sut,
+        Podcast podcast,
+        int passes)
+    {
+        var storedFlags = new List<bool?>();
+        for (var pass = 0; pass < passes; pass++)
+        {
+            await sut.GetEpisodes(
+                podcast,
+                [],
+                new IndexingContext(DomainTestFixture.UtcDaysAgo(2), SkipExpensiveYouTubeQueries: false));
+            storedFlags.Add(podcast.YouTubePlaylistQueryIsExpensive);
+        }
+
+        return storedFlags;
+    }
+
+    /// <summary>
+    /// Yields one playlist-order probe per pass and records the expensive-query flag each request carried,
+    /// so a test can observe the stored flag feeding back into the following pass.
+    /// </summary>
+    private static YouTubeEpisodeRetrievalHandler CreateSut(
+        List<bool> requestedExpensiveFlags,
+        params bool?[] probes)
+    {
+        var remainingProbes = new Queue<bool?>(probes);
+        var provider = new Mock<IYouTubeEpisodeProvider>();
+        provider
+            .Setup(x => x.GetPlaylistEpisodes(
+                It.IsAny<YouTubePlaylistId>(),
+                It.IsAny<YouTubeChannelId>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<PlaylistOrder?>()))
+            .Callback<YouTubePlaylistId, YouTubeChannelId?, IndexingContext, bool, PlaylistOrder?>(
+                (_, _, _, expensivePlaylist, _) => requestedExpensiveFlags.Add(expensivePlaylist))
+            .ReturnsAsync(() => new GetPlaylistEpisodesResponse([], remainingProbes.Dequeue()));
+
+        return new YouTubeEpisodeRetrievalHandler(
+            provider.Object,
+            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
+using Google.Apis.YouTube.v3.Data;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.YouTube.Episode;
 using RedditPodcastPoster.PodcastServices.YouTube.Handlers;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
@@ -129,5 +131,105 @@ public class YouTubeEpisodeRetrievalHandlerTests
                 indexingContext,
                 true),
             Times.Once);
+    }
+
+    [Fact(DisplayName =
+        "Across successive indexer passes a flipping playlist flips YouTubePlaylistQueryIsExpensive each time " +
+        "because a show that switches order must switch pagination strategy on the following pass.")]
+    public async Task Expensive_flag_round_trips_across_indexer_passes()
+    {
+        var podcast = new Podcast
+        {
+            Id = Guid.NewGuid(),
+            YouTubeChannelId = "UC_test_channel",
+            YouTubePlaylistId = "PL_test_playlist",
+            YouTubePlaylistQueryIsExpensive = false
+        };
+        var provider = new SequencedYouTubeEpisodeProvider(true, false, true);
+        var sut = new YouTubeEpisodeRetrievalHandler(
+            provider,
+            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
+
+        var storedFlags = new List<bool?>();
+        for (var pass = 0; pass < 3; pass++)
+        {
+            await sut.GetEpisodes(
+                podcast,
+                [],
+                new IndexingContext(DateTime.UtcNow.AddDays(-2), SkipExpensiveYouTubeQueries: false));
+            storedFlags.Add(podcast.YouTubePlaylistQueryIsExpensive);
+        }
+
+        storedFlags.Should().Equal(true, false, true);
+        provider.RequestedExpensiveFlags.Should().Equal(false, true, false);
+    }
+
+    [Fact(DisplayName =
+        "An inconclusive probe between two conclusive probes leaves YouTubePlaylistQueryIsExpensive intact " +
+        "because a pass that could not measure order must not reset the playlist pagination strategy.")]
+    public async Task Inconclusive_pass_preserves_flag_between_flips()
+    {
+        var podcast = new Podcast
+        {
+            Id = Guid.NewGuid(),
+            YouTubeChannelId = "UC_test_channel",
+            YouTubePlaylistId = "PL_test_playlist",
+            YouTubePlaylistQueryIsExpensive = false
+        };
+        var provider = new SequencedYouTubeEpisodeProvider(true, null, false);
+        var sut = new YouTubeEpisodeRetrievalHandler(
+            provider,
+            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
+
+        var storedFlags = new List<bool?>();
+        for (var pass = 0; pass < 3; pass++)
+        {
+            await sut.GetEpisodes(
+                podcast,
+                [],
+                new IndexingContext(DateTime.UtcNow.AddDays(-2), SkipExpensiveYouTubeQueries: false));
+            storedFlags.Add(podcast.YouTubePlaylistQueryIsExpensive);
+        }
+
+        storedFlags.Should().Equal(true, true, false);
+        provider.RequestedExpensiveFlags.Should().Equal(false, true, true);
+    }
+
+    /// <summary>
+    /// Returns one playlist-order probe per call and records the expensive-query flag each request
+    /// carried, so a test can observe the flag feeding back into the following pass.
+    /// </summary>
+    private sealed class SequencedYouTubeEpisodeProvider(params bool?[] probes) : IYouTubeEpisodeProvider
+    {
+        private int _call;
+
+        public List<bool> RequestedExpensiveFlags { get; } = [];
+
+        public Task<GetPlaylistEpisodesResponse> GetPlaylistEpisodes(
+            YouTubePlaylistId youTubePlaylistId,
+            YouTubeChannelId? youTubeChannelId,
+            IndexingContext indexingContext,
+            bool expensivePlaylist = false)
+        {
+            RequestedExpensiveFlags.Add(expensivePlaylist);
+            var probe = probes[Math.Min(_call++, probes.Length - 1)];
+            return Task.FromResult(new GetPlaylistEpisodesResponse([], probe));
+        }
+
+        public Task<IList<EpisodeModel>?> GetEpisodes(
+            Podcast podcast,
+            IndexingContext indexingContext,
+            IEnumerable<string> knownIds) =>
+            throw new NotImplementedException();
+
+        public Task<EpisodeModel> GetEpisodeAsync(
+            PlaylistItemSnippet playlistItemSnippet,
+            Google.Apis.YouTube.v3.Data.Video videoDetails) =>
+            throw new NotImplementedException();
+
+        public Task<EpisodeModel> GetEpisodeAsync(
+            SearchResult searchResult,
+            Google.Apis.YouTube.v3.Data.Video videoDetails) =>
+            throw new NotImplementedException();
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerTests.cs
@@ -1,45 +1,53 @@
 using FluentAssertions;
-using Google.Apis.YouTube.v3.Data;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.PodcastServices.Abstractions;
+using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using RedditPodcastPoster.PodcastServices.YouTube.Episode;
 using RedditPodcastPoster.PodcastServices.YouTube.Handlers;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
-using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using EpisodeModel = RedditPodcastPoster.Models.Episodes.Episode;
-using IYouTubeEpisodeProvider = RedditPodcastPoster.PodcastServices.YouTube.Episode.IYouTubeEpisodeProvider;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Handlers;
 
+/// <summary>
+/// Handler wiring: SkipExpensiveYouTubeQueries must choose channel vs single-page vs paginated playlist paths.
+/// </summary>
 public class YouTubeEpisodeRetrievalHandlerTests
 {
-    [Fact]
-    public async Task GetEpisodes_ChannelOnly_WhenSkipExpensiveYouTubeQueries_StillCallsChannelDiscovery()
-    {
-        var podcast = new Podcast
-        {
-            Id = Guid.NewGuid(),
-            YouTubeChannelId = "UC_test_channel",
-            YouTubePlaylistId = null!
-        };
-        var indexingContext = new IndexingContext(
-            DateTime.UtcNow.AddDays(-2),
-            SkipExpensiveYouTubeQueries: true);
-        var expectedEpisodes = new List<EpisodeModel> { new() { Title = "episode-1" } };
+    private readonly DomainTestFixture _fixture = new();
 
+    [Fact(DisplayName =
+        "When the podcast has a channel id but no playlist and SkipExpensiveYouTubeQueries is set, GetEpisodes still calls channel discovery " +
+        "because channel Search.List is not the expensive playlist walk.")]
+    public async Task Channel_only_still_calls_channel_discovery_when_expensive_queries_skipped()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast(p =>
+        {
+            p.YouTubeChannelId = _fixture.CreateYouTubeChannelId();
+            p.YouTubePlaylistId = null!;
+        });
+        var indexingContext = new IndexingContext(
+            DomainTestFixture.UtcDaysAgo(2),
+            SkipExpensiveYouTubeQueries: true);
+        var expectedEpisodes = new List<EpisodeModel>
+        {
+            _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast)
+        };
         var youTubeEpisodeProvider = new Mock<IYouTubeEpisodeProvider>();
         youTubeEpisodeProvider
             .Setup(x => x.GetEpisodes(podcast, indexingContext, It.IsAny<IEnumerable<string>>()))
             .ReturnsAsync(expectedEpisodes);
-
         var sut = new YouTubeEpisodeRetrievalHandler(
             youTubeEpisodeProvider.Object,
             NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
 
+        // Act
         var result = await sut.GetEpisodes(podcast, [], indexingContext);
 
+        // Assert
         result.Handled.Should().BeTrue();
         result.Episodes.Should().BeEquivalentTo(expectedEpisodes);
         youTubeEpisodeProvider.Verify(
@@ -54,182 +62,93 @@ public class YouTubeEpisodeRetrievalHandlerTests
             Times.Never);
     }
 
-    [Fact]
-    public async Task GetEpisodes_ExpensivePlaylist_WhenSkipExpensiveYouTubeQueries_UsesSinglePageFetch()
+    [Fact(DisplayName =
+        "When the playlist is marked expensive and SkipExpensiveYouTubeQueries is set, GetEpisodes uses a single-page playlist fetch " +
+        "because full playlist pagination must not run on that pass.")]
+    public async Task Expensive_playlist_uses_single_page_when_expensive_queries_skipped()
     {
-        var podcast = new Podcast
+        // Arrange
+        var channelId = _fixture.CreateYouTubeChannelId();
+        var playlistId = _fixture.CreateYouTubePlaylistId();
+        var podcast = _fixture.CreatePodcast(p =>
         {
-            Id = Guid.NewGuid(),
-            YouTubeChannelId = "UC_test_channel",
-            YouTubePlaylistId = "PL_test_playlist",
-            YouTubePlaylistQueryIsExpensive = true
-        };
+            p.YouTubeChannelId = channelId;
+            p.YouTubePlaylistId = playlistId;
+            p.YouTubePlaylistQueryIsExpensive = true;
+        });
         var indexingContext = new IndexingContext(
-            DateTime.UtcNow.AddDays(-2),
+            DomainTestFixture.UtcDaysAgo(2),
             SkipExpensiveYouTubeQueries: true);
-        var expectedEpisodes = new List<EpisodeModel> { new() { Title = "playlist-episode" } };
-
+        var expectedEpisodes = new List<EpisodeModel>
+        {
+            _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast)
+        };
         var youTubeEpisodeProvider = new Mock<IYouTubeEpisodeProvider>();
         youTubeEpisodeProvider
             .Setup(x => x.GetPlaylistEpisodes(
-                new YouTubePlaylistId("PL_test_playlist"),
-                new YouTubeChannelId("UC_test_channel"),
+                new YouTubePlaylistId(playlistId),
+                new YouTubeChannelId(channelId),
                 indexingContext,
                 false))
             .ReturnsAsync(new GetPlaylistEpisodesResponse(expectedEpisodes));
-
         var sut = new YouTubeEpisodeRetrievalHandler(
             youTubeEpisodeProvider.Object,
             NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
 
+        // Act
         var result = await sut.GetEpisodes(podcast, [], indexingContext);
 
+        // Assert
         result.Handled.Should().BeTrue();
         result.Episodes.Should().BeEquivalentTo(expectedEpisodes);
         youTubeEpisodeProvider.Verify(
             x => x.GetPlaylistEpisodes(
-                new YouTubePlaylistId("PL_test_playlist"),
-                new YouTubeChannelId("UC_test_channel"),
+                new YouTubePlaylistId(playlistId),
+                new YouTubeChannelId(channelId),
                 indexingContext,
                 false),
             Times.Once);
     }
 
-    [Fact]
-    public async Task GetEpisodes_ExpensivePlaylist_WhenExpensiveQueriesAllowed_UsesExpensivePagination()
+    [Fact(DisplayName =
+        "When the playlist is marked expensive and expensive queries are allowed, GetEpisodes requests expensive playlist pagination " +
+        "because that pass may walk the ascending playlist.")]
+    public async Task Expensive_playlist_uses_pagination_when_expensive_queries_allowed()
     {
-        var podcast = new Podcast
+        // Arrange
+        var channelId = _fixture.CreateYouTubeChannelId();
+        var playlistId = _fixture.CreateYouTubePlaylistId();
+        var podcast = _fixture.CreatePodcast(p =>
         {
-            Id = Guid.NewGuid(),
-            YouTubeChannelId = "UC_test_channel",
-            YouTubePlaylistId = "PL_test_playlist",
-            YouTubePlaylistQueryIsExpensive = true
-        };
+            p.YouTubeChannelId = channelId;
+            p.YouTubePlaylistId = playlistId;
+            p.YouTubePlaylistQueryIsExpensive = true;
+        });
         var indexingContext = new IndexingContext(
-            DateTime.UtcNow.AddDays(-2),
+            DomainTestFixture.UtcDaysAgo(2),
             SkipExpensiveYouTubeQueries: false);
-
         var youTubeEpisodeProvider = new Mock<IYouTubeEpisodeProvider>();
         youTubeEpisodeProvider
             .Setup(x => x.GetPlaylistEpisodes(
-                new YouTubePlaylistId("PL_test_playlist"),
-                new YouTubeChannelId("UC_test_channel"),
+                new YouTubePlaylistId(playlistId),
+                new YouTubeChannelId(channelId),
                 indexingContext,
                 true))
             .ReturnsAsync(new GetPlaylistEpisodesResponse([]));
-
         var sut = new YouTubeEpisodeRetrievalHandler(
             youTubeEpisodeProvider.Object,
             NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
 
+        // Act
         await sut.GetEpisodes(podcast, [], indexingContext);
 
+        // Assert
         youTubeEpisodeProvider.Verify(
             x => x.GetPlaylistEpisodes(
-                new YouTubePlaylistId("PL_test_playlist"),
-                new YouTubeChannelId("UC_test_channel"),
+                new YouTubePlaylistId(playlistId),
+                new YouTubeChannelId(channelId),
                 indexingContext,
                 true),
             Times.Once);
-    }
-
-    [Fact(DisplayName =
-        "Across successive indexer passes a flipping playlist flips YouTubePlaylistQueryIsExpensive each time " +
-        "because a show that switches order must switch pagination strategy on the following pass.")]
-    public async Task Expensive_flag_round_trips_across_indexer_passes()
-    {
-        var podcast = new Podcast
-        {
-            Id = Guid.NewGuid(),
-            YouTubeChannelId = "UC_test_channel",
-            YouTubePlaylistId = "PL_test_playlist",
-            YouTubePlaylistQueryIsExpensive = false
-        };
-        var provider = new SequencedYouTubeEpisodeProvider(true, false, true);
-        var sut = new YouTubeEpisodeRetrievalHandler(
-            provider,
-            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
-
-        var storedFlags = new List<bool?>();
-        for (var pass = 0; pass < 3; pass++)
-        {
-            await sut.GetEpisodes(
-                podcast,
-                [],
-                new IndexingContext(DateTime.UtcNow.AddDays(-2), SkipExpensiveYouTubeQueries: false));
-            storedFlags.Add(podcast.YouTubePlaylistQueryIsExpensive);
-        }
-
-        storedFlags.Should().Equal(true, false, true);
-        provider.RequestedExpensiveFlags.Should().Equal(false, true, false);
-    }
-
-    [Fact(DisplayName =
-        "An inconclusive probe between two conclusive probes leaves YouTubePlaylistQueryIsExpensive intact " +
-        "because a pass that could not measure order must not reset the playlist pagination strategy.")]
-    public async Task Inconclusive_pass_preserves_flag_between_flips()
-    {
-        var podcast = new Podcast
-        {
-            Id = Guid.NewGuid(),
-            YouTubeChannelId = "UC_test_channel",
-            YouTubePlaylistId = "PL_test_playlist",
-            YouTubePlaylistQueryIsExpensive = false
-        };
-        var provider = new SequencedYouTubeEpisodeProvider(true, null, false);
-        var sut = new YouTubeEpisodeRetrievalHandler(
-            provider,
-            NullLogger<YouTubeEpisodeRetrievalHandler>.Instance);
-
-        var storedFlags = new List<bool?>();
-        for (var pass = 0; pass < 3; pass++)
-        {
-            await sut.GetEpisodes(
-                podcast,
-                [],
-                new IndexingContext(DateTime.UtcNow.AddDays(-2), SkipExpensiveYouTubeQueries: false));
-            storedFlags.Add(podcast.YouTubePlaylistQueryIsExpensive);
-        }
-
-        storedFlags.Should().Equal(true, true, false);
-        provider.RequestedExpensiveFlags.Should().Equal(false, true, true);
-    }
-
-    /// <summary>
-    /// Returns one playlist-order probe per call and records the expensive-query flag each request
-    /// carried, so a test can observe the flag feeding back into the following pass.
-    /// </summary>
-    private sealed class SequencedYouTubeEpisodeProvider(params bool?[] probes) : IYouTubeEpisodeProvider
-    {
-        private int _call;
-
-        public List<bool> RequestedExpensiveFlags { get; } = [];
-
-        public Task<GetPlaylistEpisodesResponse> GetPlaylistEpisodes(
-            YouTubePlaylistId youTubePlaylistId,
-            YouTubeChannelId? youTubeChannelId,
-            IndexingContext indexingContext,
-            bool expensivePlaylist = false)
-        {
-            RequestedExpensiveFlags.Add(expensivePlaylist);
-            var probe = probes[Math.Min(_call++, probes.Length - 1)];
-            return Task.FromResult(new GetPlaylistEpisodesResponse([], probe));
-        }
-
-        public Task<IList<EpisodeModel>?> GetEpisodes(
-            Podcast podcast,
-            IndexingContext indexingContext,
-            IEnumerable<string> knownIds) =>
-            throw new NotImplementedException();
-
-        public Task<EpisodeModel> GetEpisodeAsync(
-            PlaylistItemSnippet playlistItemSnippet,
-            Google.Apis.YouTube.v3.Data.Video videoDetails) =>
-            throw new NotImplementedException();
-
-        public Task<EpisodeModel> GetEpisodeAsync(
-            SearchResult searchResult,
-            Google.Apis.YouTube.v3.Data.Video videoDetails) =>
-            throw new NotImplementedException();
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/ArbitraryYouTubePlaylistWalkRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/ArbitraryYouTubePlaylistWalkRules.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Playlist;
+
+/// <summary>
+/// Arbitrary-order YouTube playlist walks must hard-stop after MaxPages so a mis-tagged
+/// channel-scale playlist cannot burn the daily YouTube quota.
+/// </summary>
+public class ArbitraryYouTubePlaylistWalkRules
+{
+    [Fact(DisplayName =
+        "An arbitrary playlist walk trips its circuit breaker once MaxPages have been fetched and " +
+        "another page remains, because continuing would burn quota on a channel-scale playlist.")]
+    public void Trips_when_max_pages_fetched_and_next_page_remains()
+    {
+        // Arrange
+        var pagesFetched = ArbitraryYouTubePlaylistWalk.MaxPages;
+        var nextPageToken = "next-page-token";
+
+        // Act
+        var trip = ArbitraryYouTubePlaylistWalk.ShouldTripCircuitBreaker(pagesFetched, nextPageToken);
+
+        // Assert
+        trip.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "An arbitrary playlist walk does not trip when MaxPages have been fetched but no next page " +
+        "remains, because the walk completed within the quota budget.")]
+    public void Does_not_trip_when_walk_completes_exactly_at_max_pages()
+    {
+        // Arrange
+        var pagesFetched = ArbitraryYouTubePlaylistWalk.MaxPages;
+        string? nextPageToken = null;
+
+        // Act
+        var trip = ArbitraryYouTubePlaylistWalk.ShouldTripCircuitBreaker(pagesFetched, nextPageToken);
+
+        // Assert
+        trip.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "An arbitrary playlist walk does not trip before MaxPages even when a next page remains, " +
+        "because curated show playlists are expected to fit inside the page budget.")]
+    public void Does_not_trip_before_max_pages_when_next_page_remains()
+    {
+        // Arrange
+        var pagesFetched = ArbitraryYouTubePlaylistWalk.MaxPages - 1;
+        var nextPageToken = "next-page-token";
+
+        // Act
+        var trip = ArbitraryYouTubePlaylistWalk.ShouldTripCircuitBreaker(pagesFetched, nextPageToken);
+
+        // Assert
+        trip.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "The arbitrary-walk circuit-breaker message template starts with the stable prefix so App Insights " +
+        "can alert operators on the exact log line when a playlist exceeds the page budget.")]
+    public void Circuit_breaker_message_template_starts_with_stable_prefix()
+    {
+        // Arrange
+        // Act
+        var template = ArbitraryYouTubePlaylistWalk.CircuitBreakerTrippedMessageTemplate;
+
+        // Assert
+        template.Should().StartWith(ArbitraryYouTubePlaylistWalk.CircuitBreakerTrippedMessagePrefix);
+        template.Should().Contain("playlist-id=");
+        template.Should().Contain("pages-fetched=");
+        template.Should().Contain("max-pages=");
+    }
+
+    [Fact(DisplayName =
+        "Arbitrary walk batch size times MaxPages covers one thousand playlist items because that is " +
+        "enough for curated show playlists and deliberately too small for channel-scale uploads feeds.")]
+    public void Page_budget_covers_one_thousand_items()
+    {
+        // Arrange
+        // Act
+        var itemBudget = ArbitraryYouTubePlaylistWalk.BatchSize * ArbitraryYouTubePlaylistWalk.MaxPages;
+
+        // Assert
+        itemBudget.Should().Be(1000);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/PlaylistItemOrderingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/PlaylistItemOrderingRules.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Google.Apis.YouTube.v3.Data;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Playlist;
+
+/// <summary>
+/// Head-order probe for YouTube playlists: newest-first enables ReleasedSince early-stop;
+/// any strict ascending pair marks the playlist expensive. Equal timestamps are treated as
+/// non-ascending — the curated-playlist failure mode that motivates PlaylistOrder.Arbitrary.
+/// </summary>
+public class PlaylistItemOrderingRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "When playlist items are strictly newest-first by added-at, IsReverseDateOrdered returns true " +
+        "because reverse-chrono playlists may early-stop once items fall before ReleasedSince.")]
+    public void Newest_first_is_reverse_date_ordered()
+    {
+        // Arrange
+        var newer = DomainTestFixture.UtcAtTime(-1, TimeSpan.FromHours(12));
+        var older = DomainTestFixture.UtcAtTime(-2, TimeSpan.FromHours(12));
+        var items = new[] { Item(newer), Item(older) };
+
+        // Act
+        var reverse = PlaylistItemOrdering.IsReverseDateOrdered(items);
+
+        // Assert
+        reverse.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "When playlist items are strictly oldest-first by added-at, IsReverseDateOrdered returns false " +
+        "because ascending playlists need a full walk and must set the expensive-query flag.")]
+    public void Oldest_first_is_not_reverse_date_ordered()
+    {
+        // Arrange
+        var older = DomainTestFixture.UtcAtTime(-2, TimeSpan.FromHours(12));
+        var newer = DomainTestFixture.UtcAtTime(-1, TimeSpan.FromHours(12));
+        var items = new[] { Item(older), Item(newer) };
+
+        // Act
+        var reverse = PlaylistItemOrdering.IsReverseDateOrdered(items);
+
+        // Assert
+        reverse.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "When adjacent playlist items share the same added-at timestamp, IsReverseDateOrdered returns true " +
+        "because equal timestamps are non-ascending — the curated bulk-add failure mode that can " +
+        "misclassify Arbitrary playlists as newest-first.")]
+    public void Equal_added_at_timestamps_count_as_reverse_date_ordered()
+    {
+        // Arrange — KNOWN: equal timestamps satisfy reverse-chrono; Arbitrary exists because of this
+        var shared = DomainTestFixture.UtcAtTime(-1, TimeSpan.FromHours(12));
+        var items = new[] { Item(shared), Item(shared), Item(shared) };
+
+        // Act
+        var reverse = PlaylistItemOrdering.IsReverseDateOrdered(items);
+
+        // Assert
+        reverse.Should().BeTrue(
+            "equal added-at pairs never trip current < next; curated bulk-adds look newest-first to the probe");
+    }
+
+    [Fact(DisplayName =
+        "When a newest-first head is followed by a later-added item deeper in the sample, IsReverseDateOrdered " +
+        "returns false at the first ascending pair because one out-of-order item is enough to reject early-stop.")]
+    public void First_ascending_pair_rejects_reverse_date_order()
+    {
+        // Arrange
+        var newest = DomainTestFixture.UtcAtTime(-1, TimeSpan.FromHours(12));
+        var middle = DomainTestFixture.UtcAtTime(-2, TimeSpan.FromHours(12));
+        var appendedNewer = DomainTestFixture.UtcAtTime(0, TimeSpan.FromHours(6));
+        var items = new[] { Item(newest), Item(middle), Item(appendedNewer) };
+
+        // Act
+        var reverse = PlaylistItemOrdering.IsReverseDateOrdered(items);
+
+        // Assert
+        reverse.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "An empty playlist sample is treated as reverse-date-ordered because there is nothing to disprove " +
+        "newest-first and the expensive-query flag must not flip on an empty probe.")]
+    public void Empty_sample_is_reverse_date_ordered()
+    {
+        // Arrange
+        var items = Array.Empty<PlaylistItem>();
+
+        // Act
+        var reverse = PlaylistItemOrdering.IsReverseDateOrdered(items);
+
+        // Assert
+        reverse.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "A single playlist item is treated as reverse-date-ordered because one sample cannot distinguish " +
+        "ascending from newest-first and the expensive-query flag requires MinimumOrderSampleSize.")]
+    public void Single_item_is_reverse_date_ordered()
+    {
+        // Arrange
+        var items = new[] { Item(DomainTestFixture.UtcAtTime(-1, TimeSpan.FromHours(12))) };
+
+        // Act
+        var reverse = PlaylistItemOrdering.IsReverseDateOrdered(items);
+
+        // Assert
+        reverse.Should().BeTrue();
+    }
+
+    private PlaylistItem Item(DateTime publishedAt) =>
+        new()
+        {
+            Snippet = new PlaylistItemSnippet
+            {
+                Title = _fixture.CreateTitle(),
+                PublishedAtDateTimeOffset = new DateTimeOffset(publishedAt, TimeSpan.Zero)
+            }
+        };
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/YouTubeExpensiveQueryFlagRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/YouTubeExpensiveQueryFlagRules.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Playlist;
+
+public class YouTubeExpensiveQueryFlagRules
+{
+    [Fact(DisplayName =
+        "A conclusive ascending probe sets YouTubePlaylistQueryIsExpensive true " +
+        "because oldest-first playlists require full pagination.")]
+    public void Conclusive_ascending_sets_true()
+    {
+        var podcast = new Podcast { YouTubePlaylistQueryIsExpensive = false };
+
+        var changed = YouTubeExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive: true,
+            orderSampleSize: YouTubeExpensiveQueryFlag.MinimumOrderSampleSize);
+
+        changed.Should().BeTrue();
+        podcast.YouTubePlaylistQueryIsExpensive.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "A conclusive newest-first probe clears YouTubePlaylistQueryIsExpensive " +
+        "because YouTube playlists are known to flip back from ascending order.")]
+    public void Conclusive_newest_first_clears_true()
+    {
+        var podcast = new Podcast
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Podcast",
+            YouTubePlaylistId = "PL_test",
+            YouTubePlaylistQueryIsExpensive = true
+        };
+        var logger = new CapturingLogger();
+
+        var changed = YouTubeExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive: false,
+            orderSampleSize: YouTubeExpensiveQueryFlag.MinimumOrderSampleSize,
+            logger);
+
+        changed.Should().BeTrue();
+        podcast.YouTubePlaylistQueryIsExpensive.Should().BeFalse();
+        logger.Warnings.Should().ContainSingle(x =>
+            x.StartsWith(YouTubeExpensiveQueryFlag.FlagFlippedMessagePrefix));
+    }
+
+    [Fact(DisplayName =
+        "Successive conclusive probes flip YouTubePlaylistQueryIsExpensive in both directions " +
+        "because a playlist that switches order must never latch on a stale value.")]
+    public void Conclusive_probes_round_trip_in_both_directions()
+    {
+        var podcast = new Podcast { YouTubePlaylistQueryIsExpensive = false };
+        var observed = new List<bool?>();
+
+        foreach (var measured in new[] { true, false, true, false })
+        {
+            YouTubeExpensiveQueryFlag.Apply(
+                podcast,
+                measured,
+                YouTubeExpensiveQueryFlag.MinimumOrderSampleSize);
+            observed.Add(podcast.YouTubePlaylistQueryIsExpensive);
+        }
+
+        observed.Should().Equal(true, false, true, false);
+    }
+
+    [Fact(DisplayName =
+        "An inconclusive single-item probe leaves YouTubePlaylistQueryIsExpensive unchanged " +
+        "because one publish date cannot distinguish playlist order.")]
+    public void Inconclusive_sample_does_not_clear_flag()
+    {
+        var podcast = new Podcast { YouTubePlaylistQueryIsExpensive = true };
+
+        var changed = YouTubeExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive: false,
+            orderSampleSize: 1);
+
+        changed.Should().BeFalse();
+        podcast.YouTubePlaylistQueryIsExpensive.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "A null probe leaves YouTubePlaylistQueryIsExpensive unchanged " +
+        "because skipped or undated lookups must not invent a playlist-order measurement.")]
+    public void Null_probe_does_not_change_flag()
+    {
+        var podcast = new Podcast { YouTubePlaylistQueryIsExpensive = true };
+
+        var changed = YouTubeExpensiveQueryFlag.Apply(
+            podcast,
+            measuredExpensive: null,
+            orderSampleSize: YouTubeExpensiveQueryFlag.MinimumOrderSampleSize);
+
+        changed.Should().BeFalse();
+        podcast.YouTubePlaylistQueryIsExpensive.Should().BeTrue();
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/YouTubePlaylistIdChangeRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/YouTubePlaylistIdChangeRules.cs
@@ -1,35 +1,40 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Playlist;
 
 /// <summary>
-/// Operators must see YouTube playlist id swaps in App Insights (e.g. unlisted → public show playlist)
-/// because the configured playlist is release-authority for enrichment and discovery.
+/// Operators must see YouTube playlist id swaps in App Insights and retain former ids on the podcast
+/// so a bad curated-playlist swap can be rolled back.
 /// </summary>
 public class YouTubePlaylistIdChangeRules
 {
     private readonly DomainTestFixture _fixture = new();
 
     [Fact(DisplayName =
-        "When Apply is given a different YouTube playlist id, the podcast stores the new id and a Warning is logged " +
-        "with the stable prefix so operators can see curated playlist swaps in App Insights.")]
-    public void Apply_changes_id_and_logs_warning_with_stable_prefix()
+        "When Apply is given a different YouTube playlist id, the podcast stores the new id, appends the previous " +
+        "non-empty id with replaced-at to history, and logs a Warning with the stable prefix.")]
+    public void Apply_changes_id_appends_history_and_logs_warning()
     {
         // Arrange
         var previousId = _fixture.CreateYouTubePlaylistId();
         var measuredId = _fixture.CreateYouTubePlaylistId();
+        var replacedAt = DomainTestFixture.UtcAtTime(0, TimeSpan.FromHours(15));
         var podcast = _fixture.CreatePodcast(p => p.YouTubePlaylistId = previousId);
         var logger = new CapturingLogger();
 
         // Act
-        var changed = YouTubePlaylistIdChange.Apply(podcast, measuredId, logger);
+        var changed = YouTubePlaylistIdChange.Apply(podcast, measuredId, logger, replacedAt);
 
         // Assert
         changed.Should().BeTrue();
         podcast.YouTubePlaylistId.Should().Be(measuredId);
+        podcast.YouTubePlaylistIdHistory.Should().ContainSingle();
+        podcast.YouTubePlaylistIdHistory![0].Id.Should().Be(previousId);
+        podcast.YouTubePlaylistIdHistory[0].ReplacedAt.Should().Be(replacedAt);
         logger.Warnings.Should().ContainSingle(m =>
             m.StartsWith(YouTubePlaylistIdChange.ChangedMessagePrefix) &&
             m.Contains($"previous='{previousId}'") &&
@@ -38,8 +43,8 @@ public class YouTubePlaylistIdChangeRules
     }
 
     [Fact(DisplayName =
-        "When Apply is given the same YouTube playlist id already on the podcast, the id is unchanged and no Warning " +
-        "is logged because identical writes are not operator-visible events.")]
+        "When Apply is given the same YouTube playlist id already on the podcast, the id and history are unchanged " +
+        "and no Warning is logged because identical writes are not operator-visible events.")]
     public void Apply_is_noop_when_id_unchanged()
     {
         // Arrange
@@ -53,29 +58,83 @@ public class YouTubePlaylistIdChangeRules
         // Assert
         changed.Should().BeFalse();
         podcast.YouTubePlaylistId.Should().Be(playlistId);
+        podcast.YouTubePlaylistIdHistory.Should().BeNull();
         logger.Warnings.Should().BeEmpty();
     }
 
     [Fact(DisplayName =
-        "When Apply clears a YouTube playlist id to empty, the podcast stores empty and a Warning records the previous id " +
-        "because dropping the release-authority playlist is an operator-visible configuration change.")]
-    public void Apply_logs_when_playlist_id_cleared()
+        "When Apply clears a YouTube playlist id to empty, the previous id is retained in history with replaced-at " +
+        "because dropping the release-authority playlist must still be recoverable.")]
+    public void Apply_appends_history_when_playlist_id_cleared()
     {
         // Arrange
         var previousId = _fixture.CreateYouTubePlaylistId();
+        var replacedAt = DomainTestFixture.UtcAtTime(0, TimeSpan.FromHours(12));
         var podcast = _fixture.CreatePodcast(p => p.YouTubePlaylistId = previousId);
         var logger = new CapturingLogger();
 
         // Act
-        var changed = YouTubePlaylistIdChange.Apply(podcast, string.Empty, logger);
+        var changed = YouTubePlaylistIdChange.Apply(podcast, string.Empty, logger, replacedAt);
 
         // Assert
         changed.Should().BeTrue();
         podcast.YouTubePlaylistId.Should().BeEmpty();
+        podcast.YouTubePlaylistIdHistory.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new YouTubePlaylistIdHistoryEntry
+            {
+                Id = previousId,
+                ReplacedAt = replacedAt
+            });
         logger.Warnings.Should().ContainSingle(m =>
             m.StartsWith(YouTubePlaylistIdChange.ChangedMessagePrefix) &&
             m.Contains($"previous='{previousId}'") &&
             m.Contains("measured=''"));
+    }
+
+    [Fact(DisplayName =
+        "When Apply sets the first YouTube playlist id on a podcast that had none, history stays empty " +
+        "because there is no former id to recover.")]
+    public void Apply_does_not_append_history_when_previous_was_empty()
+    {
+        // Arrange
+        var measuredId = _fixture.CreateYouTubePlaylistId();
+        var podcast = _fixture.CreatePodcast(p => p.YouTubePlaylistId = string.Empty);
+        var logger = new CapturingLogger();
+
+        // Act
+        var changed = YouTubePlaylistIdChange.Apply(podcast, measuredId, logger);
+
+        // Assert
+        changed.Should().BeTrue();
+        podcast.YouTubePlaylistId.Should().Be(measuredId);
+        podcast.YouTubePlaylistIdHistory.Should().BeNull();
+        logger.Warnings.Should().ContainSingle();
+    }
+
+    [Fact(DisplayName =
+        "When Apply changes the playlist id a second time, history appends newest-last so both former ids " +
+        "remain recoverable in chronological order.")]
+    public void Apply_appends_history_newest_last_across_multiple_swaps()
+    {
+        // Arrange
+        var first = _fixture.CreateYouTubePlaylistId();
+        var second = _fixture.CreateYouTubePlaylistId();
+        var third = _fixture.CreateYouTubePlaylistId();
+        var firstReplacedAt = DomainTestFixture.UtcAtTime(-1, TimeSpan.FromHours(10));
+        var secondReplacedAt = DomainTestFixture.UtcAtTime(0, TimeSpan.FromHours(11));
+        var podcast = _fixture.CreatePodcast(p => p.YouTubePlaylistId = first);
+
+        // Act
+        YouTubePlaylistIdChange.Apply(podcast, second, replacedAtUtc: firstReplacedAt);
+        YouTubePlaylistIdChange.Apply(podcast, third, replacedAtUtc: secondReplacedAt);
+
+        // Assert
+        podcast.YouTubePlaylistId.Should().Be(third);
+        podcast.YouTubePlaylistIdHistory.Should().HaveCount(2);
+        podcast.YouTubePlaylistIdHistory![0].Id.Should().Be(first);
+        podcast.YouTubePlaylistIdHistory[0].ReplacedAt.Should().Be(firstReplacedAt);
+        podcast.YouTubePlaylistIdHistory[1].Id.Should().Be(second);
+        podcast.YouTubePlaylistIdHistory[1].ReplacedAt.Should().Be(secondReplacedAt);
     }
 
     [Fact(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/YouTubePlaylistIdChangeRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Playlist/YouTubePlaylistIdChangeRules.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Playlist;
+
+/// <summary>
+/// Operators must see YouTube playlist id swaps in App Insights (e.g. unlisted → public show playlist)
+/// because the configured playlist is release-authority for enrichment and discovery.
+/// </summary>
+public class YouTubePlaylistIdChangeRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "When Apply is given a different YouTube playlist id, the podcast stores the new id and a Warning is logged " +
+        "with the stable prefix so operators can see curated playlist swaps in App Insights.")]
+    public void Apply_changes_id_and_logs_warning_with_stable_prefix()
+    {
+        // Arrange
+        var previousId = _fixture.CreateYouTubePlaylistId();
+        var measuredId = _fixture.CreateYouTubePlaylistId();
+        var podcast = _fixture.CreatePodcast(p => p.YouTubePlaylistId = previousId);
+        var logger = new CapturingLogger();
+
+        // Act
+        var changed = YouTubePlaylistIdChange.Apply(podcast, measuredId, logger);
+
+        // Assert
+        changed.Should().BeTrue();
+        podcast.YouTubePlaylistId.Should().Be(measuredId);
+        logger.Warnings.Should().ContainSingle(m =>
+            m.StartsWith(YouTubePlaylistIdChange.ChangedMessagePrefix) &&
+            m.Contains($"previous='{previousId}'") &&
+            m.Contains($"measured='{measuredId}'") &&
+            m.Contains($"podcast-id='{podcast.Id}'"));
+    }
+
+    [Fact(DisplayName =
+        "When Apply is given the same YouTube playlist id already on the podcast, the id is unchanged and no Warning " +
+        "is logged because identical writes are not operator-visible events.")]
+    public void Apply_is_noop_when_id_unchanged()
+    {
+        // Arrange
+        var playlistId = _fixture.CreateYouTubePlaylistId();
+        var podcast = _fixture.CreatePodcast(p => p.YouTubePlaylistId = playlistId);
+        var logger = new CapturingLogger();
+
+        // Act
+        var changed = YouTubePlaylistIdChange.Apply(podcast, playlistId, logger);
+
+        // Assert
+        changed.Should().BeFalse();
+        podcast.YouTubePlaylistId.Should().Be(playlistId);
+        logger.Warnings.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName =
+        "When Apply clears a YouTube playlist id to empty, the podcast stores empty and a Warning records the previous id " +
+        "because dropping the release-authority playlist is an operator-visible configuration change.")]
+    public void Apply_logs_when_playlist_id_cleared()
+    {
+        // Arrange
+        var previousId = _fixture.CreateYouTubePlaylistId();
+        var podcast = _fixture.CreatePodcast(p => p.YouTubePlaylistId = previousId);
+        var logger = new CapturingLogger();
+
+        // Act
+        var changed = YouTubePlaylistIdChange.Apply(podcast, string.Empty, logger);
+
+        // Assert
+        changed.Should().BeTrue();
+        podcast.YouTubePlaylistId.Should().BeEmpty();
+        logger.Warnings.Should().ContainSingle(m =>
+            m.StartsWith(YouTubePlaylistIdChange.ChangedMessagePrefix) &&
+            m.Contains($"previous='{previousId}'") &&
+            m.Contains("measured=''"));
+    }
+
+    [Fact(DisplayName =
+        "When Apply trims whitespace around a new playlist id, the stored value is trimmed and compared without " +
+        "treating padded duplicates as changes.")]
+    public void Apply_trims_measured_id_and_ignores_whitespace_only_noop()
+    {
+        // Arrange
+        var playlistId = _fixture.CreateYouTubePlaylistId();
+        var podcast = _fixture.CreatePodcast(p => p.YouTubePlaylistId = playlistId);
+        var logger = new CapturingLogger();
+
+        // Act
+        var unchanged = YouTubePlaylistIdChange.Apply(podcast, $"  {playlistId}  ", logger);
+        var clearedByWhitespace = YouTubePlaylistIdChange.Apply(
+            _fixture.CreatePodcast(p => p.YouTubePlaylistId = playlistId),
+            "   ",
+            logger);
+
+        // Assert
+        unchanged.Should().BeFalse();
+        clearedByWhitespace.Should().BeTrue();
+        logger.Warnings.Should().ContainSingle();
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/IYouTubeEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/IYouTubeEpisodeProvider.cs
@@ -26,5 +26,6 @@ public interface IYouTubeEpisodeProvider
         YouTubePlaylistId youTubePlaylistId,
         YouTubeChannelId? youTubeChannelId,
         IndexingContext indexingContext, 
-        bool expensivePlaylist = false);
+        bool expensivePlaylist = false,
+        PlaylistOrder? playlistOrder = null);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
@@ -181,10 +181,12 @@ public class YouTubeEpisodeProvider(
     }
 
     public async Task<GetPlaylistEpisodesResponse> GetPlaylistEpisodes(YouTubePlaylistId youTubePlaylistId,
-        YouTubeChannelId? youTubeChannelId, IndexingContext indexingContext, bool expensivePlaylist = false)
+        YouTubeChannelId? youTubeChannelId, IndexingContext indexingContext, bool expensivePlaylist = false,
+        PlaylistOrder? playlistOrder = null)
     {
-        var playlistQueryResponse = await youTubePlaylistService.GetPlaylistVideoSnippets(new YouTubePlaylistId(
-            youTubePlaylistId.PlaylistId), indexingContext, expensivePlaylist);
+        var playlistQueryResponse = await youTubePlaylistService.GetPlaylistVideoSnippets(
+            new YouTubePlaylistId(youTubePlaylistId.PlaylistId), indexingContext,
+            expensivePlaylist: expensivePlaylist, playlistOrder: playlistOrder);
         var isExpensiveQuery = playlistQueryResponse.IsExpensiveQuery;
         if (playlistQueryResponse.Result == null || !playlistQueryResponse.Result.Any())
         {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Handlers/YouTubeEpisodeRetrievalHandler.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Handlers/YouTubeEpisodeRetrievalHandler.cs
@@ -28,9 +28,15 @@ public class YouTubeEpisodeRetrievalHandler(
 
         if (!string.IsNullOrWhiteSpace(podcast.YouTubePlaylistId))
         {
+            var arbitraryOrder = podcast.HasArbitraryYouTubePlaylistOrder();
             var runExpensivePagination = indexingContext.RunExpensiveYouTubePlaylistPagination(podcast);
-            var discoveryPath = runExpensivePagination ? "playlist-paginated" : "playlist-single-page";
-            if (podcast.HasExpensiveYouTubePlaylistQuery() && indexingContext.SkipExpensiveYouTubeQueries)
+            var discoveryPath = arbitraryOrder
+                ? "playlist-arbitrary-full-walk"
+                : runExpensivePagination
+                    ? "playlist-paginated"
+                    : "playlist-single-page";
+            if (!arbitraryOrder && podcast.HasExpensiveYouTubePlaylistQuery() &&
+                indexingContext.SkipExpensiveYouTubeQueries)
             {
                 logger.LogInformation(
                     "Podcast '{PodcastId}' has known expensive playlist query; using single-page playlist fetch this pass.",
@@ -39,13 +45,16 @@ public class YouTubeEpisodeRetrievalHandler(
 
             var getPlaylistEpisodesResult = await youTubeEpisodeProvider.GetPlaylistEpisodes(
                 new YouTubePlaylistId(podcast.YouTubePlaylistId), new YouTubeChannelId(podcast.YouTubeChannelId),
-                indexingContext, runExpensivePagination);
+                indexingContext, runExpensivePagination, podcast.YouTubePlaylistOrder);
             if (getPlaylistEpisodesResult.Results != null)
             {
                 newEpisodes = getPlaylistEpisodesResult.Results;
             }
 
-            if (getPlaylistEpisodesResult.IsExpensiveQuery.HasValue)
+            // Arbitrary-order playlists never yield a head-order probe result (IsExpensiveQuery stays
+            // null), and even if a probe value sneaks through the expensive flag must stay untouched —
+            // curated playlists have no positional order to learn from.
+            if (!arbitraryOrder && getPlaylistEpisodesResult.IsExpensiveQuery.HasValue)
             {
                 YouTubeExpensiveQueryFlag.Apply(
                     podcast,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Handlers/YouTubeEpisodeRetrievalHandler.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Handlers/YouTubeEpisodeRetrievalHandler.cs
@@ -3,6 +3,7 @@ using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Episode;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 using RedditPodcastPoster.PodcastServices.Abstractions.Handlers;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Extensions;
@@ -44,9 +45,13 @@ public class YouTubeEpisodeRetrievalHandler(
                 newEpisodes = getPlaylistEpisodesResult.Results;
             }
 
-            if (getPlaylistEpisodesResult.IsExpensiveQuery)
+            if (getPlaylistEpisodesResult.IsExpensiveQuery.HasValue)
             {
-                podcast.YouTubePlaylistQueryIsExpensive = true;
+                YouTubeExpensiveQueryFlag.Apply(
+                    podcast,
+                    getPlaylistEpisodesResult.IsExpensiveQuery,
+                    YouTubeExpensiveQueryFlag.MinimumOrderSampleSize,
+                    logger);
             }
 
             LogDiscoveryPath(podcast, discoveryPath, indexingContext, newEpisodes.Count);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Models/GetPlaylistEpisodesResponse.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Models/GetPlaylistEpisodesResponse.cs
@@ -4,4 +4,7 @@ namespace RedditPodcastPoster.PodcastServices.YouTube.Models;
 
 public record GetPlaylistEpisodesResponse(
     IList<EpisodeModel>? Results,
-    bool IsExpensiveQuery = false);
+    /// <summary>
+    /// Playlist-order probe: true = oldest-first (expensive), false = newest-first, null = inconclusive.
+    /// </summary>
+    bool? IsExpensiveQuery = null);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Models/GetPlaylistVideoSnippetsResponse.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Models/GetPlaylistVideoSnippetsResponse.cs
@@ -2,4 +2,9 @@ using Google.Apis.YouTube.v3.Data;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Models;
 
-public record GetPlaylistVideoSnippetsResponse(IList<PlaylistItem>? Result, bool IsExpensiveQuery = false);
+public record GetPlaylistVideoSnippetsResponse(
+    IList<PlaylistItem>? Result,
+    /// <summary>
+    /// Playlist-order probe: true = oldest-first (expensive), false = newest-first, null = inconclusive.
+    /// </summary>
+    bool? IsExpensiveQuery = null);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/ArbitraryYouTubePlaylistWalk.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/ArbitraryYouTubePlaylistWalk.cs
@@ -1,0 +1,38 @@
+namespace RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+
+/// <summary>
+/// Caps arbitrary-order (curated) YouTube playlist walks so a mis-tagged news-channel-scale
+/// playlist cannot burn the YouTube quota. Tripping logs at Error via
+/// <see cref="CircuitBreakerTrippedMessagePrefix"/> because in-window episodes may be missing.
+/// At <see cref="BatchSize"/> items per page, <see cref="MaxPages"/> covers ~1000 playlist items —
+/// enough for curated show playlists, deliberately too small for channel-scale uploads feeds.
+/// </summary>
+public static class ArbitraryYouTubePlaylistWalk
+{
+    /// <summary>
+    /// Full-walk page size — the YouTube API maximum. playlistItems.list costs 1 quota unit per page.
+    /// </summary>
+    public const int BatchSize = 50;
+
+    /// <summary>
+    /// Maximum pages an arbitrary-order walk may fetch. Beyond this, stop and LogError so an
+    /// operator can reclassify the playlist (or shrink it) rather than burn quota.
+    /// </summary>
+    public const int MaxPages = 20;
+
+    public const string CircuitBreakerTrippedMessagePrefix =
+        "YouTube arbitrary-playlist walk circuit-breaker tripped:";
+
+    public const string CircuitBreakerTrippedMessageTemplate =
+        CircuitBreakerTrippedMessagePrefix +
+        " playlist-id='{PlaylistId}' pages-fetched='{PagesFetched}' max-pages='{MaxPages}' " +
+        "released-since='{ReleasedSince}' next='{Next}'. Stopped to protect YouTube quota; " +
+        "in-window episodes may be missing — reclassify or shrink this playlist.";
+
+    /// <summary>
+    /// True when another page remains after <paramref name="pagesFetched"/> fetches and the
+    /// walk must stop. Call before requesting the next page.
+    /// </summary>
+    public static bool ShouldTripCircuitBreaker(int pagesFetched, string? nextPageToken) =>
+        pagesFetched >= MaxPages && !string.IsNullOrEmpty(nextPageToken);
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/CachedTolerantYouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/CachedTolerantYouTubePlaylistService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using Google.Apis.YouTube.v3.Data;
 using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Abstractions.Caches;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
@@ -19,7 +20,8 @@ public class CachedTolerantYouTubePlaylistService(
         YouTubePlaylistId playlistId,
         IndexingContext indexingContext,
         bool withContentDetails = false,
-        bool expensivePlaylist = false)
+        bool expensivePlaylist = false,
+        PlaylistOrder? playlistOrder = null)
     {
         if (_cache.TryGetValue(playlistId.PlaylistId + withContentDetails, out var playlistItems))
         {
@@ -35,7 +37,7 @@ public class CachedTolerantYouTubePlaylistService(
         }
 
         var result = await tolerantYouTubePlaylistService.GetPlaylistVideoSnippets(
-            playlistId, indexingContext, withContentDetails, expensivePlaylist);
+            playlistId, indexingContext, withContentDetails, expensivePlaylist, playlistOrder);
 
         if (result?.Result != null)
         {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/ICachedTolerantYouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/ICachedTolerantYouTubePlaylistService.cs
@@ -1,4 +1,5 @@
-﻿using RedditPodcastPoster.PodcastServices.YouTube.Models;
+﻿using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
 namespace RedditPodcastPoster.PodcastServices.YouTube.Playlist;
@@ -9,5 +10,6 @@ public interface ICachedTolerantYouTubePlaylistService
         YouTubePlaylistId playlistId,
         IndexingContext indexingContext,
         bool withContentDetails = false,
-        bool expensivePlaylist = false);
+        bool expensivePlaylist = false,
+        PlaylistOrder? playlistOrder = null);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/ITolerantYouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/ITolerantYouTubePlaylistService.cs
@@ -1,4 +1,5 @@
-﻿using RedditPodcastPoster.PodcastServices.Abstractions;
+﻿using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 
@@ -10,5 +11,6 @@ public interface ITolerantYouTubePlaylistService
         YouTubePlaylistId playlistId,
         IndexingContext indexingContext,
         bool withContentDetails = false,
-        bool expensivePlaylist = false);
+        bool expensivePlaylist = false,
+        PlaylistOrder? playlistOrder = null);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/IYouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/IYouTubePlaylistService.cs
@@ -1,4 +1,5 @@
-﻿using RedditPodcastPoster.PodcastServices.Abstractions;
+﻿using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
@@ -12,7 +13,8 @@ public interface IYouTubePlaylistService
         YouTubePlaylistId playlistId,
         IndexingContext indexingContext,
         bool withContentDetails = false,
-        bool expensivePlaylist = false);
+        bool expensivePlaylist = false,
+        PlaylistOrder? playlistOrder = null);
 
     Task<GetPlaylistInfoResponse> GetPlaylistInfo(
         IYouTubeServiceWrapper youTubeServiceWrapper,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/TolerantYouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/TolerantYouTubePlaylistService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
@@ -18,7 +19,7 @@ public class TolerantYouTubePlaylistService(
 {
     public async Task<GetPlaylistVideoSnippetsResponse> GetPlaylistVideoSnippets(
         YouTubePlaylistId playlistId, IndexingContext indexingContext, bool withContentDetails = false,
-        bool expensivePlaylist = false)
+        bool expensivePlaylist = false, PlaylistOrder? playlistOrder = null)
     {
         var result = new GetPlaylistVideoSnippetsResponse(null);
         var success = false;
@@ -29,7 +30,7 @@ public class TolerantYouTubePlaylistService(
             {
                 await quotaUsageTracker.RecordCallAsync(youTubeService.CurrentApplication, youTubeService.Usage);
                 result = await youTubePlaylistService.GetPlaylistVideoSnippets(youTubeService, playlistId,
-                    indexingContext, withContentDetails, expensivePlaylist);
+                    indexingContext, withContentDetails, expensivePlaylist, playlistOrder);
                 success = true;
             }
             catch (YouTubeQuotaException)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubeExpensiveQueryFlag.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubeExpensiveQueryFlag.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models.Podcasts;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+
+/// <summary>
+/// Applies a measured YouTube playlist-order probe to <see cref="Podcast.YouTubePlaylistQueryIsExpensive"/>.
+/// Playlists can flip between newest-first and oldest-first, so a conclusive probe both sets and clears
+/// the flag — sticky-true alone permanently misclassifies flipped playlists.
+/// </summary>
+public static class YouTubeExpensiveQueryFlag
+{
+    /// <summary>
+    /// Minimum playlist items required before treating reverse-chrono vs ascending as conclusive.
+    /// A single item cannot distinguish playlist order.
+    /// </summary>
+    public const int MinimumOrderSampleSize = 2;
+
+    public const string FlagFlippedMessagePrefix = "YouTube expensive-query flag flipped:";
+
+    public const string FlagFlippedMessageTemplate =
+        "YouTube expensive-query flag flipped: podcast-id='{PodcastId}' podcast-name='{PodcastName}' youtube-playlist-id='{YouTubePlaylistId}' previous='{Previous}' measured='{Measured}'";
+
+    /// <summary>
+    /// Writes <paramref name="measuredExpensive"/> onto the podcast when the probe is conclusive.
+    /// Returns true when the stored flag value changed.
+    /// </summary>
+    public static bool Apply(
+        Podcast podcast,
+        bool? measuredExpensive,
+        int orderSampleSize,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(podcast);
+
+        if (!measuredExpensive.HasValue || orderSampleSize < MinimumOrderSampleSize)
+        {
+            return false;
+        }
+
+        var previous = podcast.YouTubePlaylistQueryIsExpensive;
+        var measured = measuredExpensive.Value;
+        if (previous == measured)
+        {
+            return false;
+        }
+
+        podcast.YouTubePlaylistQueryIsExpensive = measured;
+        logger?.LogWarning(
+            FlagFlippedMessageTemplate,
+            podcast.Id,
+            podcast.Name,
+            podcast.YouTubePlaylistId,
+            previous,
+            measured);
+        return true;
+    }
+
+    /// <summary>
+    /// Convenience overload when the caller only has a conclusive bool (sample already validated).
+    /// </summary>
+    public static bool Apply(
+        Podcast podcast,
+        bool measuredExpensive,
+        ILogger? logger = null) =>
+        Apply(podcast, measuredExpensive, MinimumOrderSampleSize, logger);
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistIdChange.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistIdChange.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Models.Podcasts;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+
+/// <summary>
+/// Applies a new <see cref="Podcast.YouTubePlaylistId"/> and logs when the value actually changes
+/// so operators can see curated show playlist swaps (e.g. unlisted → public show playlist) in App Insights.
+/// </summary>
+public static class YouTubePlaylistIdChange
+{
+    public const string ChangedMessagePrefix = "YouTube playlist id changed:";
+
+    public const string ChangedMessageTemplate =
+        ChangedMessagePrefix +
+        " podcast-id='{PodcastId}' podcast-name='{PodcastName}' previous='{Previous}' measured='{Measured}'";
+
+    /// <summary>
+    /// Sets <paramref name="newPlaylistId"/> on the podcast when it differs from the stored value.
+    /// Null / whitespace is normalized to empty. Returns true when the stored id changed.
+    /// </summary>
+    public static bool Apply(Podcast podcast, string? newPlaylistId, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(podcast);
+
+        var measured = string.IsNullOrWhiteSpace(newPlaylistId) ? string.Empty : newPlaylistId.Trim();
+        var previous = podcast.YouTubePlaylistId ?? string.Empty;
+        if (string.Equals(previous, measured, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        podcast.YouTubePlaylistId = measured;
+        logger?.LogWarning(
+            ChangedMessageTemplate,
+            podcast.Id,
+            podcast.Name,
+            previous,
+            measured);
+        return true;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistIdChange.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistIdChange.cs
@@ -4,8 +4,9 @@ using RedditPodcastPoster.Models.Podcasts;
 namespace RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 
 /// <summary>
-/// Applies a new <see cref="Podcast.YouTubePlaylistId"/> and logs when the value actually changes
-/// so operators can see curated show playlist swaps (e.g. unlisted → public show playlist) in App Insights.
+/// Applies a new <see cref="Podcast.YouTubePlaylistId"/>, appends the previous non-empty id to
+/// <see cref="Podcast.YouTubePlaylistIdHistory"/>, and logs when the value actually changes so
+/// operators can see curated show playlist swaps and recover if a swap was wrong.
 /// </summary>
 public static class YouTubePlaylistIdChange
 {
@@ -17,9 +18,15 @@ public static class YouTubePlaylistIdChange
 
     /// <summary>
     /// Sets <paramref name="newPlaylistId"/> on the podcast when it differs from the stored value.
-    /// Null / whitespace is normalized to empty. Returns true when the stored id changed.
+    /// Null / whitespace is normalized to empty. When the previous id was non-empty it is appended
+    /// to history with <paramref name="replacedAtUtc"/> (defaults to <see cref="DateTime.UtcNow"/>).
+    /// Returns true when the stored id changed.
     /// </summary>
-    public static bool Apply(Podcast podcast, string? newPlaylistId, ILogger? logger = null)
+    public static bool Apply(
+        Podcast podcast,
+        string? newPlaylistId,
+        ILogger? logger = null,
+        DateTime? replacedAtUtc = null)
     {
         ArgumentNullException.ThrowIfNull(podcast);
 
@@ -28,6 +35,16 @@ public static class YouTubePlaylistIdChange
         if (string.Equals(previous, measured, StringComparison.Ordinal))
         {
             return false;
+        }
+
+        if (!string.IsNullOrEmpty(previous))
+        {
+            podcast.YouTubePlaylistIdHistory ??= [];
+            podcast.YouTubePlaylistIdHistory.Add(new YouTubePlaylistIdHistoryEntry
+            {
+                Id = previous,
+                ReplacedAt = replacedAtUtc ?? DateTime.UtcNow
+            });
         }
 
         podcast.YouTubePlaylistId = measured;

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
@@ -3,6 +3,7 @@ using Google;
 using Google.Apis.YouTube.v3.Data;
 using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Models.Extensions;
+using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
@@ -25,7 +26,8 @@ public class YouTubePlaylistService(
         YouTubePlaylistId playlistId,
         IndexingContext indexingContext,
         bool withContentDetails = false,
-        bool expensivePlaylist = false)
+        bool expensivePlaylist = false,
+        PlaylistOrder? playlistOrder = null)
     {
         if (indexingContext.SkipYouTubeUrlResolving)
         {
@@ -36,8 +38,19 @@ public class YouTubePlaylistService(
             return new GetPlaylistVideoSnippetsResponse(null);
         }
 
+        // Curated playlists carry no date information in their positions: new items may appear at
+        // either end. Walk at max batch size (1 quota unit per 50 items) with a hard page cap
+        // (see ArbitraryYouTubePlaylistWalk.MaxPages) and rely on the ReleasedSince added-at
+        // filter below; skip the head-order probe entirely so the expensive-query flag is never
+        // flipped by a meaningless head sample.
+        var arbitraryOrder = playlistOrder == PlaylistOrder.Arbitrary;
+
         var batchSize = MaxSearchResults;
-        if (indexingContext.ReleasedSince.HasValue)
+        if (arbitraryOrder)
+        {
+            batchSize = ArbitraryYouTubePlaylistWalk.BatchSize;
+        }
+        else if (indexingContext.ReleasedSince.HasValue)
         {
             batchSize = 3;
         }
@@ -47,6 +60,7 @@ public class YouTubePlaylistService(
         var firstRun = true;
         var knownToBeInReverseOrder = false;
         bool? isExpensiveQuery = null;
+        var pagesFetched = 0;
         var requestScope = "snippet";
         if (withContentDetails)
         {
@@ -58,6 +72,19 @@ public class YouTubePlaylistService(
             (firstRun || (knownToBeInReverseOrder && result.Any() && result.Last().Snippet.PublishedAtDateTimeOffset
                 .ReleasedSinceDate(indexingContext.ReleasedSince)) || !knownToBeInReverseOrder))
         {
+            if (arbitraryOrder &&
+                ArbitraryYouTubePlaylistWalk.ShouldTripCircuitBreaker(pagesFetched, nextPageToken))
+            {
+                logger.LogError(
+                    ArbitraryYouTubePlaylistWalk.CircuitBreakerTrippedMessageTemplate,
+                    playlistId.PlaylistId,
+                    pagesFetched,
+                    ArbitraryYouTubePlaylistWalk.MaxPages,
+                    indexingContext.ReleasedSince,
+                    nextPageToken);
+                break;
+            }
+
             var playlistRequest = youTubeServiceWrapper.YouTubeService.PlaylistItems.List(requestScope);
             playlistRequest.PlaylistId = playlistId.PlaylistId;
             playlistRequest.MaxResults = batchSize;
@@ -106,9 +133,15 @@ public class YouTubePlaylistService(
             if (firstRun)
             {
                 firstRun = false;
+                if (arbitraryOrder)
+                {
+                    logger.LogInformation(
+                        "Playlist '{playlistId}' is declared arbitrary-order; walking with batch-size '{batchSize}' capped at '{maxPages}' pages.",
+                        playlistId.PlaylistId, batchSize, ArbitraryYouTubePlaylistWalk.MaxPages);
+                }
                 // Always probe order when a date window is present — even for known-expensive
                 // playlists — so a flip back to newest-first can clear the sticky flag.
-                if (indexingContext.ReleasedSince.HasValue)
+                else if (indexingContext.ReleasedSince.HasValue)
                 {
                     var sample = playlistItemsListResponse.Items?
                         .Where(x => x?.Snippet?.PublishedAtDateTimeOffset != null)
@@ -147,6 +180,7 @@ public class YouTubePlaylistService(
             result.AddRange((playlistItemsListResponse.Items ?? [])
                 .Where(x => x.Snippet.Title != PrivateVideoTitle));
             nextPageToken = playlistItemsListResponse.NextPageToken;
+            pagesFetched++;
         }
 
         if (result.Any() && indexingContext.ReleasedSince != null)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
@@ -46,6 +46,7 @@ public class YouTubePlaylistService(
         var nextPageToken = "";
         var firstRun = true;
         var knownToBeInReverseOrder = false;
+        bool? isExpensiveQuery = null;
         var requestScope = "snippet";
         if (withContentDetails)
         {
@@ -105,18 +106,21 @@ public class YouTubePlaylistService(
             if (firstRun)
             {
                 firstRun = false;
-                if (expensivePlaylist)
+                // Always probe order when a date window is present — even for known-expensive
+                // playlists — so a flip back to newest-first can clear the sticky flag.
+                if (indexingContext.ReleasedSince.HasValue)
                 {
-                    batchSize = 10;
-                }
-                else
-                {
-                    if (indexingContext.ReleasedSince.HasValue)
+                    var sample = playlistItemsListResponse.Items?
+                        .Where(x => x?.Snippet?.PublishedAtDateTimeOffset != null)
+                        .Take(YouTubeExpensiveQueryFlag.MinimumOrderSampleSize + 6)
+                        .ToList() ?? [];
+                    if (sample.Count >= YouTubeExpensiveQueryFlag.MinimumOrderSampleSize)
                     {
-                        knownToBeInReverseOrder = PlaylistItemOrdering.IsReverseDateOrdered(playlistItemsListResponse.Items);
+                        knownToBeInReverseOrder = PlaylistItemOrdering.IsReverseDateOrdered(sample);
+                        isExpensiveQuery = !knownToBeInReverseOrder;
                         if (knownToBeInReverseOrder)
                         {
-                            batchSize = 1;
+                            batchSize = expensivePlaylist ? 10 : 1;
                             logger.LogInformation(
                                 "Playlist '{playlistId}' appears to be in reverse-date order. Setting batch-size to '{batchSize}'.",
                                 playlistId.PlaylistId, batchSize);
@@ -129,10 +133,19 @@ public class YouTubePlaylistService(
                                 playlistId.PlaylistId, batchSize);
                         }
                     }
+                    else if (expensivePlaylist)
+                    {
+                        batchSize = 10;
+                    }
+                }
+                else if (expensivePlaylist)
+                {
+                    batchSize = 10;
                 }
             }
 
-            result.AddRange(playlistItemsListResponse.Items.Where(x => x.Snippet.Title != PrivateVideoTitle));
+            result.AddRange((playlistItemsListResponse.Items ?? [])
+                .Where(x => x.Snippet.Title != PrivateVideoTitle));
             nextPageToken = playlistItemsListResponse.NextPageToken;
         }
 
@@ -142,7 +155,7 @@ public class YouTubePlaylistService(
                 x.Snippet.PublishedAtDateTimeOffset.ReleasedSinceDate(indexingContext.ReleasedSince)).ToList();
         }
 
-        return new GetPlaylistVideoSnippetsResponse(result, !knownToBeInReverseOrder);
+        return new GetPlaylistVideoSnippetsResponse(result, isExpensiveQuery);
     }
 
     public async Task<GetPlaylistInfoResponse> GetPlaylistInfo(IYouTubeServiceWrapper youTubeServiceWrapper,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
@@ -53,7 +53,8 @@ public class YouTubeItemResolver(
     {
         var latestPlaylistItems = await youTubePlaylistService.GetPlaylistVideoSnippets(
             new YouTubePlaylistId(request.Podcast.YouTubePlaylistId), indexingContext, true,
-            indexingContext.RunExpensiveYouTubePlaylistPagination(request.Podcast));
+            indexingContext.RunExpensiveYouTubePlaylistPagination(request.Podcast),
+            request.Podcast.YouTubePlaylistOrder);
         if (latestPlaylistItems?.Result == null)
         {
             return null;

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/Updaters/PodcastUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/Updaters/PodcastUpdater.cs
@@ -179,11 +179,19 @@ public class PodcastUpdater(
         }
 
         var discoveredYouTubeExpensiveQuery = !knownYouTubeExpensiveQuery && podcast.HasExpensiveYouTubePlaylistQuery();
+        var clearedYouTubeExpensiveQuery = knownYouTubeExpensiveQuery && !podcast.HasExpensiveYouTubePlaylistQuery();
         if (discoveredYouTubeExpensiveQuery)
         {
             logger.LogInformation(
                 "Expensive YouTube Query found processing '{podcastName}' with id '{podcast.}' and youtube-channel-id '{podcastYouTubeChannelId}'.",
                 podcast.Name, podcast.Id, podcast.YouTubeChannelId);
+        }
+
+        if (clearedYouTubeExpensiveQuery)
+        {
+            logger.LogWarning(
+                "YouTube expensive-query flag cleared processing '{podcastName}' with id '{podcastId}' and youtube-playlist-id '{podcastYouTubePlaylistId}'; playlist is newest-first again.",
+                podcast.Name, podcast.Id, podcast.YouTubePlaylistId);
         }
 
         var discoveredYouTubeChannelSearchForbidden = !knownYouTubeChannelSearchForbidden &&
@@ -196,10 +204,18 @@ public class PodcastUpdater(
         }
 
         var discoveredSpotifyExpensiveQuery = !knownSpotifyExpensiveQuery && podcast.HasExpensiveSpotifyEpisodesQuery();
+        var clearedSpotifyExpensiveQuery = knownSpotifyExpensiveQuery && !podcast.HasExpensiveSpotifyEpisodesQuery();
         if (discoveredSpotifyExpensiveQuery)
         {
             logger.LogInformation(
                 "Expensive Spotify Query found processing '{podcastName}' with id '{podcastId}' and spotify-id '{podcastSpotifyId}'.",
+                podcast.Name, podcast.Id, podcast.SpotifyId);
+        }
+
+        if (clearedSpotifyExpensiveQuery)
+        {
+            logger.LogWarning(
+                "Spotify expensive-query flag cleared processing '{podcastName}' with id '{podcastId}' and spotify-id '{podcastSpotifyId}'; catalogue is newest-first again.",
                 podcast.Name, podcast.Id, podcast.SpotifyId);
         }
 
@@ -218,8 +234,9 @@ public class PodcastUpdater(
 
         var podcastChanged = mergeResult.MergedEpisodes.Any() || mergeResult.AddedEpisodes.Any() ||
                              filterResult.FilteredEpisodes.Any() || enrichmentResult.UpdatedEpisodes.Any() ||
-                             discoveredYouTubeExpensiveQuery || discoveredYouTubeChannelSearchForbidden ||
-                             discoveredSpotifyExpensiveQuery;
+                             discoveredYouTubeExpensiveQuery || clearedYouTubeExpensiveQuery ||
+                             discoveredYouTubeChannelSearchForbidden ||
+                             discoveredSpotifyExpensiveQuery || clearedSpotifyExpensiveQuery;
 
         if (indexSucceeded)
         {

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
@@ -6,6 +6,7 @@ using RedditPodcastPoster.Subjects.Enrichers;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Models;
 using RedditPodcastPoster.People.Enrichers;
+using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 
 namespace RedditPodcastPoster.UrlSubmission.Factories;
 
@@ -49,7 +50,10 @@ public class PodcastAndEpisodeFactory(
         newPodcast.SpotifyId = categorisedItem.ResolvedSpotifyItem?.ShowId ?? string.Empty;
         newPodcast.AppleId = categorisedItem.ResolvedAppleItem?.ShowId;
         newPodcast.YouTubeChannelId = categorisedItem.ResolvedYouTubeItem?.ShowId ?? string.Empty;
-        newPodcast.YouTubePlaylistId = categorisedItem.ResolvedYouTubeItem?.PlaylistId ?? string.Empty;
+        YouTubePlaylistIdChange.Apply(
+            newPodcast,
+            categorisedItem.ResolvedYouTubeItem?.PlaylistId ?? string.Empty,
+            logger);
 
         if (!string.IsNullOrWhiteSpace(newPodcast.YouTubeChannelId))
         {

--- a/Cloud/Api/Dtos/Extensions/PodcastExtension.cs
+++ b/Cloud/Api/Dtos/Extensions/PodcastExtension.cs
@@ -32,6 +32,7 @@ public static class PodcastExtension
             IgnoreAllEpisodes = podcast.IgnoreAllEpisodes ?? false,
             YouTubeChannelId = podcast.YouTubeChannelId,
             YouTubePlaylistId = podcast.YouTubePlaylistId,
+            YouTubePlaylistIdHistory = podcast.YouTubePlaylistIdHistory?.ToArray(),
             IgnoredAssociatedSubjects = podcast.IgnoredAssociatedSubjects,
             IgnoredSubjects = podcast.IgnoredSubjects,
             KnownTerms = podcast.KnownTerms,

--- a/Cloud/Api/Dtos/PodcastDto.cs
+++ b/Cloud/Api/Dtos/PodcastDto.cs
@@ -88,6 +88,10 @@ public class PodcastDto
     [JsonPropertyName("youTubePlaylistId")]
     public string? YouTubePlaylistId { get; set; }
 
+    /// <summary>Former YouTube playlist ids (id + replaced-at UTC), newest last. Read-only for operators.</summary>
+    [JsonPropertyName("youTubePlaylistIdHistory")]
+    public YouTubePlaylistIdHistoryEntry[]? YouTubePlaylistIdHistory { get; set; }
+
     [JsonPropertyName("ignoredAssociatedSubjects")]
     public string[]? IgnoredAssociatedSubjects { get; set; }
 

--- a/Cloud/Api/Services/Episodes/EpisodeChangeApplier.cs
+++ b/Cloud/Api/Services/Episodes/EpisodeChangeApplier.cs
@@ -1,6 +1,7 @@
 using Api.Models;
 using Microsoft.Extensions.Logging;
 using Episode = RedditPodcastPoster.Models.Episodes.Episode;
+using RedditPodcastPoster.Bluesky.Logging;
 using RedditPodcastPoster.Models.Episodes;
 using RedditPodcastPoster.PodcastServices.Abstractions.Categorisers;
 using RedditPodcastPoster.PodcastServices.Apple;
@@ -92,8 +93,18 @@ public class EpisodeChangeApplier(ILogger<EpisodeChangeApplier> logger)
                 changeState.UnBlueskyPost = true;
             }
 
+            var settingFlagWithoutPost = episodeChangeRequest.BlueskyPosted.Value &&
+                                         episode.BlueskyPosted != true;
             episode.BlueskyPosted =
                 episodeChangeRequest.BlueskyPosted.HasValue && episodeChangeRequest.BlueskyPosted.Value ? true : null;
+            if (settingFlagWithoutPost)
+            {
+                BlueskyPostLogger.LogFlagSetWithoutPost(
+                    logger,
+                    episode,
+                    episode.PodcastId,
+                    caller: nameof(EpisodeChangeApplier) + "." + nameof(Apply));
+            }
         }
 
         if (episodeChangeRequest.Subjects != null && episode.ApplyUserSubjects(episodeChangeRequest.Subjects))

--- a/Cloud/Api/Services/Podcasts/PodcastChangeApplier.cs
+++ b/Cloud/Api/Services/Podcasts/PodcastChangeApplier.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using DomainPodcast = RedditPodcastPoster.Models.Podcasts.Podcast;
 using Api.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 
 namespace Api.Services.Podcasts;
 
@@ -101,7 +102,7 @@ public class PodcastChangeApplier(ILogger<PodcastChangeApplier> logger)
 
         if (podcastChangeRequest.YouTubePlaylistId != null)
         {
-            podcast.YouTubePlaylistId = podcastChangeRequest.YouTubePlaylistId;
+            YouTubePlaylistIdChange.Apply(podcast, podcastChangeRequest.YouTubePlaylistId, logger);
         }
 
         if (podcastChangeRequest.SkipEnrichingFromYouTube != null)

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/BlueskyPostLoggerRules.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/BlueskyPostLoggerRules.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using RedditPodcastPoster.Bluesky.Logging;
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
+using Xunit;
+
+namespace FunctionHost.Tests.Api;
+
+public class BlueskyPostLoggerRules
+{
+    [Fact(DisplayName = "FormatPostedMessage uses stable Bluesky posted: prefix and includes ids/urls.")]
+    public void format_posted_message_includes_provenance_and_urls()
+    {
+        var episodeId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var podcastId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var podcast = new Podcast
+        {
+            Id = podcastId,
+            Name = "Preacher Boys Podcast"
+        };
+        var episode = new Episode
+        {
+            Id = episodeId,
+            PodcastId = podcastId,
+            Title = "Pastor Kenny Baldwin",
+            Urls = new ServiceUrls
+            {
+                Spotify = new Uri("https://open.spotify.com/episode/spotifyEp123"),
+                YouTube = new Uri("https://www.youtube.com/watch?v=ytVid456"),
+                Apple = new Uri("https://podcasts.apple.com/us/podcast/id1?i=9876543210")
+            }
+        };
+        var podcastEpisode = new PodcastEpisode(podcast, episode);
+
+        var message = BlueskyPostLogger.FormatPostedMessage(
+            podcastEpisode,
+            caller: "BlueskyPoster.Post");
+
+        message.Should().StartWith(BlueskyPostLogger.PostedMessagePrefix);
+        message.Should().Contain($"episode-id='{episodeId}'");
+        message.Should().Contain("title='Pastor Kenny Baldwin'");
+        message.Should().Contain($"podcast-id='{podcastId}'");
+        message.Should().Contain("podcast-name='Preacher Boys Podcast'");
+        message.Should().Contain("caller='BlueskyPoster.Post'");
+        message.Should().Contain("spotify-url='https://open.spotify.com/episode/spotifyEp123'");
+        message.Should().Contain("youtube-url='https://www.youtube.com/watch?v=ytVid456'");
+        message.Should().Contain("apple-url='https://podcasts.apple.com/us/podcast/id1?i=9876543210'");
+    }
+}

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/BlueskyPostLoggerRules.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/BlueskyPostLoggerRules.cs
@@ -1,49 +1,48 @@
 using FluentAssertions;
 using RedditPodcastPoster.Bluesky.Logging;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.Models.Episodes;
-using RedditPodcastPoster.Models.Podcasts;
 using Xunit;
 
 namespace FunctionHost.Tests.Api;
 
 public class BlueskyPostLoggerRules
 {
-    [Fact(DisplayName = "FormatPostedMessage uses stable Bluesky posted: prefix and includes ids/urls.")]
-    public void format_posted_message_includes_provenance_and_urls()
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "A Bluesky post message carries the stable prefix plus episode, podcast, caller and every platform url " +
+        "because App Insights answers post provenance by searching that one line.")]
+    public void posted_message_carries_provenance_and_platform_urls()
     {
-        var episodeId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
-        var podcastId = Guid.Parse("11111111-2222-3333-4444-555555555555");
-        var podcast = new Podcast
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        var spotifyId = _fixture.CreateSpotifyId();
+        var youTubeId = _fixture.CreateYouTubeId();
+        var appleId = _fixture.CreateAppleId();
+        var episode = _fixture.CreateStoredEpisode(podcast, e =>
         {
-            Id = podcastId,
-            Name = "Preacher Boys Podcast"
-        };
-        var episode = new Episode
-        {
-            Id = episodeId,
-            PodcastId = podcastId,
-            Title = "Pastor Kenny Baldwin",
-            Urls = new ServiceUrls
-            {
-                Spotify = new Uri("https://open.spotify.com/episode/spotifyEp123"),
-                YouTube = new Uri("https://www.youtube.com/watch?v=ytVid456"),
-                Apple = new Uri("https://podcasts.apple.com/us/podcast/id1?i=9876543210")
-            }
-        };
-        var podcastEpisode = new PodcastEpisode(podcast, episode);
+            e.SpotifyId = spotifyId;
+            e.YouTubeId = youTubeId;
+            e.AppleId = appleId;
+            e.Urls.Spotify = _fixture.DefaultSpotifyUrl(spotifyId);
+            e.Urls.YouTube = _fixture.DefaultYouTubeUrl(youTubeId);
+            e.Urls.Apple = _fixture.DefaultAppleUrl(appleId);
+        });
+        var caller = _fixture.Create<string>();
 
-        var message = BlueskyPostLogger.FormatPostedMessage(
-            podcastEpisode,
-            caller: "BlueskyPoster.Post");
+        // Act
+        var message = BlueskyPostLogger.FormatPostedMessage(new PodcastEpisode(podcast, episode), caller);
 
+        // Assert
         message.Should().StartWith(BlueskyPostLogger.PostedMessagePrefix);
-        message.Should().Contain($"episode-id='{episodeId}'");
-        message.Should().Contain("title='Pastor Kenny Baldwin'");
-        message.Should().Contain($"podcast-id='{podcastId}'");
-        message.Should().Contain("podcast-name='Preacher Boys Podcast'");
-        message.Should().Contain("caller='BlueskyPoster.Post'");
-        message.Should().Contain("spotify-url='https://open.spotify.com/episode/spotifyEp123'");
-        message.Should().Contain("youtube-url='https://www.youtube.com/watch?v=ytVid456'");
-        message.Should().Contain("apple-url='https://podcasts.apple.com/us/podcast/id1?i=9876543210'");
+        message.Should().Contain($"episode-id='{episode.Id}'");
+        message.Should().Contain($"title='{episode.Title}'");
+        message.Should().Contain($"podcast-id='{podcast.Id}'");
+        message.Should().Contain($"podcast-name='{podcast.Name}'");
+        message.Should().Contain($"caller='{caller}'");
+        message.Should().Contain($"spotify-url='{episode.Urls.Spotify}'");
+        message.Should().Contain($"youtube-url='{episode.Urls.YouTube}'");
+        message.Should().Contain($"apple-url='{episode.Urls.Apple}'");
     }
 }

--- a/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHost.Tests.csproj
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHost.Tests.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.Episodes.TestSupport\RedditPodcastPoster.Episodes.TestSupport.csproj" />
     <ProjectReference Include="..\..\Azure\Azure.csproj" />
     <ProjectReference Include="..\..\Api\Api.csproj" />
     <ProjectReference Include="..\..\Discovery\Discovery.csproj" />

--- a/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubePodcastProcessor.cs
+++ b/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubePodcastProcessor.cs
@@ -139,10 +139,19 @@ public class EnrichYouTubePodcastProcessor(
         }
 
         if (!string.IsNullOrWhiteSpace(request.PlaylistId) &&
-            playlistQueryResponse.IsExpensiveQuery && !request.AcknowledgeExpensiveYouTubePlaylistQuery)
+            playlistQueryResponse.IsExpensiveQuery == true && !request.AcknowledgeExpensiveYouTubePlaylistQuery)
         {
             logger.LogError("Querying '{playlistId}' is noted for being an expensive query.", playlistId);
             return;
+        }
+
+        if (playlistQueryResponse.IsExpensiveQuery.HasValue)
+        {
+            YouTubeExpensiveQueryFlag.Apply(
+                podcast,
+                playlistQueryResponse.IsExpensiveQuery,
+                YouTubeExpensiveQueryFlag.MinimumOrderSampleSize,
+                logger);
         }
 
         // Get existing episodes from detached repository

--- a/docs/catalogue-pagination.md
+++ b/docs/catalogue-pagination.md
@@ -1,0 +1,329 @@
+# Catalogue & playlist pagination (Spotify + YouTube)
+
+**Cold-start reference** for how Cult Podcasts discovers recent episodes from Spotify
+show catalogues and YouTube playlists without burning API quota. Read this before
+changing paginators, expensive-query flags, `PlaylistOrder`, or indexer skip gates.
+
+| Companion | Purpose |
+|-----------|---------|
+| [youtube-playlist-order.md](youtube-playlist-order.md) | YouTube-only depth: Arbitrary playlists, known-ID probe sketch, curated failure modes |
+| [indexing-app-insights-queries.md](indexing-app-insights-queries.md) | Operator KQL for circuit-breaker / flag-flip log lines |
+| [post-migration/cost-analysis.md](post-migration/cost-analysis.md) | Hourly pass shaping that sets `SkipExpensive*` |
+
+---
+
+## 1. Why this exists
+
+Both Spotify and YouTube return paginated catalogues. Recent episodes are **not** always
+on page one:
+
+| Observed layout | Where recent episodes live | Cheap strategy |
+|-----------------|----------------------------|----------------|
+| Newest-first (reverse-chronological) | Head of the list | Page from offset/page 0; stop when items fall before `ReleasedSince` |
+| Oldest-first (ascending) | Tail of the list | Spotify: jump to last page and walk back. YouTube: no end-jump API → full walk (expensive) |
+| Arbitrary / curated | Either end, inconsistently | YouTube only: capped full walk + filter on added-at; never trust position |
+
+Mis-classifying order causes either **missed episodes** (early-stop on a stale head) or
+**quota burn** (unbounded walks on news-channel-scale feeds). The system therefore:
+
+1. **Probes** order from a small lead-in sample when possible.
+2. **Persists** an expensive-query flag so later passes know the cheap path.
+3. **Caps** walks that cannot early-stop, and **LogError**s when a cap trips so operators notice.
+
+---
+
+## 2. Shared concepts
+
+### `ReleasedSince`
+
+Indexing windows pass `IndexingContext.ReleasedSince`. Date-scoped walks must stop (or
+filter) once items fall outside that window. Spotify truncates to **date-only** before
+comparing (catalogue releases have no reliable time-of-day). YouTube playlist items use
+`snippet.publishedAt` = **added-to-playlist** time for playlist walks.
+
+### Expensive-query flags (podcast document)
+
+| Field | Platform | Meaning when `true` |
+|-------|----------|---------------------|
+| `spotifyEpisodesQueryIsExpensive` | Spotify | Catalogue is oldest-first; recent episodes are near the end |
+| `youTubePlaylistQueryIsExpensive` | YouTube | Playlist head is not newest-first; needs a full / expensive walk |
+
+Both flags are **nullable**. Helpers `HasExpensiveSpotifyEpisodesQuery()` /
+`HasExpensiveYouTubePlaylistQuery()` are true only when the value is explicitly `true`.
+
+**Lifecycle (both platforms):**
+
+1. A conclusive order probe (≥ 2 dated samples) measures newest-first vs ascending.
+2. Discovery applies the measurement via `*ExpensiveQueryFlag.Apply` — **sets and clears**.
+   Sticky-true alone permanently misclassifies flipped catalogues.
+3. Inconclusive probes (null / sample too thin) leave the stored flag untouched.
+4. Flag flips log **Warning** with a stable prefix (see §7).
+5. Indexer persists the podcast when the flag changed.
+
+### Skip gates (`IndexingContext`)
+
+| Flag | Default | Hourly indexer allows expensive when |
+|------|---------|--------------------------------------|
+| `SkipExpensiveSpotifyQueries` | `true` | Primary pass **and** `hour % 6 == 0` |
+| `SkipExpensiveYouTubeQueries` | `true` | Primary pass **and** `hour % 24 == 0` (midnight UTC) |
+
+Console / API submit / discovery curation often set these to `false`.
+
+`IndexingStrategy` owns the hour formulas; `Indexer` combines them with
+`IsPrimaryPass(pass, totalPasses)`.
+
+---
+
+## 3. Spotify catalogue pagination
+
+### Components
+
+| Piece | Path |
+|-------|------|
+| Orchestrator (probe + strategy) | `PodcastServices.Spotify/Paginators/SpotifyQueryPaginator.cs` |
+| Lead-in sample | `NullEpisodesLeadInPaginator.cs` (up to 3 non-null episodes) |
+| Newest-first / forward crawl | `SimpleEpisodePaginator.cs` |
+| Oldest-first end-jump | `AscendingEpisodePaginator.cs` |
+| Factory | `SpotifyEpisodePaginatorFactory.cs` |
+| Flag apply | `Models/SpotifyExpensiveQueryFlag.cs` |
+| Provider gates / page sizes | `Providers/SpotifyPodcastEpisodesProvider.cs` |
+| Discovery applies flag | `SpotifyEpisodeRetrievalHandler.cs` |
+| Enrichment applies flag | `Enrichers/SpotifyExpensiveQuerySideEffect.cs` |
+
+### Decision flow
+
+```
+GetShowEpisodes (first page)
+        │
+        ▼
+Lead-in: up to 3 non-null episodes
+        │
+        ▼
+Probe: releases monotonically non-increasing?
+        │
+        ├─ yes (≥2) → ExpensiveQueryFound = false → reverse-chrono Simple walk
+        ├─ no  (≥2) → ExpensiveQueryFound = true  → Ascending end-jump
+        └─ <2       → ExpensiveQueryFound = null  → flag unchanged; treat as reverse for walk
+        │
+        ▼
+ReleasedSince == null?  → PaginateAll (full catalogue; rare for indexer)
+ReleasedSince set       → date-scoped strategy above
+        │
+        ▼
+Final filter: release date >= ReleasedSince.Date
+```
+
+The **live probe** chooses this request's walk. The **stored**
+`SpotifyEpisodesQueryIsExpensive` mainly drives first-page `Limit` and SkipExpensive gating.
+
+### Paginators & caps
+
+| Mode | Paginator | Cap | Stop condition |
+|------|-----------|-----|----------------|
+| Newest-first + `ReleasedSince` | `SimpleEpisodePaginator(isInReverseOrder: true)` | **None** | Last in-window episode falls before `ReleasedSince` |
+| Oldest-first + `ReleasedSince` | `AscendingEpisodePaginator` | `MaxWalkBackPages = 5` | Page contains any out-of-window item, or walk-back cap |
+| Forward fallback (missing Total/Limit) | `SimpleEpisodePaginator(isInReverseOrder: false)` | `MaxPages = 20` | Cap or catalogue end |
+| No `ReleasedSince` | `PaginateAll` | Unbounded | Catalogue end |
+
+Ascending end-jump:
+
+1. Requires `Paging.Total` and `Limit` (> 0); else warn and fall back to capped forward walk.
+2. `finalOffset = max(0, ((total - 1) / limit) * limit)` — last non-empty page.
+3. Fetch that page; yield in-window items; if any item is out of window, stop (older pages are older).
+4. Else follow `Previous` up to `MaxWalkBackPages`.
+
+### Provider SkipExpensive carve-out
+
+| SkipExpensive | HasExpensive | ReleasedSince | Effect |
+|---------------|--------------|---------------|--------|
+| true | true | **null** | Skip pagination — known-id: first page only; name-path: empty |
+| true | true | **set** | **Still paginate** (bounded date-scoped path — safe) |
+| false / not expensive | * | * | Normal pagination |
+
+**Intentional divergence:** `SpotifyUrlCategoriser` (MatchOtherServices) skips FindEpisode
+whenever expensive + SkipExpensive — **no ReleasedSince exception**. URL matching on
+non-primary passes must not start catalogue walks even when discovery would.
+
+### First-page `Limit` (when `ReleasedSince` set)
+
+| Path | Expensive | Limit |
+|------|-----------|-------|
+| Known Spotify show id | true | **50** (fewer walk-back hops) |
+| Known Spotify show id | false | **5** |
+| Name-discovery | * | **50** |
+
+### Business-rule tests (Spotify)
+
+| Rule area | Test file |
+|-----------|-----------|
+| Ascending end-jump, walk-back cap, fallback | `Spotify.Tests/BusinessRules/Paginators/AscendingEpisodePaginatorRules.cs` |
+| Simple MaxPages, reverse-chrono no-cap, null slots | `.../SimpleEpisodePaginatorRules.cs` |
+| Factory selection | `.../SpotifyEpisodePaginatorFactoryRules.cs` |
+| Probe / strategy / date truncate | `.../SpotifyQueryPaginatorRules.cs` |
+| Lead-in null handling | `.../NullEpisodesLeadInPaginatorRules.cs` |
+| Flag set / clear / inconclusive | `.../Models/SpotifyExpensiveQueryFlagRules.cs` |
+| Provider Limit + SkipExpensive | `.../Providers/SpotifyPodcastEpisodesProviderRules.cs` |
+| Discovery persists flag | `.../SpotifyEpisodeRetrievalHandlerRules.cs` |
+| Enrichment side-effect | `.../Enrichers/SpotifyExpensiveQuerySideEffectRules.cs` |
+| Categoriser hard-skip (no ReleasedSince carve-out) | `.../Categorisers/SpotifyUrlCategoriserRules.cs` |
+| Pipeline persistence | `PodcastServices.Tests/BusinessRules/Indexing/IndexingOrchestrationRules.cs` |
+
+---
+
+## 4. YouTube playlist pagination
+
+### Components
+
+| Piece | Path |
+|-------|------|
+| Pagination loop | `PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs` |
+| Head-order probe | `PlaylistItemOrdering.cs` |
+| Arbitrary walk caps | `ArbitraryYouTubePlaylistWalk.cs` |
+| Flag apply | `YouTubeExpensiveQueryFlag.cs` |
+| Tolerant / cached wrappers | `TolerantYouTubePlaylistService.cs`, `CachedTolerantYouTubePlaylistService.cs` |
+| Episode materialisation | `Episode/YouTubeEpisodeProvider.cs` |
+| Discovery (applies flag) | `Handlers/YouTubeEpisodeRetrievalHandler.cs` |
+| Enrichment (does **not** apply flag) | `Resolvers/YouTubeUrlResolver.cs` (`YouTubeItemResolver`) |
+| Model | `Models/Podcasts/PlaylistOrder.cs`, `Podcast.YouTubePlaylistOrder` |
+
+### `youTubePlaylistOrder` (`PlaylistOrder?`)
+
+| Value | Behaviour |
+|-------|-----------|
+| `null` (default) | Probe head each windowed pass; maintain `youTubePlaylistQueryIsExpensive` |
+| `Arbitrary` | Curated playlist; position carries no date info; capped full walk; flag untouched |
+| `ReverseChronological` / `Ascending` | Reserved for future probe-written classification; **not consumed yet** |
+
+Set manually (or via future known-ID probe). See [youtube-playlist-order.md](youtube-playlist-order.md).
+
+### Decision flow (null order — probed)
+
+```
+playlistItems.list (small first page)
+        │
+        ▼
+Sample ≥ 2 dated items?
+        │
+        ├─ IsReverseDateOrdered → newest-first early-stop (batch 1 or 10)
+        │                         IsExpensiveQuery = false
+        └─ else                  → ascending full walk (batch 10)
+                                  IsExpensiveQuery = true
+        │
+        ▼
+Continue while nextPageToken != null
+  AND (not reverse-chrono OR last item still in ReleasedSince window)
+        │
+        ▼
+Filter results by ReleasedSince (added-at)
+Discovery: YouTubeExpensiveQueryFlag.Apply (unless Arbitrary)
+```
+
+**Equal timestamps:** bulk-added items share the same added-at. Equal pairs satisfy
+`IsReverseDateOrdered` (non-ascending). That mis-classifies some curated playlists as
+newest-first — the main reason `Arbitrary` exists.
+
+### Arbitrary mode
+
+- Batch size **50** (`ArbitraryYouTubePlaylistWalk.BatchSize`).
+- No head-order probe; `IsExpensiveQuery` stays `null`.
+- Handler never Applys the expensive flag (defense in depth even if a probe sneaks through).
+- `SkipExpensiveYouTubeQueries` does **not** degrade to a single page — the capped walk is
+  the only correct read.
+- Circuit breaker: `MaxPages = 20` (~1000 items). Before fetching past the budget with a
+  next token remaining → **LogError** and stop (prefer operator signal over quota burn).
+
+### `RunExpensiveYouTubePlaylistPagination`
+
+```text
+HasExpensiveYouTubePlaylistQuery() && !SkipExpensiveYouTubeQueries
+```
+
+Passed as `expensivePlaylist` into the service. Affects **batch size after a reverse-chrono
+probe** (1 vs 10). If the live head probe says ascending, the service still walks until
+`nextPageToken` is null even when `expensivePlaylist` is false — the handler's
+`"playlist-single-page"` label means “this pass did not request expensive batch sizing,”
+not a hard one-page stop inside `YouTubePlaylistService`.
+
+### Discovery vs enrichment
+
+| Concern | Discovery | Enrichment |
+|---------|-----------|------------|
+| Entry | `YouTubeEpisodeRetrievalHandler` | `YouTubeItemResolver` |
+| Forwards `YouTubePlaylistOrder` | Yes | Yes |
+| Applies expensive flag | **Yes** (unless Arbitrary) | **No** |
+| Path log | `YouTubeDiscoveryPath` (`playlist-arbitrary-full-walk` / `playlist-paginated` / `playlist-single-page` / `channel`) | Match via `PlaylistItemFinder` |
+
+### YouTube API cost reminder
+
+`playlistItems.list` = **1 quota unit per page**. `search.list` = **100**. A capped
+Arbitrary walk of 20×50 items costs ≤ 20 units — far cheaper than one channel search, but
+still must be capped so a mis-tagged uploads feed cannot empty the daily key budget.
+
+### Business-rule tests (YouTube)
+
+| Rule area | Test file |
+|-----------|-----------|
+| Arbitrary MaxPages / message prefix / item budget | `YouTube.Tests/Playlist/ArbitraryYouTubePlaylistWalkRules.cs` |
+| Head-order probe (incl. equal timestamps) | `YouTube.Tests/Playlist/PlaylistItemOrderingRules.cs` |
+| Flag Apply set / clear / inconclusive | `YouTube.Tests/Playlist/YouTubeExpensiveQueryFlagRules.cs` |
+| Discovery flag round-trip + Arbitrary | `YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerRules.cs` |
+| Discovery path wiring | `YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerTests.cs` |
+| `RunExpensiveYouTubePlaylistPagination` | `YouTube.Tests/IndexingContextExtensionsTests.cs` |
+| Pipeline persistence | `PodcastServices.Tests/BusinessRules/Indexing/IndexingOrchestrationRules.cs` |
+
+---
+
+## 5. Side-by-side comparison
+
+| Concern | Spotify | YouTube |
+|---------|---------|---------|
+| Newest-first strategy | Reverse-chrono Simple; stop on `ReleasedSince` | Early-stop while last added-at in window |
+| Oldest-first strategy | End-jump + walk back (`MaxWalkBackPages=5`) | Full forward walk (no API end-jump) |
+| Arbitrary / curated | N/A (catalogue is API-ordered) | `PlaylistOrder.Arbitrary` + capped walk |
+| Forward / unordered cap | `SimpleEpisodePaginator.MaxPages=20` | `ArbitraryYouTubePlaylistWalk.MaxPages=20` |
+| Order probe sample | Lead-in ≤ 3 episodes | First page sample (≥ 2 dated) |
+| Flag cleared on flip to newest-first | Yes | Yes |
+| Expensive allowed (hourly) | `hour % 6 == 0` + primary pass | `hour % 24 == 0` + primary pass |
+| SkipExpensive + ReleasedSince still walks | Provider: **yes** | Arbitrary: always; ascending known-expensive: still may full-walk on live probe |
+| Circuit-breaker log level | **Error** | **Error** (Arbitrary) |
+| Flag-flip log level | **Warning** | **Warning** |
+
+---
+
+## 6. Operator playbook
+
+| Symptom | Likely cause | Check |
+|---------|--------------|-------|
+| Recent episode missing Spotify URL | Ascending catalogue + skip-expensive without window; or walk-back circuit breaker | Flag flip / circuit-breaker Error; `ReleasedSince` window |
+| Recent YouTube URL missing on curated show | Playlist not `Arbitrary`, or wrong playlist id, or Arbitrary cap tripped | `youTubePlaylistOrder`, playlist id, Arbitrary circuit-breaker Error |
+| Expensive flag stuck `true` forever | Probe never returned conclusive newest-first (should not happen — Apply clears) | Flag-flip Warning history |
+| Quota spike on YouTube | Mis-tagged Arbitrary on a huge playlist; or many ascending full walks | Arbitrary circuit-breaker; hour-0 expensive YouTube pass |
+
+---
+
+## 7. Stable log prefixes (App Insights)
+
+| Prefix | Level | Source |
+|--------|-------|--------|
+| `Spotify pagination circuit-breaker tripped:` | Error | `SimpleEpisodePaginator`, `AscendingEpisodePaginator` |
+| `Spotify expensive-query flag flipped:` | Warning | `SpotifyExpensiveQueryFlag` |
+| `YouTube expensive-query flag flipped:` | Warning | `YouTubeExpensiveQueryFlag` |
+| `YouTube arbitrary-playlist walk circuit-breaker tripped:` | Error | `YouTubePlaylistService` via `ArbitraryYouTubePlaylistWalk` |
+| `YouTubeDiscoveryPath` | Info / Warning | `YouTubeEpisodeRetrievalHandler` |
+
+KQL: [indexing-app-insights-queries.md](indexing-app-insights-queries.md).
+
+---
+
+## 8. Agent / contributor checklist
+
+Before changing pagination, order probes, flags, or `PlaylistOrder`:
+
+- [ ] Re-read this doc and the platform companion (YouTube: [youtube-playlist-order.md](youtube-playlist-order.md))
+- [ ] Update or add a `BusinessRules/**` test with `DisplayName` stating the rule (see `.cursor/rules/unit-tests.mdc`)
+- [ ] Keep circuit-breaker / flag-flip **message prefixes** stable — App Insights alerts key off them
+- [ ] Do not invent a third Spotify order mode without an end-jump or hard cap
+- [ ] Do not remove Arbitrary's `MaxPages` cap
+- [ ] Do not make expensive-query flags sticky-true-only
+- [ ] If changing hourly gates, update `IndexingStrategy` tests / cost-analysis notes
+- [ ] Run `dotnet test` on affected `*Tests` projects + `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged`

--- a/docs/catalogue-pagination.md
+++ b/docs/catalogue-pagination.md
@@ -308,6 +308,7 @@ still must be capped so a mis-tagged uploads feed cannot empty the daily key bud
 | `Spotify pagination circuit-breaker tripped:` | Error | `SimpleEpisodePaginator`, `AscendingEpisodePaginator` |
 | `Spotify expensive-query flag flipped:` | Warning | `SpotifyExpensiveQueryFlag` |
 | `YouTube expensive-query flag flipped:` | Warning | `YouTubeExpensiveQueryFlag` |
+| `YouTube playlist id changed:` | Warning | `YouTubePlaylistIdChange` (API / URL-submit playlist swaps) |
 | `YouTube arbitrary-playlist walk circuit-breaker tripped:` | Error | `YouTubePlaylistService` via `ArbitraryYouTubePlaylistWalk` |
 | `YouTubeDiscoveryPath` | Info / Warning | `YouTubeEpisodeRetrievalHandler` |
 

--- a/docs/catalogue-pagination.md
+++ b/docs/catalogue-pagination.md
@@ -184,7 +184,7 @@ non-primary passes must not start catalogue walks even when discovery would.
 | Episode materialisation | `Episode/YouTubeEpisodeProvider.cs` |
 | Discovery (applies flag) | `Handlers/YouTubeEpisodeRetrievalHandler.cs` |
 | Enrichment (does **not** apply flag) | `Resolvers/YouTubeUrlResolver.cs` (`YouTubeItemResolver`) |
-| Model | `Models/Podcasts/PlaylistOrder.cs`, `Podcast.YouTubePlaylistOrder` |
+| Model | `Models/Podcasts/PlaylistOrder.cs`, `Podcast.YouTubePlaylistOrder`, `Podcast.YouTubePlaylistIdHistory` |
 
 ### `youTubePlaylistOrder` (`PlaylistOrder?`)
 
@@ -295,7 +295,7 @@ still must be capped so a mis-tagged uploads feed cannot empty the daily key bud
 | Symptom | Likely cause | Check |
 |---------|--------------|-------|
 | Recent episode missing Spotify URL | Ascending catalogue + skip-expensive without window; or walk-back circuit breaker | Flag flip / circuit-breaker Error; `ReleasedSince` window |
-| Recent YouTube URL missing on curated show | Playlist not `Arbitrary`, or wrong playlist id, or Arbitrary cap tripped | `youTubePlaylistOrder`, playlist id, Arbitrary circuit-breaker Error |
+| Recent YouTube URL missing on curated show | Playlist not `Arbitrary`, or wrong playlist id, or Arbitrary cap tripped | `youTubePlaylistOrder`, playlist id / `youTubePlaylistIdHistory`, Arbitrary circuit-breaker Error |
 | Expensive flag stuck `true` forever | Probe never returned conclusive newest-first (should not happen — Apply clears) | Flag-flip Warning history |
 | Quota spike on YouTube | Mis-tagged Arbitrary on a huge playlist; or many ascending full walks | Arbitrary circuit-breaker; hour-0 expensive YouTube pass |
 
@@ -308,7 +308,7 @@ still must be capped so a mis-tagged uploads feed cannot empty the daily key bud
 | `Spotify pagination circuit-breaker tripped:` | Error | `SimpleEpisodePaginator`, `AscendingEpisodePaginator` |
 | `Spotify expensive-query flag flipped:` | Warning | `SpotifyExpensiveQueryFlag` |
 | `YouTube expensive-query flag flipped:` | Warning | `YouTubeExpensiveQueryFlag` |
-| `YouTube playlist id changed:` | Warning | `YouTubePlaylistIdChange` (API / URL-submit playlist swaps) |
+| `YouTube playlist id changed:` | Warning | `YouTubePlaylistIdChange` (API / URL-submit playlist swaps; former id kept on `youTubePlaylistIdHistory`) |
 | `YouTube arbitrary-playlist walk circuit-breaker tripped:` | Error | `YouTubePlaylistService` via `ArbitraryYouTubePlaylistWalk` |
 | `YouTubeDiscoveryPath` | Info / Warning | `YouTubeEpisodeRetrievalHandler` |
 

--- a/docs/indexing-app-insights-queries.md
+++ b/docs/indexing-app-insights-queries.md
@@ -128,9 +128,12 @@ Deployed or pending (diagnostic logging work — `HourlyOrchestration`, `Orchest
 | `Spotify enrich miss:` | `SpotifyEpisodeEnricher` | Warning — no Spotify candidate matched, with rejection context |
 | `Spotify episode not available in market:` | `SpotifyNonPlayableSkipLogger` | **Error** — Spotify returned `restrictions.reason=market` |
 | `Skipping Spotify episode` | `SpotifyNonPlayableSkipLogger` | Warning — non-playable for a reason other than market |
-| `Spotify pagination circuit-breaker tripped:` | Spotify paginators | **Error** — a bounded catalogue walk hit `MaxPages`; in-window episodes may be missing |
+| `Spotify pagination circuit-breaker tripped:` | Spotify paginators | **Error** — a bounded catalogue walk hit `MaxPages` / `MaxWalkBackPages`; in-window episodes may be missing |
 | `Spotify expensive-query flag flipped:` | `SpotifyExpensiveQueryFlag` | Warning — conclusive catalogue-order probe changed `SpotifyEpisodesQueryIsExpensive` |
 | `YouTube expensive-query flag flipped:` | `YouTubeExpensiveQueryFlag` | Warning — conclusive playlist-order probe changed `YouTubePlaylistQueryIsExpensive` |
+| `YouTube arbitrary-playlist walk circuit-breaker tripped:` | `ArbitraryYouTubePlaylistWalk` / `YouTubePlaylistService` | **Error** — Arbitrary playlist walk hit `MaxPages`; in-window episodes may be missing — reclassify or shrink the playlist |
+
+Design reference for order modes, caps, and flag lifecycle: [catalogue-pagination.md](catalogue-pagination.md).
 
 Jakub Jahl is **usually not** YouTube-authority (Spotify/Apple discovery). For Jakub, prefer `Batch 4:` membership, podcast name logs, and `YouTubeDiscoveryPath` at Info level.
 
@@ -894,7 +897,7 @@ AppTraces
 
 ### B. Ascending pagination circuit breaker (quota cap hit)
 
-For oldest-first (`spotifyEpisodesQueryIsExpensive`) catalogues, indexing now uses Spotify's `Total` and `Limit` metadata to jump directly to the final page and walks backwards toward `ReleasedSince`. `SimpleEpisodePaginator.MaxPages` still bounds that reverse walk and the forward fallback used when Spotify omits paging metadata.
+For oldest-first (`spotifyEpisodesQueryIsExpensive`) catalogues, indexing now uses Spotify's `Total` and `Limit` metadata to jump directly to the final page and walks backwards toward `ReleasedSince`. That backwards walk is bounded by the small `AscendingEpisodePaginator.MaxWalkBackPages`; the larger `SimpleEpisodePaginator.MaxPages` bounds only the forward crawl from offset zero, used when Spotify omits paging metadata. Both trips share the message prefix below — `walk-back='true'` identifies the backwards walk, `reverse-chronological='false'` the forward crawl.
 
 ```kusto
 AppTraces
@@ -915,6 +918,35 @@ AppTraces
 | parse Message with * "episode-id='" episodeId "'" * "market='" market "'" *
 | summarize occurrences = count(), latest = max(TimeGenerated) by episodeId, market
 | order by latest desc
+```
+
+---
+
+## 10. YouTube playlist pagination — Arbitrary circuit breaker
+
+Curated playlists (`youTubePlaylistOrder = Arbitrary`) walk at 50 items/page capped by `ArbitraryYouTubePlaylistWalk.MaxPages` (20 ≈ 1000 items). A trip means the playlist is larger than the safety budget — reclassify or shrink it rather than raising the cap casually. Design: [catalogue-pagination.md](catalogue-pagination.md), [youtube-playlist-order.md](youtube-playlist-order.md).
+
+### A. Arbitrary walk circuit-breaker trips (7d)
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(7d)
+| where Message startswith "YouTube arbitrary-playlist walk circuit-breaker tripped:"
+| project TimeGenerated, AppRoleName, Message, OperationId
+| order by TimeGenerated desc
+```
+
+### B. YouTube playlist signals together (flag flips + Arbitrary cap + discovery path)
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(24h)
+| where AppRoleName == "indexer-infra"
+| where Message startswith "YouTube arbitrary-playlist walk circuit-breaker tripped:"
+   or Message startswith "YouTube expensive-query flag flipped:"
+   or Message has "YouTubeDiscoveryPath"
+| project TimeGenerated, SeverityLevel, Message, OperationId
+| order by TimeGenerated desc
 ```
 
 ---

--- a/docs/indexing-app-insights-queries.md
+++ b/docs/indexing-app-insights-queries.md
@@ -125,6 +125,12 @@ Deployed or pending (diagnostic logging work — `HourlyOrchestration`, `Orchest
 | `YouTubeDiscoveryPath` | `YouTubeEpisodeRetrievalHandler` | Warning when YouTube-authority; Info otherwise |
 | `YouTubeAuthorityPodcastAudit` | `PodcastsUpdater` | Per YouTube-authority podcast |
 | `YouTubeAuthorityIndexingAudit` | `PodcastsUpdater` | Batch-level YouTube-authority summary |
+| `Spotify enrich miss:` | `SpotifyEpisodeEnricher` | Warning — no Spotify candidate matched, with rejection context |
+| `Spotify episode not available in market:` | `SpotifyNonPlayableSkipLogger` | **Error** — Spotify returned `restrictions.reason=market` |
+| `Skipping Spotify episode` | `SpotifyNonPlayableSkipLogger` | Warning — non-playable for a reason other than market |
+| `Spotify pagination circuit-breaker tripped:` | Spotify paginators | **Error** — a bounded catalogue walk hit `MaxPages`; in-window episodes may be missing |
+| `Spotify expensive-query flag flipped:` | `SpotifyExpensiveQueryFlag` | Warning — conclusive catalogue-order probe changed `SpotifyEpisodesQueryIsExpensive` |
+| `YouTube expensive-query flag flipped:` | `YouTubeExpensiveQueryFlag` | Warning — conclusive playlist-order probe changed `YouTubePlaylistQueryIsExpensive` |
 
 Jakub Jahl is **usually not** YouTube-authority (Spotify/Apple discovery). For Jakub, prefer `Batch 4:` membership, podcast name logs, and `YouTubeDiscoveryPath` at Info level.
 
@@ -863,6 +869,53 @@ az monitor log-analytics query -w 2b1c62ee-689f-422a-816b-be1605ae88fa -t P14D -
 ```
 
 **Note:** use **single-line** `--analytics-query` with `-t P14D`; multi-line heredocs can return unfiltered workspace noise.
+
+---
+
+## 9. Spotify enrichment misses — market, non-playable, pagination cap
+
+When an episode never merges its Spotify URL, these three signals separate "Spotify never returned the row" from "the matcher rejected it".
+
+### A. All Spotify enrichment failure signals (24h)
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(24h)
+| where AppRoleName == "indexer-infra"
+| where Message startswith "Spotify enrich miss:"
+   or Message startswith "Spotify episode not available in market:"
+   or Message startswith "Spotify pagination circuit-breaker tripped:"
+   or Message startswith "Skipping Spotify episode"
+| project TimeGenerated, SeverityLevel, Message, OperationId
+| order by TimeGenerated desc
+```
+
+`SeverityLevel == 3` (Error) is market-unavailable or a tripped circuit breaker; `2` (Warning) is an enrich miss or another non-playable reason.
+
+### B. Ascending pagination circuit breaker (quota cap hit)
+
+For oldest-first (`spotifyEpisodesQueryIsExpensive`) catalogues, indexing now uses Spotify's `Total` and `Limit` metadata to jump directly to the final page and walks backwards toward `ReleasedSince`. `SimpleEpisodePaginator.MaxPages` still bounds that reverse walk and the forward fallback used when Spotify omits paging metadata.
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(7d)
+| where Message startswith "Spotify pagination circuit-breaker tripped:"
+| project TimeGenerated, AppRoleName, Message
+| order by TimeGenerated desc
+```
+
+Repeated trips for the same show mean the requested release window spans more pages than the safety limit, or Spotify omitted the metadata needed for the end jump. Investigate rather than ignoring the Error.
+
+### C. Market-unavailable episodes by show
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(30d)
+| where Message startswith "Spotify episode not available in market:"
+| parse Message with * "episode-id='" episodeId "'" * "market='" market "'" *
+| summarize occurrences = count(), latest = max(TimeGenerated) by episodeId, market
+| order by latest desc
+```
 
 ---
 

--- a/docs/indexing-app-insights-queries.md
+++ b/docs/indexing-app-insights-queries.md
@@ -131,6 +131,7 @@ Deployed or pending (diagnostic logging work — `HourlyOrchestration`, `Orchest
 | `Spotify pagination circuit-breaker tripped:` | Spotify paginators | **Error** — a bounded catalogue walk hit `MaxPages` / `MaxWalkBackPages`; in-window episodes may be missing |
 | `Spotify expensive-query flag flipped:` | `SpotifyExpensiveQueryFlag` | Warning — conclusive catalogue-order probe changed `SpotifyEpisodesQueryIsExpensive` |
 | `YouTube expensive-query flag flipped:` | `YouTubeExpensiveQueryFlag` | Warning — conclusive playlist-order probe changed `YouTubePlaylistQueryIsExpensive` |
+| `YouTube playlist id changed:` | `YouTubePlaylistIdChange` | Warning — stored `youTubePlaylistId` changed (API curator / URL submit); re-check Arbitrary / expensive order |
 | `YouTube arbitrary-playlist walk circuit-breaker tripped:` | `ArbitraryYouTubePlaylistWalk` / `YouTubePlaylistService` | **Error** — Arbitrary playlist walk hit `MaxPages`; in-window episodes may be missing — reclassify or shrink the playlist |
 
 Design reference for order modes, caps, and flag lifecycle: [catalogue-pagination.md](catalogue-pagination.md).
@@ -936,16 +937,27 @@ AppTraces
 | order by TimeGenerated desc
 ```
 
-### B. YouTube playlist signals together (flag flips + Arbitrary cap + discovery path)
+### B. YouTube playlist signals together (flag flips + playlist id change + Arbitrary cap + discovery path)
 
 ```kusto
 AppTraces
 | where TimeGenerated > ago(24h)
-| where AppRoleName == "indexer-infra"
+| where AppRoleName == "indexer-infra" or AppRoleName == "api-infra"
 | where Message startswith "YouTube arbitrary-playlist walk circuit-breaker tripped:"
    or Message startswith "YouTube expensive-query flag flipped:"
+   or Message startswith "YouTube playlist id changed:"
    or Message has "YouTubeDiscoveryPath"
-| project TimeGenerated, SeverityLevel, Message, OperationId
+| project TimeGenerated, AppRoleName, SeverityLevel, Message, OperationId
+| order by TimeGenerated desc
+```
+
+### C. Playlist id swaps only (7d)
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(7d)
+| where Message startswith "YouTube playlist id changed:"
+| project TimeGenerated, AppRoleName, Message, OperationId
 | order by TimeGenerated desc
 ```
 

--- a/docs/post-deploy-preacher-boys-2026-07-25.md
+++ b/docs/post-deploy-preacher-boys-2026-07-25.md
@@ -1,10 +1,10 @@
 # Post-deploy Cosmos apply — Preacher Boys (2026-07-25)
 
 **Why:** Prod Cosmospodcast docs are rewritten when the indexer `Save()`s a podcast.
-Until `youTubePlaylistOrder` ships in a deployed build, a Save can **drop** that
-unknown property. Playlist id / expensive flag / publication offset can also be
+Until `youTubePlaylistOrder` / `youTubePlaylistIdHistory` ship in a deployed build, a Save can
+**drop** those unknown properties. Playlist id / expensive flag / publication offset can also be
 overwritten by older code or by a sticky probe. Re-apply this checklist **after**
-deploying the PR that adds `PlaylistOrder` / Arbitrary walks
+deploying the PR that adds `PlaylistOrder` / Arbitrary walks / playlist-id history
 ([#920](https://github.com/cultpodcasts/RedditPodcastPoster/pull/920) or successor).
 
 | | |
@@ -18,6 +18,7 @@ deploying the PR that adds `PlaylistOrder` / Arbitrary walks
 | Field | Desired | Notes |
 |-------|---------|-------|
 | `youTubePlaylistId` | `PLKdUWzQpByAQ` | Public show playlist (contains recent episodes). Replaces unlisted `PL3bVHY_fIafVIG-QBn_UtBqpeRfLeBhsJ`. |
+| `youTubePlaylistIdHistory` | `[{ id: PL3bVHY_fIafVIG-QBn_UtBqpeRfLeBhsJ, replacedAt: <UTC of first swap> }]` | Seed the former unlisted id — the 2026-07-25 Cosmos patch did not go through `YouTubePlaylistIdChange.Apply`. |
 | `youTubePlaylistOrder` | `Arbitrary` | Curated; new items may appear at either end. Requires deployed Arbitrary walk code. |
 | `youTubePlaylistQueryIsExpensive` | `false` | Meaningless under Arbitrary (probe suppressed); keep false so old builds do not force odd batch sizing. |
 | `youTubePublicationOffset` | `0` | Was `−3456000000000` (−4 days). Video and audio publish near-simultaneously for this show; −4 days pulled the YouTube window wrongly. `0` ≡ `TimeSpan.Zero` (same as null). |
@@ -44,6 +45,8 @@ $ResourceGroup = 'AutomatedData'
 $AccountName = 'cultpodcasts-db'
 $DatabaseName = 'cultpodcasts-db'
 $PodcastId = '4672c845-15b4-4f88-bbff-567d521fe4a2'
+$FormerPlaylistId = 'PL3bVHY_fIafVIG-QBn_UtBqpeRfLeBhsJ'
+$ReplacedAt = [datetime]::Parse('2026-07-25T13:30:00Z').ToUniversalTime()
 
 function New-CosmosDbAuthorizationHeader {
     param([string]$Verb,[string]$ResourceType,[string]$ResourceId,[string]$Key,[datetime]$Date)
@@ -63,7 +66,7 @@ $uri = "$endpoint$resourceId/docs"
 $date = [datetime]::UtcNow
 $auth = New-CosmosDbAuthorizationHeader -Verb POST -ResourceType docs -ResourceId $resourceId -Key $key -Date $date
 $queryBody = @{
-    query = 'SELECT c.id, c.name, c.youTubePlaylistId, c.youTubePlaylistOrder, c.youTubePlaylistQueryIsExpensive, c.youTubePublicationOffset FROM c WHERE c.id = @id'
+    query = 'SELECT c.id, c.name, c.youTubePlaylistId, c.youTubePlaylistIdHistory, c.youTubePlaylistOrder, c.youTubePlaylistQueryIsExpensive, c.youTubePublicationOffset FROM c WHERE c.id = @id'
     parameters = @(@{ name = '@id'; value = $PodcastId })
 } | ConvertTo-Json -Depth 5 -Compress
 $headers = @{
@@ -71,21 +74,25 @@ $headers = @{
     'x-ms-documentdb-isquery' = 'True'; 'Content-Type' = 'application/query+json'
     'x-ms-documentdb-query-enablecrosspartition' = 'True'
 }
-Write-Host 'BEFORE:'; (Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $queryBody).Documents | ConvertTo-Json
+Write-Host 'BEFORE:'; (Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $queryBody).Documents | ConvertTo-Json -Depth 6
 
 # PATCH
 $docResourceId = "dbs/$DatabaseName/colls/Podcasts/docs/$PodcastId"
 $patchUri = "$endpoint$docResourceId"
 $date = [datetime]::UtcNow
 $auth = New-CosmosDbAuthorizationHeader -Verb PATCH -ResourceType docs -ResourceId $docResourceId -Key $key -Date $date
+$history = @(
+    @{ id = $FormerPlaylistId; replacedAt = $ReplacedAt.ToString('o') }
+)
 $patchBody = @{
     operations = @(
         @{ op = 'set'; path = '/youTubePlaylistId'; value = 'PLKdUWzQpByAQ' }
+        @{ op = 'set'; path = '/youTubePlaylistIdHistory'; value = $history }
         @{ op = 'set'; path = '/youTubePlaylistOrder'; value = 'Arbitrary' }
         @{ op = 'set'; path = '/youTubePlaylistQueryIsExpensive'; value = $false }
         @{ op = 'set'; path = '/youTubePublicationOffset'; value = 0 }
     )
-} | ConvertTo-Json -Depth 5 -Compress
+} | ConvertTo-Json -Depth 6 -Compress
 $patchHeaders = @{
     Authorization = $auth; 'x-ms-date' = $date.ToString('r'); 'x-ms-version' = '2018-12-31'
     'Content-Type' = 'application/json_patch+json'
@@ -96,15 +103,16 @@ Write-Host 'AFTER:'
 [pscustomobject]@{
     id = $patched.id
     youTubePlaylistId = $patched.youTubePlaylistId
+    youTubePlaylistIdHistory = $patched.youTubePlaylistIdHistory
     youTubePlaylistOrder = $patched.youTubePlaylistOrder
     youTubePlaylistQueryIsExpensive = $patched.youTubePlaylistQueryIsExpensive
     youTubePublicationOffset = $patched.youTubePublicationOffset
-} | ConvertTo-Json
+} | ConvertTo-Json -Depth 6
 ```
 
 ## After apply — smoke
 
-1. Confirm fields match the desired table above.
+1. Confirm fields match the desired table above (including history entry for the former unlisted id).
 2. Run `index.exe` (or wait for hourly) against Preacher Boys; expect discovery path
    `playlist-arbitrary-full-walk` and Kenny Baldwin (`GUo_kOfWuZI`) YouTube merge if still missing.
 3. Watch App Insights for `YouTube arbitrary-playlist walk circuit-breaker tripped:`
@@ -114,5 +122,5 @@ Write-Host 'AFTER:'
 
 | When (UTC) | What | Result |
 |------------|------|--------|
-| 2026-07-25 ~13:30 | Applied playlist id + `Arbitrary` + expensive=false (offset left −4d) | OK — still present when re-read same day |
-| *(after deploy)* | Re-apply full desired table including `youTubePublicationOffset=0` | Pending |
+| 2026-07-25 ~13:30 | Applied playlist id + `Arbitrary` + expensive=false (offset left −4d; **no history**) | OK — still present when re-read same day |
+| *(after deploy)* | Re-apply full desired table including `youTubePublicationOffset=0` + seed `youTubePlaylistIdHistory` | Pending |

--- a/docs/post-deploy-preacher-boys-2026-07-25.md
+++ b/docs/post-deploy-preacher-boys-2026-07-25.md
@@ -1,0 +1,118 @@
+# Post-deploy Cosmos apply — Preacher Boys (2026-07-25)
+
+**Why:** Prod Cosmospodcast docs are rewritten when the indexer `Save()`s a podcast.
+Until `youTubePlaylistOrder` ships in a deployed build, a Save can **drop** that
+unknown property. Playlist id / expensive flag / publication offset can also be
+overwritten by older code or by a sticky probe. Re-apply this checklist **after**
+deploying the PR that adds `PlaylistOrder` / Arbitrary walks
+([#920](https://github.com/cultpodcasts/RedditPodcastPoster/pull/920) or successor).
+
+| | |
+|-|-|
+| Podcast id | `4672c845-15b4-4f88-bbff-567d521fe4a2` |
+| Name / fileKey | Preacher Boys Podcast / `preacher_boys_podcast` |
+| Account / DB / container | `cultpodcasts-db` / `cultpodcasts-db` / `Podcasts` |
+
+## Desired end state
+
+| Field | Desired | Notes |
+|-------|---------|-------|
+| `youTubePlaylistId` | `PLKdUWzQpByAQ` | Public show playlist (contains recent episodes). Replaces unlisted `PL3bVHY_fIafVIG-QBn_UtBqpeRfLeBhsJ`. |
+| `youTubePlaylistOrder` | `Arbitrary` | Curated; new items may appear at either end. Requires deployed Arbitrary walk code. |
+| `youTubePlaylistQueryIsExpensive` | `false` | Meaningless under Arbitrary (probe suppressed); keep false so old builds do not force odd batch sizing. |
+| `youTubePublicationOffset` | `0` | Was `−3456000000000` (−4 days). Video and audio publish near-simultaneously for this show; −4 days pulled the YouTube window wrongly. `0` ≡ `TimeSpan.Zero` (same as null). |
+
+Do **not** change `releaseAuthority` (`YouTube`) or `youTubeChannelId` (`UCUnhn-4KoLWr0ffbPjMf-gQ`) unless separately agreed.
+
+## Verify current (read-only)
+
+```powershell
+pwsh ./scripts/query-cosmos-lookups.ps1 -Query Podcast -PodcastId 4672c845-15b4-4f88-bbff-567d521fe4a2
+```
+
+Or project the fields this checklist cares about (extend the Podcast query / use the
+patch script's BEFORE dump below).
+
+## Apply after deploy
+
+Confirm indexer/api blob deploy first ([production-deploy-truth](../.cursor/rules/production-deploy-truth.mdc)), then run:
+
+```powershell
+$ErrorActionPreference = 'Stop'
+$SubscriptionId = 'a6b8f1a2-6163-41bc-aa6d-e33928939a6e'
+$ResourceGroup = 'AutomatedData'
+$AccountName = 'cultpodcasts-db'
+$DatabaseName = 'cultpodcasts-db'
+$PodcastId = '4672c845-15b4-4f88-bbff-567d521fe4a2'
+
+function New-CosmosDbAuthorizationHeader {
+    param([string]$Verb,[string]$ResourceType,[string]$ResourceId,[string]$Key,[datetime]$Date)
+    $keyBytes = [Convert]::FromBase64String($Key)
+    $payload = "$($Verb.ToLowerInvariant())`n$($ResourceType.ToLowerInvariant())`n$ResourceId`n$($Date.ToString('r').ToLowerInvariant())`n`n"
+    $hmac = [System.Security.Cryptography.HMACSHA256]::new($keyBytes)
+    $sig = [Convert]::ToBase64String($hmac.ComputeHash([Text.Encoding]::UTF8.GetBytes($payload)))
+    [uri]::EscapeDataString("type=master&ver=1.0&sig=$sig")
+}
+
+$key = az cosmosdb keys list --subscription $SubscriptionId --resource-group $ResourceGroup --name $AccountName --type keys --query primaryMasterKey -o tsv
+$endpoint = "https://$AccountName.documents.azure.com:443/"
+
+# BEFORE
+$resourceId = "dbs/$DatabaseName/colls/Podcasts"
+$uri = "$endpoint$resourceId/docs"
+$date = [datetime]::UtcNow
+$auth = New-CosmosDbAuthorizationHeader -Verb POST -ResourceType docs -ResourceId $resourceId -Key $key -Date $date
+$queryBody = @{
+    query = 'SELECT c.id, c.name, c.youTubePlaylistId, c.youTubePlaylistOrder, c.youTubePlaylistQueryIsExpensive, c.youTubePublicationOffset FROM c WHERE c.id = @id'
+    parameters = @(@{ name = '@id'; value = $PodcastId })
+} | ConvertTo-Json -Depth 5 -Compress
+$headers = @{
+    Authorization = $auth; 'x-ms-date' = $date.ToString('r'); 'x-ms-version' = '2018-12-31'
+    'x-ms-documentdb-isquery' = 'True'; 'Content-Type' = 'application/query+json'
+    'x-ms-documentdb-query-enablecrosspartition' = 'True'
+}
+Write-Host 'BEFORE:'; (Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $queryBody).Documents | ConvertTo-Json
+
+# PATCH
+$docResourceId = "dbs/$DatabaseName/colls/Podcasts/docs/$PodcastId"
+$patchUri = "$endpoint$docResourceId"
+$date = [datetime]::UtcNow
+$auth = New-CosmosDbAuthorizationHeader -Verb PATCH -ResourceType docs -ResourceId $docResourceId -Key $key -Date $date
+$patchBody = @{
+    operations = @(
+        @{ op = 'set'; path = '/youTubePlaylistId'; value = 'PLKdUWzQpByAQ' }
+        @{ op = 'set'; path = '/youTubePlaylistOrder'; value = 'Arbitrary' }
+        @{ op = 'set'; path = '/youTubePlaylistQueryIsExpensive'; value = $false }
+        @{ op = 'set'; path = '/youTubePublicationOffset'; value = 0 }
+    )
+} | ConvertTo-Json -Depth 5 -Compress
+$patchHeaders = @{
+    Authorization = $auth; 'x-ms-date' = $date.ToString('r'); 'x-ms-version' = '2018-12-31'
+    'Content-Type' = 'application/json_patch+json'
+    'x-ms-documentdb-partitionkey' = "[`"$PodcastId`"]"
+}
+$patched = Invoke-RestMethod -Method Patch -Uri $patchUri -Headers $patchHeaders -Body $patchBody
+Write-Host 'AFTER:'
+[pscustomobject]@{
+    id = $patched.id
+    youTubePlaylistId = $patched.youTubePlaylistId
+    youTubePlaylistOrder = $patched.youTubePlaylistOrder
+    youTubePlaylistQueryIsExpensive = $patched.youTubePlaylistQueryIsExpensive
+    youTubePublicationOffset = $patched.youTubePublicationOffset
+} | ConvertTo-Json
+```
+
+## After apply — smoke
+
+1. Confirm fields match the desired table above.
+2. Run `index.exe` (or wait for hourly) against Preacher Boys; expect discovery path
+   `playlist-arbitrary-full-walk` and Kenny Baldwin (`GUo_kOfWuZI`) YouTube merge if still missing.
+3. Watch App Insights for `YouTube arbitrary-playlist walk circuit-breaker tripped:`
+   (should **not** fire for this ~355-item playlist).
+
+## Status log
+
+| When (UTC) | What | Result |
+|------------|------|--------|
+| 2026-07-25 ~13:30 | Applied playlist id + `Arbitrary` + expensive=false (offset left −4d) | OK — still present when re-read same day |
+| *(after deploy)* | Re-apply full desired table including `youTubePublicationOffset=0` | Pending |

--- a/docs/youtube-playlist-order.md
+++ b/docs/youtube-playlist-order.md
@@ -47,6 +47,10 @@ Nullable enum on `Podcast` (`PlaylistOrder`, JSON `youTubePlaylistOrder`):
 | `Arbitrary` | Curated playlist; position carries no date information |
 | `ReverseChronological` / `Ascending` | Reserved for future probe-written classification; not yet consumed |
 
+Former playlist ids are retained on `youTubePlaylistIdHistory` (`id` + `replacedAt` UTC, newest last)
+whenever `YouTubePlaylistIdChange.Apply` swaps a non-empty configured id — so a bad curated swap
+is recoverable from the podcast document (and surfaced on the API podcast DTO).
+
 When `Arbitrary`:
 
 - Walk at batch size 50 with hard page cap `ArbitraryYouTubePlaylistWalk.MaxPages` (= 20 →

--- a/docs/youtube-playlist-order.md
+++ b/docs/youtube-playlist-order.md
@@ -1,0 +1,96 @@
+# YouTube playlist order (depth)
+
+**Start here for cold-start across both platforms:** [catalogue-pagination.md](catalogue-pagination.md).
+
+This page keeps YouTube-specific depth: why curated playlists break the binary probe,
+what `Arbitrary` does, the known-ID position probe sketch, and equal-timestamp failure modes.
+
+---
+
+## Problem
+
+Indexing and enrichment historically assumed a YouTube playlist is either **newest-first**
+(early-stop from the head) or **oldest-first** (expensive full walk). The order probe
+(`PlaylistItemOrdering.IsReverseDateOrdered`) samples the head each windowed pass and flips
+`Podcast.YouTubePlaylistQueryIsExpensive` accordingly.
+
+Manually curated playlists break both assumptions:
+
+- New videos are sometimes added at the head and sometimes appended at the end
+  (observed on curated show playlists where a new episode sat near the end behind a
+  bulk-added backlog).
+- Bulk-added items share identical `snippet.publishedAt` (added-at) timestamps. Equal
+  timestamps satisfy `IsReverseDateOrdered` (non-ascending), so the probe misclassifies the
+  playlist as newest-first, early-stops on the stale head, finds nothing, and can flip the
+  expensive flag to `false` — hiding appended episodes.
+
+---
+
+## Key API facts
+
+| Fact | Consequence |
+|------|-------------|
+| `playlistItems.list` costs **1 quota unit per page of 50** | A walk of ~350 items is ~8 units/pass — cheaper than one `search.list` (100 units) |
+| No reverse/tail pagination — `nextPageToken` only walks forward | "Check both ends cheaply" is not possible positionally |
+| `playlistItems.list` accepts `playlistId` + `videoId` (~1 unit) and returns `snippet.position` | A known video's playlist position can be looked up without walking |
+| For playlist items, `snippet.publishedAt` = **added-to-playlist time** | On curated playlists, added-at is the "new to this feed" signal regardless of position |
+
+---
+
+## `youTubePlaylistOrder` (implemented)
+
+Nullable enum on `Podcast` (`PlaylistOrder`, JSON `youTubePlaylistOrder`):
+
+| Value | Meaning |
+|-------|---------|
+| `null` (absent) | Probe head order each windowed pass; maintain `youTubePlaylistQueryIsExpensive` |
+| `Arbitrary` | Curated playlist; position carries no date information |
+| `ReverseChronological` / `Ascending` | Reserved for future probe-written classification; not yet consumed |
+
+When `Arbitrary`:
+
+- Walk at batch size 50 with hard page cap `ArbitraryYouTubePlaylistWalk.MaxPages` (= 20 →
+  ~1000 items). Prefer an **Error** log + stop over burning quota on a mis-tagged
+  channel-scale playlist.
+- Head-order probe skipped; `IsExpensiveQuery` stays `null`; discovery never Applys the
+  expensive flag.
+- `ReleasedSince` filter (added-at) still applies after the walk.
+- `SkipExpensiveYouTubeQueries` does not degrade to a single page.
+
+Full decision tables, discovery vs enrichment, and hourly gates:
+[catalogue-pagination.md](catalogue-pagination.md) §4–5.
+
+---
+
+## Known-ID position probe (sketch — not yet implemented)
+
+Goal: classify playlist order cheaply using episodes we already know.
+
+1. Take the 2–3 most recent stored episodes that carry a `youTubeId`.
+2. For each, `playlistItems.list(part=snippet, playlistId, videoId)` (~1 unit) →
+   `snippet.position` + added-at.
+3. Compare episode release order vs playlist position:
+   - newer → lower position consistently → `ReverseChronological`
+   - newer → higher position consistently → `Ascending`
+   - mixed / outliers → `Arbitrary`
+4. Suggest (or `--apply`) `youTubePlaylistOrder` on the podcast.
+
+Total cost ~2–3 units. Dry-run by default; never write episodes. Does **not** find brand-new
+videos — only classifies where new items tend to land.
+
+Non-goals: hourly both-ends paging; undocumented page-token arithmetic to jump to the tail.
+
+---
+
+## Business-rule tests
+
+Authoritative matrix: [catalogue-pagination.md](catalogue-pagination.md) §4
+("Business-rule tests (YouTube)").
+
+Critical YouTube-only cases:
+
+| Rule | Test |
+|------|------|
+| Equal added-at timestamps count as reverse-chrono (curated failure mode) | `PlaylistItemOrderingRules` |
+| Arbitrary circuit breaker trips at MaxPages with next token remaining | `ArbitraryYouTubePlaylistWalkRules` |
+| Arbitrary leaves expensive flag untouched even if a probe value sneaks through | `YouTubeEpisodeRetrievalHandlerRules` |

--- a/scripts/assert-unit-test-guardrails.ps1
+++ b/scripts/assert-unit-test-guardrails.ps1
@@ -1,0 +1,230 @@
+<#
+.SYNOPSIS
+  Asserts mechanical unit-test guardrails from .cursor/rules/unit-tests.mdc.
+
+.DESCRIPTION
+  Scans C# test sources for hard-fail patterns. Used by Cursor stop hooks and CI.
+  Exit 0 = clean; exit 1 = violations found.
+
+.PARAMETER Path
+  One or more files/directories to scan.
+
+.PARAMETER GitChanged
+  Scan test files changed vs HEAD (unstaged + staged + untracked) or vs -BaseRef.
+
+.PARAMETER BaseRef
+  When set with -GitChanged, diff against this ref (e.g. origin/main) instead of the working tree alone.
+
+.PARAMETER Json
+  Emit a JSON object { violations: [...], ok: bool } to stdout (still exit 1 on fail).
+#>
+[CmdletBinding()]
+param(
+    [string[]] $Path,
+    [switch] $GitChanged,
+    [string] $BaseRef,
+    [switch] $Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$BrandDenylist = @(
+    'Preacher Boys',
+    'Pastor Kenny Baldwin',
+    'Virginia I The Age',
+    'Virginia | Ep',
+    'Postmormon',
+    'Cults to Consciousness',
+    'C2C'
+)
+
+function Test-IsTestSourcePath([string] $filePath) {
+    $n = $filePath -replace '\\', '/'
+    if ($n -notmatch '\.cs$') { return $false }
+    if ($n -match '/obj/|/bin/') { return $false }
+    # Fixture / test-support libraries are not rule-test bodies
+    if ($n -match 'TestSupport/') { return $false }
+    return (
+        $n -match 'Tests?/' -or
+        $n -match '\.Tests/' -or
+        $n -match 'FunctionHost\.Tests/'
+    )
+}
+
+function Get-GitChangedTestFiles([string] $base) {
+    $files = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+    if ($base) {
+        git diff --name-only --diff-filter=ACMR "$base...HEAD" 2>$null | ForEach-Object { [void]$files.Add($_) }
+        git diff --name-only --diff-filter=ACMR "$base" 2>$null | ForEach-Object { [void]$files.Add($_) }
+    }
+    else {
+        git diff --name-only --diff-filter=ACMR HEAD 2>$null | ForEach-Object { [void]$files.Add($_) }
+        git diff --name-only --cached --diff-filter=ACMR 2>$null | ForEach-Object { [void]$files.Add($_) }
+        git ls-files --others --exclude-standard 2>$null | ForEach-Object { [void]$files.Add($_) }
+    }
+
+    $root = (git rev-parse --show-toplevel 2>$null)
+    if (-not $root) { $root = Get-Location }
+    $result = @()
+    foreach ($rel in $files) {
+        if (-not (Test-IsTestSourcePath $rel)) { continue }
+        $full = Join-Path $root $rel
+        if (Test-Path -LiteralPath $full) { $result += $full }
+    }
+    return $result | Sort-Object -Unique
+}
+
+function Get-ScanTargets {
+    if ($GitChanged) {
+        return @(Get-GitChangedTestFiles $BaseRef)
+    }
+    if (-not $Path -or $Path.Count -eq 0) {
+        throw 'Specify -Path and/or -GitChanged.'
+    }
+    $targets = @()
+    foreach ($p in $Path) {
+        if (-not (Test-Path -LiteralPath $p)) { continue }
+        $item = Get-Item -LiteralPath $p
+        if ($item.PSIsContainer) {
+            Get-ChildItem -LiteralPath $item.FullName -Recurse -Filter *.cs -File |
+                Where-Object { Test-IsTestSourcePath $_.FullName } |
+                ForEach-Object { $targets += $_.FullName }
+        }
+        elseif (Test-IsTestSourcePath $item.FullName) {
+            $targets += $item.FullName
+        }
+    }
+    return $targets | Sort-Object -Unique
+}
+
+function Add-Violation(
+    [System.Collections.Generic.List[object]] $list,
+    [string] $file,
+    [int] $line,
+    [string] $rule,
+    [string] $detail) {
+    $list.Add([pscustomobject]@{
+            file   = $file
+            line   = $line
+            rule   = $rule
+            detail = $detail
+        }) | Out-Null
+}
+
+function Test-FileGuardrails([string] $filePath) {
+    $violations = [System.Collections.Generic.List[object]]::new()
+    $lines = Get-Content -LiteralPath $filePath
+    $rel = $filePath
+    try {
+        $root = (git rev-parse --show-toplevel 2>$null)
+        if ($root) {
+            $rel = $filePath.Substring($root.Length).TrimStart('\', '/')
+        }
+    }
+    catch { }
+
+    $normalized = $filePath -replace '\\', '/'
+    $inBusinessRules = $normalized -match '/BusinessRules/'
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $lineNum = $i + 1
+        $line = $lines[$i]
+        $trimmed = $line.Trim()
+
+        if ($trimmed.StartsWith('//') -or $trimmed.StartsWith('*') -or $trimmed.StartsWith('///')) {
+            continue
+        }
+
+        foreach ($brand in $BrandDenylist) {
+            if ($line -like "*$brand*") {
+                Add-Violation $violations $rel $lineNum 'no-production-brand-names' `
+                    "Found production brand/literal '$brand'. Use scenario-shaped fixtures / generated titles."
+            }
+        }
+
+        if ($line -match 'Guid\.Parse\s*\(' -or $line -match 'new\s+Guid\s*\(\s*"') {
+            Add-Violation $violations $rel $lineNum 'no-hardcoded-guid' `
+                'Hardcoded Guid literal. Use _fixture.CreateGuid() or specimen identity.'
+        }
+
+        if ($line -match 'new\s+DateTime\s*\(\s*20\d{2}\s*,') {
+            Add-Violation $violations $rel $lineNum 'no-fixed-calendar-datetime' `
+                'Fixed calendar DateTime. Use DomainTestFixture.UtcDaysAgo / UtcAtTime / UtcDateDaysAgo.'
+        }
+
+        if ($inBusinessRules -and $line -match 'throw\s+new\s+NotImplementedException\s*\(') {
+            Add-Violation $violations $rel $lineNum 'no-notimplemented-in-businessrules' `
+                'NotImplementedException test double in BusinessRules. Prefer Moq or a focused fake.'
+        }
+
+        # [Fact] or [Theory] without DisplayName on the same attribute
+        if ($trimmed -match '^\[Fact\]\s*$' -or $trimmed -match '^\[Theory\]\s*$') {
+            Add-Violation $violations $rel $lineNum 'fact-requires-displayname' `
+                '[Fact]/[Theory] missing DisplayName. Use [Fact(DisplayName = "...")].'
+        }
+        elseif ($trimmed -match '^\[(Fact|Theory)\(' -and $trimmed -notmatch 'DisplayName\s*=') {
+            # Multi-line attribute: Fact( then DisplayName on following lines
+            $window = ($lines[$i..([Math]::Min($i + 6, $lines.Count - 1))] -join ' ')
+            if ($window -notmatch 'DisplayName\s*=') {
+                Add-Violation $violations $rel $lineNum 'fact-requires-displayname' `
+                    'Fact/Theory attribute missing DisplayName.'
+            }
+        }
+    }
+
+    # Section comments: any public async?/Task|void test method should have Arrange nearby
+    $text = $lines -join "`n"
+    $methodMatches = [regex]::Matches(
+        $text,
+        '(?m)^\s*public\s+(?:async\s+)?(?:Task|ValueTask|void)\s+(\w+)\s*\([^)]*\)\s*\{')
+    foreach ($m in $methodMatches) {
+        $name = $m.Groups[1].Value
+        if ($name -match '^(ToString|Equals|GetHashCode|Dispose)$') { continue }
+        # Find line number of method
+        $prefix = $text.Substring(0, $m.Index)
+        $methodLine = ($prefix -split "`n").Count
+        $bodyStart = $m.Index + $m.Length
+        $slice = $text.Substring($bodyStart, [Math]::Min(800, $text.Length - $bodyStart))
+        if ($slice -notmatch '//\s*Arrange') {
+            Add-Violation $violations $rel $methodLine 'missing-arrange-act-assert' `
+                "Test method '$name' missing '// Arrange' (require Arrange/Act/Assert section comments)."
+        }
+    }
+
+    return $violations
+}
+
+$targets = @(Get-ScanTargets)
+$all = [System.Collections.Generic.List[object]]::new()
+foreach ($t in $targets) {
+    foreach ($v in (Test-FileGuardrails $t)) {
+        $all.Add($v) | Out-Null
+    }
+}
+
+if ($Json) {
+    [pscustomobject]@{
+        ok         = ($all.Count -eq 0)
+        scanned    = @($targets)
+        violations = @($all)
+    } | ConvertTo-Json -Depth 5
+}
+else {
+    if ($targets.Count -eq 0) {
+        Write-Host 'unit-test guardrails: no matching test files to scan.'
+    }
+    elseif ($all.Count -eq 0) {
+        Write-Host "unit-test guardrails: OK ($($targets.Count) file(s))."
+    }
+    else {
+        Write-Host "unit-test guardrails: $($all.Count) violation(s) in $($targets.Count) file(s):" -ForegroundColor Red
+        foreach ($v in $all) {
+            Write-Host ("  {0}:{1} [{2}] {3}" -f $v.file, $v.line, $v.rule, $v.detail) -ForegroundColor Red
+        }
+        Write-Host 'See .cursor/rules/unit-tests.mdc'
+    }
+}
+
+if ($all.Count -gt 0) { exit 1 }
+exit 0


### PR DESCRIPTION
## Summary
- Stop YouTube release-authority podcasts seeding from Spotify/Apple-only catalogue rows, and require a YouTube URL before Bluesky/Tweet for YouTube-RA shows.
- Fix Spotify enrich misses on oldest-first catalogues via end-jump + walk-back (`MaxWalkBackPages=5`); forward fallback capped at `MaxPages=20`; re-probe expensive flags both ways for Spotify and YouTube.
- Add `youTubePlaylistOrder=Arbitrary` for curated playlists (capped full walk, MaxPages=20 circuit breaker) plus catalogue-pagination docs and unit-test guardrail enforcement.
- Provenance logs: Bluesky posts, Spotify enrich misses, market skips, pagination circuit-breakers, expensive-flag flips.

## Post-deploy Cosmos (Preacher Boys) — re-apply if indexer Save drops fields

Checklist + ready-to-run patch: [`docs/post-deploy-preacher-boys-2026-07-25.md`](docs/post-deploy-preacher-boys-2026-07-25.md)

| Field | Desired |
|-------|---------|
| `youTubePlaylistId` | `PLKdUWzQpByAQ` |
| `youTubePlaylistOrder` | `Arbitrary` |
| `youTubePlaylistQueryIsExpensive` | `false` |
| `youTubePublicationOffset` | `0` (was −4 days) |

Podcast id: `4672c845-15b4-4f88-bbff-567d521fe4a2`. Playlist id + Arbitrary were applied 2026-07-25; **offset still −4d until post-deploy re-apply**. Old builds can strip `youTubePlaylistOrder` on podcast Save — re-run the checklist after deploy.

## Test plan
- [ ] `dotnet test` Spotify + YouTube + PodcastServices (+ FunctionHost Bluesky logger) suites green
- [ ] CI unit-test guardrails step clean on changed test files
- [ ] Deploy indexer; confirm blob `lastModified` ([production-deploy-truth](.cursor/rules/production-deploy-truth.mdc))
- [ ] Run post-deploy Preacher Boys patch (doc above), including `youTubePublicationOffset=0`
- [ ] Index Preacher Boys — expect `playlist-arbitrary-full-walk` and YouTube URL on `8f3b0115-…` (`GUo_kOfWuZI`)
- [ ] Index Virginia — expect Spotify URL `03Zi9NxlUqCRgXtXUpz0pH` on `f58f1992-…`
- [ ] App Insights: Arbitrary circuit-breaker / flag-flip / Bluesky / enrich-miss prefixes per `docs/indexing-app-insights-queries.md` and `docs/catalogue-pagination.md`