### PR TITLE
fix(api): route podcast names containing slashes

### DIFF
--- a/Cloud/Api/Controllers/EpisodeController.cs
+++ b/Cloud/Api/Controllers/EpisodeController.cs
@@ -25,6 +25,9 @@ public class EpisodeController(
 {
     private const string? Route = "episode/{episodeId:guid}";
     private const string? PodcastIdentifierRoute = "episode/{podcastIdentifier}/{episodeId:guid}";
+    // Rare fallback: App Service decodes %2F to '/', so names with '/' become
+    // extra segments and miss PodcastIdentifierRoute (see #9290).
+    private const string? PodcastIdentifierCatchAllRoute = "episode/{*podcastAndEpisode}";
     private const string? PodcastIdRoute = "episode/{podcastId:guid}/{episodeId:guid}";
 
 
@@ -40,7 +43,9 @@ public class EpisodeController(
     {
         var podcastEpisodeGetRequest = Guid.TryParse(podcastIdentifier, out var podcastId)
             ? new PodcastEpisodeRequestWrapper(podcastId, episodeId)
-            : new PodcastEpisodeRequestWrapper(podcastIdentifier, episodeId);
+            : new PodcastEpisodeRequestWrapper(
+                PodcastRouteNameNormalizer.Normalize(podcastIdentifier),
+                episodeId);
         return HandleRequest(
             req,
             ["curate"],
@@ -48,6 +53,24 @@ public class EpisodeController(
             getEpisodeHandler.Handle,
             Unauthorised,
             ct);
+    }
+
+    [Function("PodcastNameEpisodeGetSlash")]
+    public Task<HttpResponseData> GetByPodcastIdentifierCatchAll(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = PodcastIdentifierCatchAllRoute)]
+        HttpRequestData req,
+        string podcastAndEpisode,
+        FunctionContext _,
+        CancellationToken ct
+    )
+    {
+        if (!PodcastEpisodePathParser.TrySplitTrailingEpisodeId(
+                podcastAndEpisode, out var podcastIdentifier, out var episodeId))
+        {
+            return Task.FromResult(req.CreateResponse(System.Net.HttpStatusCode.NotFound));
+        }
+
+        return GetByPodcastIdentifier(req, podcastIdentifier, episodeId, _, ct);
     }
 
 

--- a/Cloud/Api/Controllers/PodcastController.cs
+++ b/Cloud/Api/Controllers/PodcastController.cs
@@ -70,7 +70,7 @@ public class PodcastController(
 
     [Function("PodcastGetWithEpisodeId")]
     public Task<HttpResponseData> GetWithEpisodeId(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "podcast/{podcastName}/{episodeId}")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "podcast/{podcastName}/{episodeId:guid}")]
         HttpRequestData req,
         string podcastName,
         Guid episodeId,
@@ -82,6 +82,26 @@ public class PodcastController(
             getPodcastHandler.Handle,
             Unauthorised,
             ct);
+
+    // Rare fallback: App Service decodes %2F to '/', so names with '/' become
+    // extra segments and miss the routes above (Azure/azure-functions-host#9290).
+    // Also stops Guid-bind 500s when a split name wrongly hits PodcastGetWithEpisodeId.
+    [Function("PodcastGetSlash")]
+    public Task<HttpResponseData> GetByIdentifierCatchAll(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "podcast/{*podcastIdentifier}")]
+        HttpRequestData req,
+        string podcastIdentifier,
+        CancellationToken ct
+    )
+    {
+        if (PodcastEpisodePathParser.TrySplitTrailingEpisodeId(
+                podcastIdentifier, out var podcastName, out var episodeId))
+        {
+            return GetWithEpisodeId(req, podcastName, episodeId, ct);
+        }
+
+        return GetByIdentifier(req, podcastIdentifier, ct);
+    }
 
     [Function("PodcastPost")]
     public Task<HttpResponseData> Post(

--- a/Cloud/Api/Models/PodcastEpisodePathParser.cs
+++ b/Cloud/Api/Models/PodcastEpisodePathParser.cs
@@ -1,0 +1,31 @@
+namespace Api.Models;
+
+/// <summary>
+/// Splits route paths where the podcast name may contain '/' (after %2F decode)
+/// and the final segment is an episode id.
+/// </summary>
+public static class PodcastEpisodePathParser
+{
+    public static bool TrySplitTrailingEpisodeId(
+        string path,
+        out string podcastIdentifier,
+        out Guid episodeId)
+    {
+        podcastIdentifier = string.Empty;
+        episodeId = default;
+
+        var lastSlash = path.LastIndexOf('/');
+        if (lastSlash <= 0)
+        {
+            return false;
+        }
+
+        if (!Guid.TryParse(path.AsSpan(lastSlash + 1), out episodeId))
+        {
+            return false;
+        }
+
+        podcastIdentifier = path[..lastSlash];
+        return podcastIdentifier.Length > 0;
+    }
+}

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastEpisodePathParserTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastEpisodePathParserTests.cs
@@ -1,0 +1,61 @@
+using Api.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace FunctionHost.Tests.Api.Models;
+
+public class PodcastEpisodePathParserTests
+{
+    [Fact(DisplayName =
+        "Trailing episode guid after a slash-containing podcast name: path splits into name + episode id, because hosts decode %2F into path separators.")]
+    public void splits_slash_containing_podcast_name_and_trailing_episode_id()
+    {
+        // Arrange
+        var episodeId = Guid.NewGuid();
+        var path = $"True Crime Show w/ Guest Host/{episodeId:D}";
+
+        // Act
+        var ok = PodcastEpisodePathParser.TrySplitTrailingEpisodeId(
+            path, out var podcastName, out var parsedEpisodeId);
+
+        // Assert
+        ok.Should().BeTrue();
+        podcastName.Should().Be("True Crime Show w/ Guest Host");
+        parsedEpisodeId.Should().Be(episodeId);
+    }
+
+    [Fact(DisplayName =
+        "Trailing episode guid after a single-segment podcast name: path splits into name + episode id for the two-segment route shape.")]
+    public void splits_single_segment_podcast_name_and_trailing_episode_id()
+    {
+        // Arrange
+        var episodeId = Guid.NewGuid();
+        var path = $"Plain Podcast Name/{episodeId:D}";
+
+        // Act
+        var ok = PodcastEpisodePathParser.TrySplitTrailingEpisodeId(
+            path, out var podcastName, out var parsedEpisodeId);
+
+        // Assert
+        ok.Should().BeTrue();
+        podcastName.Should().Be("Plain Podcast Name");
+        parsedEpisodeId.Should().Be(episodeId);
+    }
+
+    [Fact(DisplayName =
+        "Path without a trailing guid: split fails, because the catch-all cannot invent an episode id.")]
+    public void rejects_path_without_trailing_guid()
+    {
+        // Arrange
+        const string path = "True Crime Show w/ Guest Host";
+
+        // Act
+        var ok = PodcastEpisodePathParser.TrySplitTrailingEpisodeId(
+            path, out var podcastName, out var parsedEpisodeId);
+
+        // Assert
+        ok.Should().BeFalse();
+        podcastName.Should().BeEmpty();
+        parsedEpisodeId.Should().Be(Guid.Empty);
+    }
+}


### PR DESCRIPTION
## Summary
- App Service decodes `%2F` before Functions routing ([azure-functions-host#9290](https://github.com/Azure/azure-functions-host/issues/9290)), which splits names like `w/ Emily Compagno` and caused podcast GET **500**s / episode GET **404**s.
- Keep existing `PodcastController` / `EpisodeController` GET templates for the common case.
- Add catch-all fallbacks (`podcast/{*…}`, `episode/{*…}`) that re-join the name and parse a trailing episode guid; constrain `PodcastGetWithEpisodeId` to `{episodeId:guid}` so a split name cannot Guid-bind-fail.
- `WEBSITE_RESTORE_RAW_REQUEST_PATH` alone is insufficient when the path already arrives with a literal `/` (CF Worker → Azure).

## Test plan
- [ ] Authenticated GET `/podcast/The%20FOX%20True%20Crime%20Podcast%20w%2F%20Emily%20Compagno` returns 200 (not 500)
- [ ] Authenticated GET `/episode/The%20FOX%20True%20Crime%20Podcast%20w%2F%20Emily%20Compagno/{guid}` returns 200 (not 404)
- [ ] Normal podcast/episode name routes without `/` still work
- [ ] `dotnet test Cloud/Unit-Tests/FunctionHost.Tests --filter PodcastEpisodePathParserTests` green


Made with [Cursor](https://cursor.com)