### PR TITLE
fix(indexing): merge same-day Spotify catalogue rows during YouTube enrichment

### DIFF
--- a/.cursor/hooks/unit-test-guardrails-after-edit.ps1
+++ b/.cursor/hooks/unit-test-guardrails-after-edit.ps1
@@ -1,8 +1,8 @@
 #Requires -Version 7
 <#
-  afterFileEdit: if the edited file is a test source, run guardrail scan and
-  append violations to .cursor/hooks/.unit-test-guardrail-failures.jsonl so the
-  stop hook can force a fix loop.
+  afterFileEdit: if the edited file is a test source, record it against this
+  conversation's state so the stop hook only follow-ups the agent that edited it
+  (never other agents sharing the same workspace / dirty git tree).
 #>
 $ErrorActionPreference = 'Stop'
 $stdin = [Console]::In.ReadToEnd()
@@ -24,25 +24,91 @@ if (-not $filePath) {
     exit 0
 }
 
+# Without a conversation id we cannot isolate agents — skip recording (fail open).
+$conversationId = $null
+if ($payload) {
+    foreach ($name in @('conversation_id', 'conversationId', 'session_id', 'sessionId')) {
+        if ($payload.PSObject.Properties.Name -contains $name -and $payload.$name) {
+            $conversationId = [string]$payload.$name
+            break
+        }
+    }
+}
+if ([string]::IsNullOrWhiteSpace($conversationId)) {
+    Write-Output '{}'
+    exit 0
+}
+
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 Set-Location $repoRoot
 
 $script = Join-Path $repoRoot 'scripts\assert-unit-test-guardrails.ps1'
+# Probe whether this path is a test source the scanner cares about.
 $out = & pwsh -NoProfile -File $script -Path $filePath -Json 2>&1 | Out-String
 $result = $null
 try { $result = $out | ConvertFrom-Json } catch { }
 
