### PR TITLE
fix(indexing): widen Spotify catalogue fetch ReleasedSince for enrich

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -1304,4 +1304,47 @@ public class CatalogueMatchingRules
         // Assert
         result.Should().BeSameAs(candidateWithoutRelease);
     }
+
+    [Fact(DisplayName =
+        "Incident (Jul 2026): when enriching a YouTube-discovered episode whose Spotify row is title-confident " +
+        "(editorial prefix + case variation) and whose duration is within five minutes, the match succeeds even " +
+        "though the date-only Spotify release sits two calendar days before the offset-adjusted probe date.")]
+    public void youtube_discovered_title_confident_duration_match_succeeds_when_spotify_date_two_days_before_probe()
+    {
+        // Arrange — probe body carries capitals; Spotify row is "<prefix> " + lowercased probe body,
+        // so the case-sensitive containment gate fails and matching must fall to title-confidence.
+        var probeTitle = "Nightshade: How The Victims Were Silenced";
+        var spotifyTitle = "Special Report " + probeTitle.ToLowerInvariant();
+        var probeLength = new TimeSpan(0, 25, 19);
+        var spotifyLength = new TimeSpan(0, 27, 58);
+        var probeRelease = DomainTestFixture.UtcAtTime(-2, new TimeSpan(9, 7, 30));
+        var spotifyRelease = probeRelease.Date.AddDays(-2);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = probeTitle;
+            e.Length = probeLength;
+            e.Release = probeRelease;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+        });
+        var spotifyCandidate = _fixture.CreateEpisode(e =>
+        {
+            e.Title = spotifyTitle;
+            e.Length = spotifyLength;
+            e.Release = spotifyRelease;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+        });
+        var podcast = _fixture.CreatePodcast(p =>
+            p.YouTubePublicationOffset = TimeSpan.FromHours(1).Ticks);
+
+        // Act
+        var result = _matcher.FindCatalogueMatchByLength(
+            probe,
+            [spotifyCandidate],
+            podcast,
+            episodeMatchRegex: null,
+            new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
+
+        // Assert
+        result.Should().BeSameAs(spotifyCandidate);
+    }
 }

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/SpotifyCatalogueFetchReleasedSinceRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/SpotifyCatalogueFetchReleasedSinceRules.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using RedditPodcastPoster.Episodes.Matching;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+
+namespace RedditPodcastPoster.Episodes.Tests.BusinessRules.Matching;
+
+/// <summary>
+/// Spotify catalogue fetch window must include date-only rows the matcher can still accept.
+/// </summary>
+public class SpotifyCatalogueFetchReleasedSinceRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "GetSpotifyCatalogueFetchReleasedSince widens the indexing ReleasedSince floor by the " +
+        "audio-release consideration threshold so date-only Spotify catalogue rows that still match " +
+        "within GetToleranceTicks are not dropped by PaginateEpisodes before enrichment.")]
+    public void spotify_catalogue_fetch_released_since_widens_by_consideration_threshold()
+    {
+        // Arrange
+        var indexingReleasedSince = DomainTestFixture.UtcDateDaysAgo(2);
+
+        // Act
+        var fetchReleasedSince = EpisodeReleaseTolerance.GetSpotifyCatalogueFetchReleasedSince(indexingReleasedSince);
+        var nullFetch = EpisodeReleaseTolerance.GetSpotifyCatalogueFetchReleasedSince(null);
+
+        // Assert
+        fetchReleasedSince.Should().Be(
+            indexingReleasedSince.Date.Subtract(
+                EpisodeReleaseTolerance.YouTubeAuthorityToAudioReleaseConsiderationThreshold));
+        nullFetch.Should().BeNull();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodeReleaseTolerance.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodeReleaseTolerance.cs
@@ -104,6 +104,22 @@ public static class EpisodeReleaseTolerance
             ? YouTubeReleaseAuthoritySpotifyCatalogueDayTolerance
             : 1;
 
+    /// <summary>
+    /// Spotify catalogue releases are date-only (midnight UTC) and often land one or more calendar days
+    /// before the indexing <paramref name="indexingReleasedSince"/> floor derived from YouTube publish.
+    /// Widen the Spotify fetch window to match <see cref="GetToleranceTicks"/> acceptance so enrichment
+    /// candidates are not filtered out of <c>PaginateEpisodes</c> before the matcher runs.
+    /// </summary>
+    public static DateTime? GetSpotifyCatalogueFetchReleasedSince(DateTime? indexingReleasedSince)
+    {
+        if (!indexingReleasedSince.HasValue)
+        {
+            return null;
+        }
+
+        return indexingReleasedSince.Value.Date.Subtract(YouTubeAuthorityToAudioReleaseConsiderationThreshold);
+    }
+
     public static bool SpotifyCatalogueReleaseMatches(DateTime spotifyCatalogueRelease, DateTime expectedRelease) =>
         SpotifyCatalogueReleaseMatches(spotifyCatalogueRelease, expectedRelease, toleranceTicks: 0, podcast: null);
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Providers/SpotifyPodcastEpisodesProviderRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Providers/SpotifyPodcastEpisodesProviderRules.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using RedditPodcastPoster.Episodes.Matching;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Spotify;
@@ -399,8 +400,61 @@ public class SpotifyPodcastEpisodesProviderRules
         capturedRequest!.Limit.Should().Be(50);
         result.Episodes.Select(x => x.Id).Should().Contain(recent.Id);
         paginator.Verify(
-            x => x.PaginateEpisodes(It.IsAny<IPaginatable<SimpleEpisode>?>(), It.IsAny<IndexingContext>()),
+            x => x.PaginateEpisodes(
+                It.IsAny<IPaginatable<SimpleEpisode>?>(),
+                It.Is<IndexingContext>(ctx =>
+                    ctx.ReleasedSince == EpisodeReleaseTolerance.GetSpotifyCatalogueFetchReleasedSince(
+                        indexingContext.ReleasedSince))),
             Times.Once);
+    }
+
+    [Fact(DisplayName =
+        "When GetEpisodes paginates with ReleasedSince, the Spotify fetch window is widened by the " +
+        "audio-release consideration threshold so a date-only Spotify row one day before the indexing floor " +
+        "remains a catalogue candidate for YouTube-discovered enrichment.")]
+    public async Task Known_id_path_widens_released_since_for_spotify_catalogue_fetch()
+    {
+        // Arrange
+        var showId = _fixture.CreateSpotifyId();
+        var indexingReleasedSince = DomainTestFixture.UtcDateDaysAgo(2);
+        var episodeJustBeforeFloor = CreateEpisode(_fixture.CreateSpotifyId(), daysAgo: 3);
+        IndexingContext? capturedFetchContext = null;
+        var wrapper = new Mock<ISpotifyClientWrapper>();
+        wrapper
+            .Setup(x => x.GetShowEpisodes(
+                showId,
+                It.IsAny<ShowEpisodesRequest>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Paging<SimpleEpisode>
+            {
+                Items = [episodeJustBeforeFloor],
+                Next = null
+            });
+
+        var paginator = new Mock<ISpotifyQueryPaginator>();
+        paginator
+            .Setup(x => x.PaginateEpisodes(It.IsAny<IPaginatable<SimpleEpisode>?>(), It.IsAny<IndexingContext>()))
+            .Callback<IPaginatable<SimpleEpisode>?, IndexingContext>((_, ctx) => capturedFetchContext = ctx)
+            .ReturnsAsync(new PodcastEpisodesResult([episodeJustBeforeFloor]));
+
+        var sut = CreateSut(wrapper.Object, paginator.Object, Mock.Of<ISpotifySearchResultFinder>());
+        var indexingContext = new IndexingContext(
+            ReleasedSince: indexingReleasedSince,
+            SkipPodcastDiscovery: true,
+            SkipExpensiveSpotifyQueries: false);
+
+        // Act
+        var result = await sut.GetEpisodes(
+            new GetEpisodesRequest(new SpotifyPodcastId(showId), Market.CountryCode),
+            indexingContext);
+
+        // Assert
+        capturedFetchContext.Should().NotBeNull();
+        capturedFetchContext!.ReleasedSince.Should().Be(
+            EpisodeReleaseTolerance.GetSpotifyCatalogueFetchReleasedSince(indexingReleasedSince));
+        capturedFetchContext.ReleasedSince.Should().BeBefore(indexingReleasedSince.Date);
+        result.Episodes.Select(x => x.Id).Should().Contain(episodeJustBeforeFloor.Id);
     }
 
     [Fact(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyPodcastEpisodesProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Providers/SpotifyPodcastEpisodesProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes.Matching;
 using RedditPodcastPoster.PodcastServices.Abstractions.Caches;
 using RedditPodcastPoster.PodcastServices.Spotify.Client;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
@@ -92,7 +93,9 @@ public class SpotifyPodcastEpisodesProvider(
                         }
 
                         var paginateEpisodeResponse =
-                            await spotifyQueryPaginator.PaginateEpisodes(paging.Episodes, indexingContext);
+                            await spotifyQueryPaginator.PaginateEpisodes(
+                                paging.Episodes,
+                                WithSpotifyCatalogueFetchReleasedSince(indexingContext));
                         var result = paginateEpisodeResponse.Episodes.GroupBy(x => x.Id).Select(x => x.First());
                         allEpisodes.Add(result.ToList());
                         expensiveQueryFound = MergeExpensiveQueryFound(
@@ -130,7 +133,9 @@ public class SpotifyPodcastEpisodesProvider(
         GetEpisodesRequest request,
         IndexingContext indexingContext)
     {
-        if (_cache.TryGetValue(request.SpotifyPodcastId.PodcastId, out var episodes))
+        var fetchContext = WithSpotifyCatalogueFetchReleasedSince(indexingContext);
+        var cacheKey = GetCacheKey(request.SpotifyPodcastId.PodcastId, indexingContext.ReleasedSince);
+        if (_cache.TryGetValue(cacheKey, out var episodes))
         {
             return episodes;
         }
@@ -180,13 +185,25 @@ public class SpotifyPodcastEpisodesProvider(
                 nameof(GetEpisodes));
         }
 
-        var results = await spotifyQueryPaginator.PaginateEpisodes(pagedEpisodes, indexingContext);
+        var results = await spotifyQueryPaginator.PaginateEpisodes(pagedEpisodes, fetchContext);
         var freeResults = new PodcastEpisodesResult(
             TakeFreeEpisodes(results.Episodes, market),
             results.ExpensiveQueryFound);
-        _cache[request.SpotifyPodcastId.PodcastId] = freeResults;
+        _cache[cacheKey] = freeResults;
         return freeResults;
     }
+
+    private static IndexingContext WithSpotifyCatalogueFetchReleasedSince(IndexingContext indexingContext) =>
+        indexingContext with
+        {
+            ReleasedSince = EpisodeReleaseTolerance.GetSpotifyCatalogueFetchReleasedSince(
+                indexingContext.ReleasedSince)
+        };
+
+    private static string GetCacheKey(string podcastId, DateTime? releasedSince) =>
+        releasedSince.HasValue
+            ? $"{podcastId}:{releasedSince.Value.Date:yyyy-MM-dd}"
+            : podcastId;
 
     private List<SimpleEpisode> TakeFreeEpisodes(IEnumerable<SimpleEpisode> episodes, string market)
     {


### PR DESCRIPTION
## Summary
- Spotify `PaginateEpisodes` was hard-filtering episodes older than `indexingContext.ReleasedSince` before matching, so date-only Spotify catalogue rows (often one+ calendar days before a YouTube-derived floor) never reached enrichment — unlike Apple, which only uses ReleasedSince as stop-paging.
- Wire `EpisodeReleaseTolerance.GetSpotifyCatalogueFetchReleasedSince` (14-day widen via `YouTubeAuthorityToAudioReleaseConsiderationThreshold`) into `SpotifyPodcastEpisodesProvider` for pagination context and ReleasedSince-aware cache keys.
- BusinessRules coverage: helper rules, provider widen assertion, and a CatalogueMatchingRules regression for title-confident YouTube-discovered enrich when Spotify date is two days before the probe.

## Test plan
- [ ] `dotnet test` on `RedditPodcastPoster.Episodes.Tests` and `RedditPodcastPoster.PodcastServices.Spotify.Tests` (SpotifyCatalogueFetchReleasedSinceRules, SpotifyPodcastEpisodesProviderRules, CatalogueMatchingRules)
- [ ] `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged`
- [ ] Confirm enrich path for YouTube-discovered episodes can still match Spotify rows whose date-only release sits before the indexing floor
