### PR TITLE
fix(infra): WEBSITE_RESTORE_RAW_REQUEST_PATH on api-infra

### DIFF
--- a/Infrastructure/functions.bicep
+++ b/Infrastructure/functions.bicep
@@ -731,6 +731,9 @@ module apiFunction 'function.bicep' = {
     instanceMemoryMB: 2048
     appSettings: union({
         Logging__LogLevel__Api: 'Information'
+        // App Service FE decodes %2F before the Functions host; this restores the
+        // raw path so podcast/subject names containing '/' route correctly.
+        WEBSITE_RESTORE_RAW_REQUEST_PATH: '1'
     }, apiSettings)
     userAssignedIdentityId: userAssignedIdentityId
     userAssignedIdentityClientId: userAssignedIdentityClientId


### PR DESCRIPTION
## Summary
- Set `WEBSITE_RESTORE_RAW_REQUEST_PATH=1` on the api Function App in Bicep so names with `/` (e.g. `w/ Emily Compagno`) route correctly after App Service path decoding.
- Already applied on prod `api-infra` via CLI.

## Test plan
- [ ] Authenticated GET `/episode/The%20FOX%20True%20Crime%20Podcast%20w%2F%20Emily%20Compagno/{guid}` returns 200 from Azure (not 404)
- [ ] Same for `GET /podcast/...w%2F...`
- [ ] Confirm setting present: `az functionapp config appsettings list --name api-infra --resource-group AutomatedInfra --query \"[?name=='WEBSITE_RESTORE_RAW_REQUEST_PATH']\"`