-if ($result -and -not $result.ok -and $result.violations) {
-    $stateDir = Join-Path $PSScriptRoot '.state'
-    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
-    $stateFile = Join-Path $stateDir 'unit-test-guardrail-failures.jsonl'
-    $entry = [pscustomobject]@{
-        at         = [DateTime]::UtcNow.ToString('o')
-        file       = $filePath
-        violations = $result.violations
-    }
-    Add-Content -LiteralPath $stateFile -Value ($entry | ConvertTo-Json -Compress -Depth 6)
+# Non-test paths return ok:true with scanned:[]. Only track files the scanner accepted.
+$scanned = @()
+if ($result -and $result.scanned) { $scanned = @($result.scanned) }
+if ($scanned.Count -eq 0) {
+    Write-Output '{}'
+    exit 0
 }
+
+$violations = @()
+if ($result -and -not $result.ok -and $result.violations) {
+    $violations = @($result.violations)
+}
+
+$stateDir = Join-Path $PSScriptRoot '.state'
+New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+# Sanitize conversation id for a filename (UUIDs are fine; strip path separators just in case).
+$safeId = ($conversationId -replace '[\\/:*?"<>|]', '_')
+$stateFile = Join-Path $stateDir "unit-test-guardrail-$safeId.json"
+
+$state = [pscustomobject]@{
+    conversation_id = $conversationId
+    files           = @()
+    last_violations = @()
+    updated_at      = [DateTime]::UtcNow.ToString('o')
+}
+if (Test-Path -LiteralPath $stateFile) {
+    try {
+        $loaded = Get-Content -LiteralPath $stateFile -Raw | ConvertFrom-Json
+        if ($loaded) {
+            $state.files = @($loaded.files)
+            if ($loaded.last_violations) { $state.last_violations = @($loaded.last_violations) }
+        }
+    }
+    catch { }
+}
+
+$fileSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+foreach ($f in @($state.files)) {
+    if ($f) { [void]$fileSet.Add([string]$f) }
+}
+[void]$fileSet.Add($filePath)
+$state.files = @($fileSet)
+$state.updated_at = [DateTime]::UtcNow.ToString('o')
+
+# Keep latest violation snapshot for this conversation (overwrite stale rows for this file).
+$kept = [System.Collections.Generic.List[object]]::new()
+foreach ($v in @($state.last_violations)) {
+    if (-not $v) { continue }
+    $vFile = [string]$v.file
+    # Drop prior rows that refer to this absolute path or its repo-relative form.
+    if ($vFile -and (
+            [string]::Equals($vFile, $filePath, [StringComparison]::OrdinalIgnoreCase) -or
+            $filePath.EndsWith($vFile, [StringComparison]::OrdinalIgnoreCase))) {
+        continue
+    }
+    $kept.Add($v) | Out-Null
+}
+foreach ($v in $violations) { $kept.Add($v) | Out-Null }
+$state.last_violations = @($kept)
+
+($state | ConvertTo-Json -Compress -Depth 8) | Set-Content -LiteralPath $stateFile -Encoding utf8
 
 Write-Output '{}'
 exit 0

--- a/.cursor/hooks/unit-test-guardrails-stop.ps1
+++ b/.cursor/hooks/unit-test-guardrails-stop.ps1
@@ -1,7 +1,10 @@
 #Requires -Version 7
 <#
-  stop: if git-changed test files (or afterFileEdit failure log) violate
-  unit-test guardrails, emit followup_message so the agent must fix them.
+  stop: if THIS conversation edited test files that still violate unit-test
+  guardrails, emit followup_message so the same agent must fix them.
+
+  Intentionally does NOT scan the whole git working tree (-GitChanged): that
+  pulled other agents' dirty test files into this conversation's follow-up loop.
 #>
 $ErrorActionPreference = 'Stop'
 $stdin = [Console]::In.ReadToEnd()
@@ -19,29 +22,66 @@ if ($status -ne 'completed') {
     exit 0
 }
 
+$conversationId = $null
+if ($payload) {
+    foreach ($name in @('conversation_id', 'conversationId', 'session_id', 'sessionId')) {
+        if ($payload.PSObject.Properties.Name -contains $name -and $payload.$name) {
+            $conversationId = [string]$payload.$name
+            break
+        }
+    }
+}
+
+# No conversation scope ⇒ do not follow up (avoids cross-agent wake-ups).
+if ([string]::IsNullOrWhiteSpace($conversationId)) {
+    Write-Output '{}'
+    exit 0
+}
+
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 Set-Location $repoRoot
 
+$stateDir = Join-Path $PSScriptRoot '.state'
+$safeId = ($conversationId -replace '[\\/:*?"<>|]', '_')
+$stateFile = Join-Path $stateDir "unit-test-guardrail-$safeId.json"
+
+# One-time migration: drop the legacy shared jsonl so other agents stop inheriting it.
+$legacyShared = Join-Path $stateDir 'unit-test-guardrail-failures.jsonl'
+if (Test-Path -LiteralPath $legacyShared) {
+    Remove-Item -LiteralPath $legacyShared -Force -ErrorAction SilentlyContinue
+}
+
+if (-not (Test-Path -LiteralPath $stateFile)) {
+    Write-Output '{}'
+    exit 0
+}
+
+$state = $null
+try { $state = Get-Content -LiteralPath $stateFile -Raw | ConvertFrom-Json } catch { }
+$files = @()
+if ($state -and $state.files) { $files = @($state.files | Where-Object { $_ }) }
+
+if ($files.Count -eq 0) {
+    Remove-Item -LiteralPath $stateFile -Force -ErrorAction SilentlyContinue
+    Write-Output '{}'
+    exit 0
+}
+
+$existing = @($files | Where-Object { Test-Path -LiteralPath $_ })
+if ($existing.Count -eq 0) {
+    Remove-Item -LiteralPath $stateFile -Force -ErrorAction SilentlyContinue
+    Write-Output '{}'
+    exit 0
+}
+
 $script = Join-Path $repoRoot 'scripts\assert-unit-test-guardrails.ps1'
-$jsonOut = & pwsh -NoProfile -File $script -GitChanged -Json 2>&1 | Out-String
+$jsonOut = & pwsh -NoProfile -File $script -Path $existing -Json 2>&1 | Out-String
 $result = $null
 try { $result = $jsonOut | ConvertFrom-Json } catch { }
 
 $violations = @()
 if ($result -and $result.violations) {
     $violations = @($result.violations)
-}
-
-$stateFile = Join-Path $PSScriptRoot '.state\unit-test-guardrail-failures.jsonl'
-if (Test-Path -LiteralPath $stateFile) {
-    # Include recent after-edit findings still present on disk
-    Get-Content -LiteralPath $stateFile -ErrorAction SilentlyContinue | ForEach-Object {
-        try {
-            $row = $_ | ConvertFrom-Json
-            if ($row.violations) { $violations += @($row.violations) }
-        }
-        catch { }
-    }
 }
 
 # De-dupe by file:line:rule
@@ -53,12 +93,20 @@ foreach ($v in $violations) {
 }
 
 if ($unique.Count -eq 0) {
-    if (Test-Path -LiteralPath $stateFile) {
-        Remove-Item -LiteralPath $stateFile -Force -ErrorAction SilentlyContinue
-    }
+    Remove-Item -LiteralPath $stateFile -Force -ErrorAction SilentlyContinue
     Write-Output '{}'
     exit 0
 }
+
+# Persist fresh violations for this conversation only (helps the next after-edit merge).
+if ($state) {
+    $state.last_violations = @($unique)
+    $state.updated_at = [DateTime]::UtcNow.ToString('o')
+    ($state | ConvertTo-Json -Compress -Depth 8) | Set-Content -LiteralPath $stateFile -Encoding utf8
+}
+
+$pathArgs = ($existing | ForEach-Object { "'$_'" }) -join ', '
+$verifyCmd = "pwsh ./scripts/assert-unit-test-guardrails.ps1 -Path @($pathArgs)"
 
 if ($loopCount -ge 3) {
     $summary = ($unique | Select-Object -First 8 | ForEach-Object {
@@ -66,12 +114,12 @@ if ($loopCount -ge 3) {
         }) -join "`n"
     Write-Output (@{
             followup_message = @"
-STOP: unit-test guardrail violations remain after $loopCount fix attempts. Do not claim the test work is done.
+STOP: unit-test guardrail violations remain after $loopCount fix attempts in this conversation. Do not claim the test work is done.
 
 $summary
 
-Read .cursor/rules/unit-tests.mdc and fix every violation, then re-run:
-pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged
+Read .cursor/rules/unit-tests.mdc and fix every violation in the files this conversation edited, then re-run:
+$verifyCmd
 "@
         } | ConvertTo-Json -Compress)
     exit 0
@@ -83,12 +131,12 @@ $summary = ($unique | Select-Object -First 12 | ForEach-Object {
 
 Write-Output (@{
         followup_message = @"
-Unit-test guardrail violations detected (unit-tests.mdc). Fix them before finishing.
+Unit-test guardrail violations detected in files this conversation edited (unit-tests.mdc). Fix them before finishing. Do not edit other agents' test files.
 
 $summary
 
 Re-read .cursor/rules/unit-tests.mdc. Prefer DomainTestFixture specimens, Fact(DisplayName=...), Arrange/Act/Assert, and Moq over NotImplementedException doubles. Then run:
-pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged
+$verifyCmd
 "@
     } | ConvertTo-Json -Compress)
 exit 0

--- a/.cursor/rules/unit-tests-enforcement.mdc
+++ b/.cursor/rules/unit-tests-enforcement.mdc
@@ -22,6 +22,10 @@ alwaysApply: true
 | `throw new NotImplementedException` in `BusinessRules/**` test doubles | Prefer Moq / focused fakes that implement only used members |
 | Raw `new Podcast` / `new Episode` filler when `DomainTestFixture` applies | Use fixture factories |
 
+## Cursor stop hook (conversation-scoped)
+
+The `.cursor/hooks` stop follow-up only re-prompts **the conversation that edited** the violating test files. It does **not** scan the whole git working tree, so another agent sharing the workspace is not woken to fix this agent's tests. CI / manual checks may still use `-GitChanged`.
+
 ## Stop checklist
 
 Before claiming test work done:

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -645,12 +645,13 @@ public class CatalogueMatchingRules
         "inside the expanded twelve-hour release window.")]
     public void youtube_discovered_unique_duration_within_release_window_matches_without_title_confidence()
     {
-        // Arrange — Virginia-style: Apple/YouTube title vs editorial Spotify rename; same length, same day
-        const string storedTitle = "Virginia | Ep 3: Mommy still loves you";
-        const string spotifyTitle = "Ep 3 — A restraining order that changed everything";
+        // Arrange — serialised-narrative shape: Apple/YouTube title vs editorial Spotify rename;
+        // same length, same day
+        var storedTitle = _fixture.CreateTitle();
+        var spotifyTitle = _fixture.CreateTitle();
         var sharedLength = TimeSpan.FromMinutes(58) + TimeSpan.FromSeconds(34);
-        var probeRelease = new DateTime(2026, 7, 24, 19, 0, 0, DateTimeKind.Utc);
-        var spotifyRelease = new DateTime(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+        var probeRelease = DomainTestFixture.UtcAtTime(-2, new TimeSpan(19, 0, 0));
+        var spotifyRelease = DomainTestFixture.SameCalendarDateWithTime(probeRelease, new TimeSpan(12, 0, 0));
         var probe = _fixture.CreateEpisode(e =>
         {
             e.Title = storedTitle;
@@ -680,6 +681,44 @@ public class CatalogueMatchingRules
     }
 
     [Fact(DisplayName =
+        "Incident (Jul 2026): when enriching a YouTube-discovered episode, a date-only Spotify catalogue " +
+        "row from the same calendar day must match on unique duration even though its midnight release " +
+        "sits more than twelve hours from a late-in-the-day YouTube publish.")]
+    public void youtube_discovered_spotify_date_only_same_day_unique_duration_matches_outside_twelve_hours()
+    {
+        // Arrange — Spotify carries no time-of-day, so its midnight release is 21 hours from the video
+        var youTubePublish = DomainTestFixture.UtcAtTime(-3, new TimeSpan(21, 0, 0));
+        var spotifyRelease = DomainTestFixture.SpotifyCatalogueReleaseDaysAfterYouTube(youTubePublish, 0);
+        var sharedLength = _fixture.CreateDuration();
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = sharedLength;
+            e.Release = youTubePublish;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+        });
+        var spotifyCatalogueItem = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = sharedLength;
+            e.Release = spotifyRelease;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+        });
+        var podcast = _fixture.CreatePodcast();
+
+        // Act
+        var result = _matcher.FindCatalogueMatchByLength(
+            probe,
+            [spotifyCatalogueItem],
+            podcast,
+            episodeMatchRegex: null,
+            new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
+
+        // Assert
+        result.Should().BeSameAs(spotifyCatalogueItem);
+    }
+
+    [Fact(DisplayName =
         "When enriching a YouTube-discovered episode with both EnrichingYouTubeDiscoveredEpisode and " +
         "AcceptUniqueDurationWithoutTitleMatch set (legacy Spotify finder combo), indexing must still " +
         "refuse a wrong-week Spotify catalogue row within five minutes whose title is wholly disjoint.")]
@@ -692,18 +731,19 @@ public class CatalogueMatchingRules
             "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost";
         var lastWeekYouTubeLength = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
         var thisWeekSpotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-15, new TimeSpan(3, 30, 46));
         var probe = _fixture.CreateEpisode(e =>
         {
             e.Title = lastWeekYouTubeTitle;
             e.Length = lastWeekYouTubeLength;
-            e.Release = new DateTime(2026, 7, 11, 3, 30, 46, DateTimeKind.Utc);
+            e.Release = youTubeRelease;
             e.YouTubeId = _fixture.CreateYouTubeId();
         });
         var catalogueItem = _fixture.CreateEpisode(e =>
         {
             e.Title = thisWeekSpotifyTitle;
             e.Length = thisWeekSpotifyLength;
-            e.Release = new DateTime(2026, 7, 13, 8, 30, 0, DateTimeKind.Utc);
+            e.Release = DomainTestFixture.SpotifyCatalogueReleaseDaysAfterYouTube(youTubeRelease, 2);
             e.SpotifyId = _fixture.CreateSpotifyId();
         });
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
@@ -246,10 +246,29 @@ public sealed partial class EpisodePlatformMatcher
         var matches = sampleList
             .Where(x =>
                 Math.Abs((x.Length - probe.Length).Ticks) < CatalogueYouTubeDiscoveredDurationThreshold &&
-                Math.Abs((x.Release - probe.Release).Ticks) < CatalogueYouTubeDiscoveredReleaseThreshold.Ticks)
+                IsWithinYouTubeDiscoveredReleaseWindow(probe.Release, x))
             .ToList();
 
         return matches.Count == 1 ? matches[0] : null;
+    }
+
+    /// <summary>
+    /// Spotify catalogue releases are date-only (midnight UTC), so a late-in-the-day YouTube publish
+    /// sits more than twelve hours from its own Spotify row. Compare Spotify rows with the shared
+    /// calendar-day tolerance instead. Apple/YouTube catalogue rows carry a publish time-of-day and
+    /// keep the twelve-hour tick window.
+    /// </summary>
+    private static bool IsWithinYouTubeDiscoveredReleaseWindow(DateTime probeRelease, Episode catalogueItem)
+    {
+        if (!string.IsNullOrWhiteSpace(catalogueItem.SpotifyId))
+        {
+            return EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
+                catalogueItem.Release,
+                probeRelease);
+        }
+
+        return Math.Abs((catalogueItem.Release - probeRelease).Ticks) <
+               CatalogueYouTubeDiscoveredReleaseThreshold.Ticks;
     }
 
     private static bool HasCatalogueTitleConfidence(string probeTitle, string candidateTitle)
@@ -294,8 +313,7 @@ public sealed partial class EpisodePlatformMatcher
         if (released != DateTime.MinValue)
         {
             var releaseMatches = sampleList
-                .Where(x => Math.Abs((x.Release - released).Ticks) <
-                            CatalogueYouTubeDiscoveredReleaseThreshold.Ticks)
+                .Where(x => IsWithinYouTubeDiscoveredReleaseWindow(released, x))
                 .ToList();
             if (releaseMatches.Count == 1)
             {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SearchResultFinderCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SearchResultFinderCatalogueWrapperRules.cs
@@ -90,14 +90,14 @@ public class SearchResultFinderCatalogueWrapperRules
         "disjoint title must not be selected.")]
     public void find_by_length_youtube_enrichment_does_not_duration_snipe_disjoint_title()
     {
-        // Arrange — wrong-week YouTube (~59:40) must not claim this week's Spotify (~62:39) on duration alone
-        const string youTubeTitle =
-            "Civic turnout strategies for mid-cycle ballot measures";
-        const string spotifyTitle =
-            "She Spent a Fortune in a Wellness Scheme with a Guest: New parenthood and a decade lost";
-        var youTubeLength = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
-        var spotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(39);
+        // Arrange — wrong-week YouTube must not claim a later Spotify row on duration alone
+        var youTubeTitle = _fixture.CreateLongTitle();
+        var spotifyTitle = _fixture.CreateLongTitle();
+        var youTubeLength = _fixture.CreateDuration();
+        var spotifyLength = youTubeLength + TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(59);
         var matchingId = _fixture.CreateSpotifyId();
+        var probeRelease = DomainTestFixture.UtcAtTime(-9, new TimeSpan(3, 30, 46));
+        var spotifyReleaseDate = DomainTestFixture.UtcDateDaysAgo(7);
         var episodes = new List<SimpleEpisode>
         {
             new()
@@ -105,7 +105,7 @@ public class SearchResultFinderCatalogueWrapperRules
                 Id = matchingId,
                 Name = spotifyTitle,
                 DurationMs = (int)spotifyLength.TotalMilliseconds,
-                ReleaseDate = "2026-07-13"
+                ReleaseDate = spotifyReleaseDate.ToString("yyyy-MM-dd")
             }
         };
 
@@ -115,7 +115,7 @@ public class SearchResultFinderCatalogueWrapperRules
             youTubeLength,
             episodes,
             releaseAuthority: Service.YouTube,
-            released: new DateTime(2026, 7, 11, 3, 30, 46, DateTimeKind.Utc),
+            released: probeRelease,
             enrichingYouTubeDiscoveredEpisode: true);
 
         // Assert
@@ -124,14 +124,16 @@ public class SearchResultFinderCatalogueWrapperRules
 
     [Fact(DisplayName =
         "When enriching a YouTube-discovered episode via the Spotify finder, a sole catalogue row " +
-        "with unique duration inside the twelve-hour release window is selected even when titles diverge.")]
+        "with unique duration on the same calendar day is selected even when titles diverge.")]
     public void find_by_length_youtube_enrichment_accepts_unique_duration_within_release_window()
     {
-        // Arrange
-        const string youTubeTitle = "Virginia | Ep 3: Mommy still loves you";
-        const string spotifyTitle = "Ep 3 — A restraining order that changed everything";
-        var length = TimeSpan.FromMinutes(58) + TimeSpan.FromSeconds(34);
+        // Arrange — YouTube title vs wholly different Spotify rename; same length, same calendar day
+        var youTubeTitle = _fixture.CreateLongTitle();
+        var spotifyTitle = _fixture.CreateLongTitle();
+        var length = _fixture.CreateDuration();
         var matchingId = _fixture.CreateSpotifyId();
+        var spotifyReleaseDate = DomainTestFixture.UtcDateDaysAgo(2);
+        var probeRelease = DomainTestFixture.UtcAtTime(-2, TimeSpan.FromHours(10));
         var episodes = new List<SimpleEpisode>
         {
             new()
@@ -139,7 +141,7 @@ public class SearchResultFinderCatalogueWrapperRules
                 Id = matchingId,
                 Name = spotifyTitle,
                 DurationMs = (int)length.TotalMilliseconds,
-                ReleaseDate = "2026-07-24"
+                ReleaseDate = spotifyReleaseDate.ToString("yyyy-MM-dd")
             }
         };
 
@@ -149,7 +151,46 @@ public class SearchResultFinderCatalogueWrapperRules
             length,
             episodes,
             releaseAuthority: Service.Spotify,
-            released: new DateTime(2026, 7, 24, 10, 0, 0, DateTimeKind.Utc),
+            released: probeRelease,
+            enrichingYouTubeDiscoveredEpisode: true);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(matchingId);
+    }
+
+    [Fact(DisplayName =
+        "When enriching a YouTube-discovered episode via the Spotify finder, a sole catalogue row with " +
+        "unique duration on the same calendar day is selected even when the YouTube publish is more than " +
+        "twelve hours after Spotify midnight, because Spotify catalogue releases are date-only.")]
+    public void find_by_length_youtube_enrichment_accepts_same_day_spotify_outside_twelve_hours()
+    {
+        // Arrange
+        var youTubeTitle = _fixture.CreateLongTitle();
+        var spotifyTitle = _fixture.CreateLongTitle();
+        var length = _fixture.CreateDuration();
+        var matchingId = _fixture.CreateSpotifyId();
+        var afternoonPublish = TimeSpan.FromHours(17) + TimeSpan.FromMinutes(28);
+        var probeRelease = DomainTestFixture.UtcAtTime(-2, afternoonPublish);
+        var episodes = new List<SimpleEpisode>
+        {
+            new()
+            {
+                Id = matchingId,
+                Name = spotifyTitle,
+                DurationMs = (int)length.TotalMilliseconds,
+                ReleaseDate = probeRelease.ToString("yyyy-MM-dd")
+            }
+        };
+        (probeRelease - probeRelease.Date).Should().BeGreaterThan(TimeSpan.FromHours(12));
+
+        // Act
+        var result = _sut.FindMatchingEpisodeByLength(
+            youTubeTitle,
+            length,
+            episodes,
+            releaseAuthority: Service.Spotify,
+            released: probeRelease,
             enrichingYouTubeDiscoveredEpisode: true);
 
         // Assert
@@ -195,10 +236,11 @@ public class SearchResultFinderCatalogueWrapperRules
     public void find_by_length_youtube_enrichment_accepts_title_confident_duration_match()
     {
         // Arrange
-        const string title =
-            "Civic turnout strategies for mid-cycle ballot measures";
-        var length = TimeSpan.FromMinutes(59) + TimeSpan.FromSeconds(40);
+        var title = _fixture.CreateLongTitle();
+        var length = _fixture.CreateDuration();
         var matchingId = _fixture.CreateSpotifyId();
+        var releaseDate = DomainTestFixture.UtcDateDaysAgo(5);
+        var probeRelease = DomainTestFixture.UtcAtTime(-5, new TimeSpan(3, 30, 46));
         var episodes = new List<SimpleEpisode>
         {
             new()
@@ -206,7 +248,7 @@ public class SearchResultFinderCatalogueWrapperRules
                 Id = matchingId,
                 Name = title,
                 DurationMs = (int)length.TotalMilliseconds,
-                ReleaseDate = "2026-07-11"
+                ReleaseDate = releaseDate.ToString("yyyy-MM-dd")
             }
         };
 
@@ -216,7 +258,7 @@ public class SearchResultFinderCatalogueWrapperRules
             length,
             episodes,
             releaseAuthority: Service.YouTube,
-            released: new DateTime(2026, 7, 11, 3, 30, 46, DateTimeKind.Utc),
+            released: probeRelease,
             enrichingYouTubeDiscoveredEpisode: true);
 
         // Assert

--- a/Cloud/Unit-Tests/Indexer.Tests/PodcastEpisodeExtensionsTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/PodcastEpisodeExtensionsTests.cs
@@ -17,9 +17,12 @@ namespace Indexer.Tests;
 
 public class PodcastEpisodeExtensionsTests
 {
-    [Fact]
+    [Fact(DisplayName =
+        "ToEpisodeSearchRecord maps platform ids and podcast language, and wires YouTube image " +
+        "compaction through the youtubeId.")]
     public void Maps_service_ids_language_and_compacts_youtube_image()
     {
+        // Arrange
         var episode = CreateEpisode();
         episode.Images = new EpisodeImages
         {
@@ -35,8 +38,10 @@ public class PodcastEpisodeExtensionsTests
             SearchTerms = "podcast terms"
         };
 
+        // Act
         var result = new PodcastEpisode(podcast, episode).ToEpisodeSearchRecord();
 
+        // Assert
         result.SpotifyId.Should().Be("spotify-episode-id");
         result.YoutubeId.Should().Be("youtube-id");
         result.AppleId.Should().Be("987654321");
@@ -49,9 +54,11 @@ public class PodcastEpisodeExtensionsTests
         result.Duration.Should().Be("00:02:03");
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "ToEpisodeSearchRecord omits blank platform ids and compacts a Spotify-only image.")]
     public void Compacts_spotify_image_and_omits_empty_ids()
     {
+        // Arrange
         var episode = CreateEpisode();
         episode.SpotifyId = " ";
         episode.YouTubeId = string.Empty;
@@ -61,55 +68,72 @@ public class PodcastEpisodeExtensionsTests
             Spotify = new Uri("https://i.scdn.co/image/opaque")
         };
 
+        // Act
         var result = new PodcastEpisode(new Podcast { Name = "Podcast" }, episode)
             .ToEpisodeSearchRecord();
 
+        // Assert
         result.SpotifyId.Should().BeNull();
         result.YoutubeId.Should().BeNull();
         result.AppleId.Should().BeNull();
         result.Image.Should().Be("sopaque");
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "ToEpisodeSearchRecord truncates long descriptions on a word boundary and appends an ellipsis.")]
     public void Truncates_long_description_on_word_boundary_with_ellipsis()
     {
+        // Arrange
         var episode = CreateEpisode();
         // 220 chars of complete words, then a partial token that would be mid-cut at 230.
-        episode.Description = new string('a', 10) + " " + new string('b', 209) + " Salt Lake City continues";
+        episode.Description = new string('a', 10) + " " + new string('b', 209) + " Alpha Bravo continues";
         episode.Description.Length.Should().BeGreaterThan(Constants.DescriptionSize);
 
+        // Act
         var result = new PodcastEpisode(new Podcast { Name = "Podcast" }, episode)
             .ToEpisodeSearchRecord();
 
+        // Assert
         result.EpisodeDescription.Length.Should().BeLessThanOrEqualTo(Constants.DescriptionSize);
         result.EpisodeDescription.Should().EndWith("\u2026");
-        result.EpisodeDescription.Should().Contain("Salt");
-        result.EpisodeDescription.Should().NotContain("Lake");
+        result.EpisodeDescription.Should().Contain("Alpha");
+        result.EpisodeDescription.Should().NotContain("Bravo");
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "ToEpisodeSearchRecord trims short descriptions without truncating or appending an ellipsis.")]
     public void Leaves_short_description_unchanged()
     {
+        // Arrange
         var episode = CreateEpisode();
         episode.Description = "  Short description.  ";
 
+        // Act
         var result = new PodcastEpisode(new Podcast { Name = "Podcast" }, episode)
             .ToEpisodeSearchRecord();
 
+        // Assert
         result.EpisodeDescription.Should().Be("Short description.");
     }
 
-    [Fact]
-    public void Slim_schema_drops_explicit_and_hides_language()
+    [Fact(DisplayName =
+        "Slim EpisodeSearchRecord schema drops explicit, keeps platform ids, and leaves lang " +
+        "filterable+facetable and retrievable for search/flix language flags.")]
+    public void Slim_schema_drops_explicit_and_keeps_lang_retrievable()
     {
-        var fields = new FieldBuilder
+        // Arrange
+        var builder = new FieldBuilder
         {
             Serializer = new JsonObjectSerializer(new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             })
-        }.Build(typeof(EpisodeSearchRecord));
+        };
 
+        // Act
+        var fields = builder.Build(typeof(EpisodeSearchRecord));
+
+        // Assert
         fields.Should().NotContain(field => field.Name == "explicit");
         fields.Should().Contain(field => field.Name == "spotifyId");
         fields.Should().Contain(field => field.Name == "youtubeId");
@@ -119,7 +143,7 @@ public class PodcastEpisodeExtensionsTests
         var language = fields.Single(field => field.Name == "lang");
         language.IsFilterable.Should().BeTrue();
         language.IsFacetable.Should().BeTrue();
-        language.IsHidden.Should().BeTrue();
+        language.IsHidden.Should().BeFalse();
     }
 
     private static Episode CreateEpisode() => new()
@@ -127,7 +151,7 @@ public class PodcastEpisodeExtensionsTests
         Id = Guid.NewGuid(),
         Title = " Episode ",
         Description = "Description",
-        Release = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc),
+        Release = DateTime.UtcNow.Date.AddDays(-9).AddHours(12),
         Length = TimeSpan.FromSeconds(123),
         SpotifyId = "spotify-episode-id",
         YouTubeId = "youtube-id",


### PR DESCRIPTION
## Summary

- **Spotify catalogue releases are now compared by calendar day during YouTube-discovered enrichment.** Spotify rows carry a date-only release (midnight UTC), so a late-in-the-day YouTube publish sat more than twelve hours from its own Spotify row and was rejected by the flat tick window. Apple rows carry a real publish time-of-day, so they matched — which is why episodes ended up with an Apple URL but no Spotify URL. Spotify rows now use the shared calendar-day tolerance (`EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches`); Apple/YouTube rows keep the twelve-hour window. The widening applies in both places that used the raw threshold, and only behind the existing unique-duration gate (a sole candidate within five minutes), so wrong-week duration snipes are still refused.
- **Fixed a schema test that had been failing on `main`.** `9406e3af` deliberately made `EpisodeSearchRecord.Lang` retrievable so search/flix cards can show language flags, but `Indexer.Tests` still asserted the old hidden-field contract. It now asserts `IsHidden == false`, is renamed accordingly, and the rest of that file was brought up to the guardrail shape.
- **Scoped the unit-test guardrail hooks to the editing conversation.** The stop hook scanned the whole dirty git tree, so any agent sharing the workspace was woken to fix test files another conversation had edited. Edited test files are now tracked per conversation id and only those are scanned on stop.

Reproduced against The Roys Report: the Spotify URL for the 25 Jul episode now merges into the existing episode rather than being dropped.

## Test plan

- [x] `RedditPodcastPoster.Episodes.Tests` — 293 passed (includes new `youtube_discovered_spotify_date_only_same_day_unique_duration_matches_outside_twelve_hours`)
- [x] `RedditPodcastPoster.PodcastServices.Spotify.Tests` — 160 passed (includes new `find_by_length_youtube_enrichment_accepts_same_day_spotify_outside_twelve_hours`)
- [x] `Indexer.Tests` — 101 passed (was 100/1 failing on `main`)
- [x] Downstream projects consuming the matcher: Apple 34, YouTube 210, PodcastServices 68, UrlSubmission 58, FunctionHost 126 — all green
- [x] New matcher test confirmed to fail without the fix (short-circuiting the Spotify branch yields `null`), so it genuinely guards the behaviour
- [x] `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged` clean
- [x] Verified live via published `Index.exe` reindex of The Roys Report — Spotify link present on the episode
