### PR TITLE
feat: always-promote-as-hero via edge hero DO

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/ApiClient.cs
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/ApiClient.cs
@@ -1,9 +1,12 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RedditPodcastPoster.Auth0.Clients;
 using RedditPodcastPoster.EdgeApi.Configuration;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
 
 namespace RedditPodcastPoster.EdgeApi.Clients;
 
@@ -22,11 +25,52 @@ public class ApiClient(
         var response = await httpClient.GetAsync(new Uri(_apiOptions.Endpoint, "test"));
         if (response.StatusCode != HttpStatusCode.OK)
         {
-            logger.LogError("Failure");
+            logger.LogError("Edge API test endpoint failed with status {StatusCode}.", response.StatusCode);
         }
         else
         {
-            logger.LogInformation("Success");
+            logger.LogInformation("Edge API test endpoint succeeded.");
         }
+    }
+
+    public async Task AppendHeroEpisodes(IReadOnlyList<Guid> episodeIds, CancellationToken cancellationToken = default)
+    {
+        if (episodeIds.Count == 0)
+        {
+            return;
+        }
+
+        var token = await auth0Client.GetClientToken();
+        using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(_apiOptions.Endpoint, "hero-curation/episodes"));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        request.Content = JsonContent.Create(new AppendHeroEpisodesRequest
+        {
+            EpisodeIds = episodeIds.ToArray()
+        });
+
+        var episodeIdList = string.Join(',', episodeIds);
+        var response = await httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            logger.LogError(
+                "Hero auto-promote: AppendHeroEpisodes failed with status {StatusCode}. EpisodeIds: {EpisodeIds}. Body: {Body}",
+                response.StatusCode,
+                episodeIdList,
+                body);
+            response.EnsureSuccessStatusCode();
+            return;
+        }
+
+        logger.LogInformation(
+            "Hero auto-promote: AppendHeroEpisodes succeeded for {Count} episode(s). EpisodeIds: {EpisodeIds}.",
+            episodeIds.Count,
+            episodeIdList);
+    }
+
+    private sealed class AppendHeroEpisodesRequest
+    {
+        [JsonPropertyName("episodeIds")]
+        public Guid[] EpisodeIds { get; init; } = [];
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/IApiClient.cs
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/IApiClient.cs
@@ -3,4 +3,6 @@ namespace RedditPodcastPoster.EdgeApi.Clients;
 public interface IApiClient
 {
     Task Test();
+
+    Task AppendHeroEpisodes(IReadOnlyList<Guid> episodeIds, CancellationToken cancellationToken = default);
 }

--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.EdgeApi.Clients;
 using RedditPodcastPoster.EdgeApi.Configuration;
 using RedditPodcastPoster.EdgeApi.Extensions;
+using RedditPodcastPoster.EdgeApi.Heroes;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
 
 namespace RedditPodcastPoster.EdgeApi.Extensions;
 
@@ -16,6 +18,7 @@ public static class ServiceCollectionExtensions
         services.AddAuth0Client();
         services.BindConfiguration<ApiOptions>("api");
         services.AddScoped<IApiClient, ApiClient>();
+        services.AddScoped<IHeroEpisodePromoter, EdgeHeroEpisodePromoter>();
         if (bypassCertificateValidation)
         {
             services.AddHttpClient<IApiClient, ApiClient>()

--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/Heroes/EdgeHeroEpisodePromoter.cs
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/Heroes/EdgeHeroEpisodePromoter.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.EdgeApi.Clients;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
+
+namespace RedditPodcastPoster.EdgeApi.Heroes;
+
+public sealed class EdgeHeroEpisodePromoter(
+    IApiClient apiClient,
+    ILogger<EdgeHeroEpisodePromoter> logger) : IHeroEpisodePromoter
+{
+    public async Task PromoteAsync(IReadOnlyList<Guid> episodeIds, CancellationToken cancellationToken = default)
+    {
+        if (episodeIds.Count == 0)
+        {
+            return;
+        }
+
+        var episodeIdList = string.Join(',', episodeIds);
+        try
+        {
+            await apiClient.AppendHeroEpisodes(episodeIds, cancellationToken);
+            logger.LogInformation(
+                "Hero auto-promote: posted {Count} episode(s) to edge hero curation. EpisodeIds: {EpisodeIds}.",
+                episodeIds.Count,
+                episodeIdList);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Hero auto-promote: failed posting {Count} episode(s) to edge hero curation; episode pipeline continues. EpisodeIds: {EpisodeIds}.",
+                episodeIds.Count,
+                episodeIdList);
+        }
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/RedditPodcastPoster.EdgeApi.csproj
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/RedditPodcastPoster.EdgeApi.csproj
@@ -13,8 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
-  <ItemGroup>
+    <ItemGroup>
     <ProjectReference Include="..\RedditPodcastPoster.Auth0\RedditPodcastPoster.Auth0.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.Abstractions\RedditPodcastPoster.PodcastServices.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Class-Libraries/RedditPodcastPoster.Models/Podcasts/Podcast.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Podcasts/Podcast.cs
@@ -61,6 +61,10 @@ public class Podcast
     [JsonPropertyOrder(60)]
     public bool? BypassShortEpisodeChecking { get; set; }
 
+    [JsonPropertyName("alwaysPromoteAsHero")]
+    [JsonPropertyOrder(62)]
+    public bool? AlwaysPromoteAsHero { get; set; }
+
     [JsonPropertyName("minimumDuration")]
     [JsonPropertyOrder(61)]
     public TimeSpan? MinimumDuration { get; set; }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Heroes/IHeroEpisodePromoter.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Heroes/IHeroEpisodePromoter.cs
@@ -1,0 +1,42 @@
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
+
+namespace RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
+
+public interface IHeroEpisodePromoter
+{
+    /// <summary>
+    /// Best-effort append of newly indexed episode IDs to the edge hero list.
+    /// Must not throw in a way that fails indexing — implementations log and swallow.
+    /// </summary>
+    Task PromoteAsync(IReadOnlyList<Guid> episodeIds, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Selects newly indexed episode IDs eligible for auto-hero when the podcast is flagged.
+/// </summary>
+public static class HeroAutoPromoteSelector
+{
+    public static readonly TimeSpan WeekWindow = TimeSpan.FromDays(7);
+
+    public static IReadOnlyList<Guid> SelectEpisodeIds(
+        Podcast podcast,
+        IEnumerable<Episode> addedEpisodes,
+        DateTime utcNow)
+    {
+        if (podcast.AlwaysPromoteAsHero != true)
+        {
+            return [];
+        }
+
+        var cutoff = utcNow - WeekWindow;
+        return addedEpisodes
+            .Where(ep =>
+                !ep.Ignored &&
+                !ep.Removed &&
+                ep.Release >= cutoff)
+            .Select(ep => ep.Id)
+            .Distinct()
+            .ToArray();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Heroes/HeroAutoPromoteSelectorRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Heroes/HeroAutoPromoteSelectorRules.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
+using Xunit;
+
+namespace RedditPodcastPoster.PodcastServices.Tests.BusinessRules.Heroes;
+
+public class HeroAutoPromoteSelectorRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "Always-promote podcast with a newly indexed in-week episode: selector returns that episode id, because indexing should auto-append it to heroes.")]
+    public void selects_in_week_episode_when_flagged()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        podcast.AlwaysPromoteAsHero = true;
+        var episodeId = _fixture.CreateGuid();
+        var episode = _fixture.CreateEpisode(e =>
+        {
+            e.Id = episodeId;
+            e.Release = DomainTestFixture.UtcDaysAgo(2);
+            e.Ignored = false;
+            e.Removed = false;
+        });
+
+        // Act
+        var ids = HeroAutoPromoteSelector.SelectEpisodeIds(
+            podcast,
+            [episode],
+            DomainTestFixture.UtcToday);
+
+        // Assert
+        ids.Should().Equal(episodeId);
+    }
+
+    [Fact(DisplayName =
+        "Always-promote off: selector returns no ids for newly indexed episodes, because only flagged podcasts auto-promote.")]
+    public void skips_when_flag_off()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        podcast.AlwaysPromoteAsHero = false;
+        var episode = _fixture.CreateEpisode(e =>
+        {
+            e.Release = DomainTestFixture.UtcDaysAgo(1);
+            e.Ignored = false;
+            e.Removed = false;
+        });
+
+        // Act
+        var ids = HeroAutoPromoteSelector.SelectEpisodeIds(
+            podcast,
+            [episode],
+            DomainTestFixture.UtcToday);
+
+        // Assert
+        ids.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName =
+        "Always-promote podcast with an episode older than one week: selector returns no ids, because heroes only cover the current week window.")]
+    public void skips_episodes_older_than_week()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        podcast.AlwaysPromoteAsHero = true;
+        var episode = _fixture.CreateEpisode(e =>
+        {
+            e.Release = DomainTestFixture.UtcDaysAgo(8);
+            e.Ignored = false;
+            e.Removed = false;
+        });
+
+        // Act
+        var ids = HeroAutoPromoteSelector.SelectEpisodeIds(
+            podcast,
+            [episode],
+            DomainTestFixture.UtcToday);
+
+        // Assert
+        ids.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName =
+        "Always-promote podcast with ignored or removed newly indexed episodes: selector returns no ids, because those episodes are not hero-eligible.")]
+    public void skips_ignored_or_removed()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        podcast.AlwaysPromoteAsHero = true;
+        var ignored = _fixture.CreateEpisode(e =>
+        {
+            e.Release = DomainTestFixture.UtcDaysAgo(1);
+            e.Ignored = true;
+            e.Removed = false;
+        });
+        var removed = _fixture.CreateEpisode(e =>
+        {
+            e.Release = DomainTestFixture.UtcDaysAgo(1);
+            e.Ignored = false;
+            e.Removed = true;
+        });
+
+        // Act
+        var ids = HeroAutoPromoteSelector.SelectEpisodeIds(
+            podcast,
+            [ignored, removed],
+            DomainTestFixture.UtcToday);
+
+        // Assert
+        ids.Should().BeEmpty();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/Support/PodcastUpdaterTestHarness.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/Support/PodcastUpdaterTestHarness.cs
@@ -14,6 +14,7 @@ using RedditPodcastPoster.Models.Subjects;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 using RedditPodcastPoster.Text.EliminationTerms;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using RedditPodcastPoster.Configuration.Options;
 using RedditPodcastPoster.PodcastServices.Enrichers;
@@ -40,6 +41,11 @@ internal sealed class PodcastUpdaterTestHarness
             .Setup(x => x.GetAsync())
             .ReturnsAsync(EliminationTermsProvider.Object);
 
+        HeroEpisodePromoter = new Mock<IHeroEpisodePromoter>();
+        HeroEpisodePromoter
+            .Setup(x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
         Updater = new PodcastUpdater(
             PodcastRepository,
             EpisodeRepository,
@@ -50,6 +56,7 @@ internal sealed class PodcastUpdaterTestHarness
             eliminationTermsInstance.Object,
             Options.Create(DefaultPostingCriteria),
             YouTubeQuotaUsageTracker.Object,
+            HeroEpisodePromoter.Object,
             NullLogger<PodcastUpdater>.Instance);
 
         EpisodeEnricher
@@ -90,6 +97,8 @@ internal sealed class PodcastUpdaterTestHarness
     public Mock<IPodcastFilter> PodcastFilter { get; }
 
     public Mock<IYouTubeQuotaUsageTracker> YouTubeQuotaUsageTracker { get; }
+
+    public Mock<IHeroEpisodePromoter> HeroEpisodePromoter { get; }
 
     public Mock<IEliminationTermsProvider> EliminationTermsProvider { get; }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/Extensions/ServiceCollectionExtensions.cs
@@ -4,11 +4,13 @@ using RedditPodcastPoster.PodcastServices.Abstractions.Categorisers;
 using RedditPodcastPoster.PodcastServices.Abstractions.Clients;
 using RedditPodcastPoster.PodcastServices.Abstractions.Matching;
 using RedditPodcastPoster.PodcastServices.Abstractions.Updaters;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
 using RedditPodcastPoster.PodcastServices.Categorisers;
 using RedditPodcastPoster.PodcastServices.Clients;
 using RedditPodcastPoster.PodcastServices.Enrichers;
 using RedditPodcastPoster.PodcastServices.Extensions;
 using RedditPodcastPoster.PodcastServices.Handlers;
+using RedditPodcastPoster.PodcastServices.Heroes;
 using RedditPodcastPoster.PodcastServices.Matching;
 using RedditPodcastPoster.PodcastServices.Merging;
 using RedditPodcastPoster.PodcastServices.Models;
@@ -29,6 +31,7 @@ public static class ServiceCollectionExtensions
                 .AddScoped<IPodcastPassApiCache, PodcastPassApiCache>()
                 .AddScoped<IPodcastsUpdater, PodcastsUpdater>()
                 .AddScoped<IPodcastUpdater, PodcastUpdater>()
+                .AddScoped<IHeroEpisodePromoter, NullHeroEpisodePromoter>()
                 .AddScoped<INonPodcastServiceCategoriser, NonPodcastServiceCategoriser>()
                 .AddScoped<IPodcastServicesEpisodeEnricher, PodcastServicesEpisodeEnricher>()
                 .AddScoped<IStreamingServiceMetaDataHandler, StreamingServiceMetaDataHandler>()

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/Heroes/NullHeroEpisodePromoter.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/Heroes/NullHeroEpisodePromoter.cs
@@ -1,0 +1,12 @@
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
+
+namespace RedditPodcastPoster.PodcastServices.Heroes;
+
+/// <summary>No-op promoter used unless EdgeApi registers a real implementation.</summary>
+public sealed class NullHeroEpisodePromoter : IHeroEpisodePromoter
+{
+    public Task PromoteAsync(IReadOnlyList<Guid> episodeIds, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/Updaters/PodcastUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/Updaters/PodcastUpdater.cs
@@ -12,6 +12,7 @@ using RedditPodcastPoster.Models.Subjects;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Abstractions.Extensions;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
 using RedditPodcastPoster.PodcastServices.Abstractions.Matching;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Updaters;
@@ -32,6 +33,7 @@ public class PodcastUpdater(
     IAsyncInstance<IEliminationTermsProvider> eliminationTermsProviderInstance,
     IOptions<PostingCriteria> postingCriteria,
     IYouTubeQuotaUsageTracker youTubeQuotaUsageTracker,
+    IHeroEpisodePromoter heroEpisodePromoter,
     ILogger<PodcastUpdater> logger)
     : IPodcastUpdater
 {
@@ -176,6 +178,20 @@ public class PodcastUpdater(
             }
 
             await episodeRepository.Save(mergeResult.AddedEpisodes);
+
+            var heroIds = HeroAutoPromoteSelector.SelectEpisodeIds(
+                podcast,
+                mergeResult.AddedEpisodes,
+                DateTime.UtcNow);
+            if (heroIds.Count > 0)
+            {
+                logger.LogInformation(
+                    "Hero auto-promote: source={CreationSource}, podcastId={PodcastId}, episodeIds={EpisodeIds}.",
+                    EpisodeCreationSource.Indexer,
+                    podcast.Id,
+                    string.Join(',', heroIds));
+                await heroEpisodePromoter.PromoteAsync(heroIds);
+            }
         }
 
         var discoveredYouTubeExpensiveQuery = !knownYouTubeExpensiveQuery && podcast.HasExpensiveYouTubePlaylistQuery();

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionHeroAutoPromoteRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionHeroAutoPromoteRules.cs
@@ -1,0 +1,328 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RedditPodcastPoster.Episodes.Logging;
+using RedditPodcastPoster.Episodes.TestSupport.Fakes;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
+using RedditPodcastPoster.UrlSubmission.Categorisation;
+using RedditPodcastPoster.UrlSubmission.Factories;
+using RedditPodcastPoster.UrlSubmission.Models;
+using RedditPodcastPoster.UrlSubmission.Processors;
+
+namespace RedditPodcastPoster.UrlSubmission.Tests.BusinessRules.UrlSubmission;
+
+public class UrlSubmissionHeroAutoPromoteRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "URL submit creates an in-week episode on an always-promote podcast and persists it: promoter receives that episode id, because curated URL adds must notify hero DO the same as indexing.")]
+    public async Task created_in_week_on_flagged_podcast_promotes()
+    {
+        // Arrange
+        var episodeRepository = new InMemoryEpisodeRepository();
+        var podcastRepository = new InMemoryPodcastRepository();
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.AlwaysPromoteAsHero = true;
+        podcastRepository.Seed(podcast);
+
+        var episodeId = _fixture.CreateGuid();
+        var newEpisode = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithDuration(_fixture.CreateDuration())
+            .WithRelease(DomainTestFixture.UtcDateDaysAgo(1)));
+        newEpisode.Id = episodeId;
+        newEpisode.PodcastId = podcast.Id;
+        newEpisode.Ignored = false;
+        newEpisode.Removed = false;
+
+        var podcastProcessor = new Mock<IPodcastProcessor>();
+        podcastProcessor
+            .Setup(x => x.AddEpisodeToExistingPodcast(It.IsAny<CategorisedItem>()))
+            .ReturnsAsync(new SubmitResult(
+                SubmitResultState.Created,
+                SubmitResultState.None,
+                Episode: newEpisode,
+                Podcast: podcast));
+
+        var heroEpisodePromoter = new Mock<IHeroEpisodePromoter>();
+        IReadOnlyList<Guid>? promotedIds = null;
+        heroEpisodePromoter
+            .Setup(x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<Guid>, CancellationToken>((ids, _) => promotedIds = ids)
+            .Returns(Task.CompletedTask);
+
+        var processor = CreateProcessor(
+            podcastProcessor.Object,
+            podcastRepository,
+            episodeRepository,
+            heroEpisodePromoter: heroEpisodePromoter.Object);
+
+        var categorisedItem = new CategorisedItem(
+            podcast,
+            [],
+            null,
+            null,
+            null,
+            null,
+            null,
+            Service.Spotify);
+
+        // Act
+        await processor.ProcessCategorisedItem(
+            categorisedItem,
+            new SubmitOptions(null, MatchOtherServices: true, PersistToDatabase: true));
+
+        // Assert
+        promotedIds.Should().Equal(episodeId);
+    }
+
+    [Fact(DisplayName =
+        "Discovery curation creates an in-week episode on an always-promote podcast and persists it: promoter receives that episode id, because discovery submits share the URL-submit create path into hero DO.")]
+    public async Task discovery_created_in_week_on_flagged_podcast_promotes()
+    {
+        // Arrange
+        var episodeRepository = new InMemoryEpisodeRepository();
+        var podcastRepository = new InMemoryPodcastRepository();
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.AlwaysPromoteAsHero = true;
+        podcastRepository.Seed(podcast);
+
+        var episodeId = _fixture.CreateGuid();
+        var newEpisode = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithDuration(_fixture.CreateDuration())
+            .WithRelease(DomainTestFixture.UtcDateDaysAgo(1)));
+        newEpisode.Id = episodeId;
+        newEpisode.PodcastId = podcast.Id;
+        newEpisode.Ignored = false;
+        newEpisode.Removed = false;
+
+        var podcastProcessor = new Mock<IPodcastProcessor>();
+        podcastProcessor
+            .Setup(x => x.AddEpisodeToExistingPodcast(It.IsAny<CategorisedItem>()))
+            .ReturnsAsync(new SubmitResult(
+                SubmitResultState.Created,
+                SubmitResultState.None,
+                Episode: newEpisode,
+                Podcast: podcast));
+
+        var heroEpisodePromoter = new Mock<IHeroEpisodePromoter>();
+        IReadOnlyList<Guid>? promotedIds = null;
+        heroEpisodePromoter
+            .Setup(x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<Guid>, CancellationToken>((ids, _) => promotedIds = ids)
+            .Returns(Task.CompletedTask);
+
+        var processor = CreateProcessor(
+            podcastProcessor.Object,
+            podcastRepository,
+            episodeRepository,
+            heroEpisodePromoter: heroEpisodePromoter.Object);
+
+        var categorisedItem = new CategorisedItem(
+            podcast,
+            [],
+            null,
+            null,
+            null,
+            null,
+            null,
+            Service.Spotify);
+
+        // Act
+        await processor.ProcessCategorisedItem(
+            categorisedItem,
+            new SubmitOptions(
+                null,
+                MatchOtherServices: true,
+                PersistToDatabase: true,
+                CreationSource: EpisodeCreationSource.Discovery));
+
+        // Assert
+        promotedIds.Should().Equal(episodeId);
+    }
+
+    [Fact(DisplayName =
+        "URL submit creates an episode when always-promote is off: promoter is not called, because only flagged podcasts auto-append to heroes.")]
+    public async Task created_when_flag_off_does_not_promote()
+    {
+        // Arrange
+        var episodeRepository = new InMemoryEpisodeRepository();
+        var podcastRepository = new InMemoryPodcastRepository();
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.AlwaysPromoteAsHero = false;
+        podcastRepository.Seed(podcast);
+
+        var newEpisode = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithDuration(_fixture.CreateDuration())
+            .WithRelease(DomainTestFixture.UtcDateDaysAgo(1)));
+        newEpisode.PodcastId = podcast.Id;
+        newEpisode.Ignored = false;
+        newEpisode.Removed = false;
+
+        var podcastProcessor = new Mock<IPodcastProcessor>();
+        podcastProcessor
+            .Setup(x => x.AddEpisodeToExistingPodcast(It.IsAny<CategorisedItem>()))
+            .ReturnsAsync(new SubmitResult(
+                SubmitResultState.Created,
+                SubmitResultState.None,
+                Episode: newEpisode,
+                Podcast: podcast));
+
+        var heroEpisodePromoter = new Mock<IHeroEpisodePromoter>();
+        var processor = CreateProcessor(
+            podcastProcessor.Object,
+            podcastRepository,
+            episodeRepository,
+            heroEpisodePromoter: heroEpisodePromoter.Object);
+
+        var categorisedItem = new CategorisedItem(
+            podcast,
+            [],
+            null,
+            null,
+            null,
+            null,
+            null,
+            Service.Spotify);
+
+        // Act
+        await processor.ProcessCategorisedItem(
+            categorisedItem,
+            new SubmitOptions(null, MatchOtherServices: true, PersistToDatabase: true));
+
+        // Assert
+        heroEpisodePromoter.Verify(
+            x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact(DisplayName =
+        "URL submit creates an always-promote episode but PersistToDatabase is false: promoter is not called, because dry-run submits must not notify hero DO.")]
+    public async Task created_without_persist_does_not_promote()
+    {
+        // Arrange
+        var episodeRepository = new InMemoryEpisodeRepository();
+        var podcastRepository = new InMemoryPodcastRepository();
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.AlwaysPromoteAsHero = true;
+        podcastRepository.Seed(podcast);
+
+        var newEpisode = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithDuration(_fixture.CreateDuration())
+            .WithRelease(DomainTestFixture.UtcDateDaysAgo(1)));
+        newEpisode.PodcastId = podcast.Id;
+        newEpisode.Ignored = false;
+        newEpisode.Removed = false;
+
+        var podcastProcessor = new Mock<IPodcastProcessor>();
+        podcastProcessor
+            .Setup(x => x.AddEpisodeToExistingPodcast(It.IsAny<CategorisedItem>()))
+            .ReturnsAsync(new SubmitResult(
+                SubmitResultState.Created,
+                SubmitResultState.None,
+                Episode: newEpisode,
+                Podcast: podcast));
+
+        var heroEpisodePromoter = new Mock<IHeroEpisodePromoter>();
+        var processor = CreateProcessor(
+            podcastProcessor.Object,
+            podcastRepository,
+            episodeRepository,
+            heroEpisodePromoter: heroEpisodePromoter.Object);
+
+        var categorisedItem = new CategorisedItem(
+            podcast,
+            [],
+            null,
+            null,
+            null,
+            null,
+            null,
+            Service.Spotify);
+
+        // Act
+        await processor.ProcessCategorisedItem(
+            categorisedItem,
+            new SubmitOptions(null, MatchOtherServices: true, PersistToDatabase: false));
+
+        // Assert
+        heroEpisodePromoter.Verify(
+            x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact(DisplayName =
+        "URL submit enriches an existing episode on an always-promote podcast: promoter is not called, because auto-promote is create-only and does not backfill.")]
+    public async Task enriched_existing_episode_does_not_promote()
+    {
+        // Arrange
+        var episodeRepository = new InMemoryEpisodeRepository();
+        var podcastRepository = new InMemoryPodcastRepository();
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.AlwaysPromoteAsHero = true;
+        podcastRepository.Seed(podcast);
+
+        var enrichedEpisode = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithDuration(_fixture.CreateDuration())
+            .WithRelease(DomainTestFixture.UtcDateDaysAgo(1)));
+        enrichedEpisode.PodcastId = podcast.Id;
+        enrichedEpisode.Ignored = false;
+        enrichedEpisode.Removed = false;
+
+        var podcastProcessor = new Mock<IPodcastProcessor>();
+        podcastProcessor
+            .Setup(x => x.AddEpisodeToExistingPodcast(It.IsAny<CategorisedItem>()))
+            .ReturnsAsync(new SubmitResult(
+                SubmitResultState.Enriched,
+                SubmitResultState.None,
+                Episode: enrichedEpisode,
+                Podcast: podcast));
+
+        var heroEpisodePromoter = new Mock<IHeroEpisodePromoter>();
+        var processor = CreateProcessor(
+            podcastProcessor.Object,
+            podcastRepository,
+            episodeRepository,
+            heroEpisodePromoter: heroEpisodePromoter.Object);
+
+        var categorisedItem = new CategorisedItem(
+            podcast,
+            [],
+            enrichedEpisode,
+            null,
+            null,
+            null,
+            null,
+            Service.Spotify);
+
+        // Act
+        await processor.ProcessCategorisedItem(
+            categorisedItem,
+            new SubmitOptions(null, MatchOtherServices: true, PersistToDatabase: true));
+
+        // Assert
+        heroEpisodePromoter.Verify(
+            x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static CategorisedItemProcessor CreateProcessor(
+        IPodcastProcessor podcastProcessor,
+        InMemoryPodcastRepository podcastRepository,
+        InMemoryEpisodeRepository episodeRepository,
+        IPodcastAndEpisodeFactory? factory = null,
+        IHeroEpisodePromoter? heroEpisodePromoter = null)
+    {
+        factory ??= new Mock<IPodcastAndEpisodeFactory>().Object;
+        heroEpisodePromoter ??= new Mock<IHeroEpisodePromoter>().Object;
+        return new CategorisedItemProcessor(
+            podcastProcessor,
+            podcastRepository,
+            episodeRepository,
+            factory,
+            heroEpisodePromoter,
+            NullLogger<CategorisedItem>.Instance);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionPersistenceRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionPersistenceRules.cs
@@ -4,6 +4,7 @@ using Moq;
 using RedditPodcastPoster.Episodes.TestSupport.Fakes;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Factories;
 using RedditPodcastPoster.UrlSubmission.Models;
@@ -388,14 +389,17 @@ public class UrlSubmissionPersistenceRules
         IPodcastProcessor podcastProcessor,
         InMemoryPodcastRepository podcastRepository,
         InMemoryEpisodeRepository episodeRepository,
-        IPodcastAndEpisodeFactory? factory = null)
+        IPodcastAndEpisodeFactory? factory = null,
+        IHeroEpisodePromoter? heroEpisodePromoter = null)
     {
         factory ??= new Mock<IPodcastAndEpisodeFactory>().Object;
+        heroEpisodePromoter ??= new Mock<IHeroEpisodePromoter>().Object;
         return new CategorisedItemProcessor(
             podcastProcessor,
             podcastRepository,
             episodeRepository,
             factory,
+            heroEpisodePromoter,
             NullLogger<CategorisedItem>.Instance);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/CategorisedItemProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/CategorisedItemProcessor.cs
@@ -1,10 +1,12 @@
 using Microsoft.Extensions.Logging;
-using RedditPodcastPoster.Episodes;
+using RedditPodcastPoster.Episodes.Logging;
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.Persistence.Abstractions.Repositories;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
 using RedditPodcastPoster.UrlSubmission.Categorisation;
 using RedditPodcastPoster.UrlSubmission.Factories;
 using RedditPodcastPoster.UrlSubmission.Models;
-using RedditPodcastPoster.Episodes.Logging;
 
 namespace RedditPodcastPoster.UrlSubmission.Processors;
 
@@ -13,6 +15,7 @@ public class CategorisedItemProcessor(
     IPodcastRepository podcastRepository,
     IEpisodeRepository episodeRepository,
     IPodcastAndEpisodeFactory podcastAndEpisodeFactory,
+    IHeroEpisodePromoter heroEpisodePromoter,
     ILogger<CategorisedItem> logger) : ICategorisedItemProcessor
 {
     public async Task<SubmitResult> ProcessCategorisedItem(CategorisedItem categorisedItem, SubmitOptions submitOptions)
@@ -102,9 +105,43 @@ public class CategorisedItemProcessor(
                 submitOptions.CreationSource,
                 categorisedItem.Authority,
                 caller: "CategorisedItemProcessor.ProcessCategorisedItem");
+
+            if (submitOptions.PersistToDatabase)
+            {
+                var podcast = submitResult.Podcast ?? categorisedItem.MatchingPodcast;
+                if (podcast != null)
+                {
+                    await PromoteCreatedEpisodeIfEligible(
+                        podcast,
+                        submitResult.Episode,
+                        submitOptions.CreationSource);
+                }
+            }
         }
 
         LogSubmitEpisodeState(submitResult);
         return submitResult;
+    }
+
+    private async Task PromoteCreatedEpisodeIfEligible(
+        Podcast podcast,
+        Episode episode,
+        EpisodeCreationSource creationSource)
+    {
+        var heroIds = HeroAutoPromoteSelector.SelectEpisodeIds(
+            podcast,
+            [episode],
+            DateTime.UtcNow);
+        if (heroIds.Count == 0)
+        {
+            return;
+        }
+
+        logger.LogInformation(
+            "Hero auto-promote: source={CreationSource}, podcastId={PodcastId}, episodeIds={EpisodeIds}.",
+            creationSource,
+            podcast.Id,
+            string.Join(',', heroIds));
+        await heroEpisodePromoter.PromoteAsync(heroIds);
     }
 }

--- a/Cloud/Api/Api.csproj
+++ b/Cloud/Api/Api.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Common\RedditPodcastPoster.Common.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.ContentPublisher\RedditPodcastPoster.ContentPublisher.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Discovery\RedditPodcastPoster.Discovery.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.EdgeApi\RedditPodcastPoster.EdgeApi.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.EntitySearchIndexer\RedditPodcastPoster.EntitySearchIndexer.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Indexing\RedditPodcastPoster.Indexing.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Persistence\RedditPodcastPoster.Persistence.csproj" />

--- a/Cloud/Api/Dtos/Extensions/PodcastExtension.cs
+++ b/Cloud/Api/Dtos/Extensions/PodcastExtension.cs
@@ -14,6 +14,7 @@ public static class PodcastExtension
             Removed = podcast.Removed,
             IndexAllEpisodes = podcast.IndexAllEpisodes,
             BypassShortEpisodeChecking = podcast.BypassShortEpisodeChecking,
+            AlwaysPromoteAsHero = podcast.AlwaysPromoteAsHero,
             ReleaseAuthority = podcast.ReleaseAuthority,
             PrimaryPostService = podcast.PrimaryPostService,
             SpotifyId = podcast.SpotifyId,

--- a/Cloud/Api/Dtos/PodcastDto.cs
+++ b/Cloud/Api/Dtos/PodcastDto.cs
@@ -23,6 +23,9 @@ public class PodcastDto
     [JsonPropertyName("bypassShortEpisodeChecking")]
     public bool? BypassShortEpisodeChecking { get; set; }
 
+    [JsonPropertyName("alwaysPromoteAsHero")]
+    public bool? AlwaysPromoteAsHero { get; set; }
+
     [JsonPropertyName("releaseAuthority")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Service? ReleaseAuthority { get; set; }

--- a/Cloud/Api/Ioc.cs
+++ b/Cloud/Api/Ioc.cs
@@ -18,6 +18,7 @@ using RedditPodcastPoster.Configuration.Options;
 using RedditPodcastPoster.ContentPublisher.Extensions;
 using RedditPodcastPoster.Discovery.Extensions;
 using RedditPodcastPoster.Discovery.Services;
+using RedditPodcastPoster.EdgeApi.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
 using RedditPodcastPoster.Episodes.Extensions;
 using RedditPodcastPoster.Indexing.Extensions;
@@ -54,6 +55,7 @@ public static class Ioc
             .AddSpotifyServices()
             .AddAppleServices()
             .AddPodcastServices()
+            .AddEdgeApiClient(bypassCertificateValidation: false)
             .AddCommonServices()
             .AddRemoteClient()
             .AddScoped(s => new iTunesSearchManager())

--- a/Cloud/Api/Models/PodcastChangeRequest.cs
+++ b/Cloud/Api/Models/PodcastChangeRequest.cs
@@ -23,6 +23,9 @@ public class PodcastChangeRequest
     [JsonPropertyName("bypassShortEpisodeChecking")]
     public bool? BypassShortEpisodeChecking { get; set; }
 
+    [JsonPropertyName("alwaysPromoteAsHero")]
+    public bool? AlwaysPromoteAsHero { get; set; }
+
     [JsonPropertyName("releaseAuthority")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Service? ReleaseAuthority { get; set; }

--- a/Cloud/Api/Services/Podcasts/PodcastChangeApplier.cs
+++ b/Cloud/Api/Services/Podcasts/PodcastChangeApplier.cs
@@ -24,6 +24,11 @@ public class PodcastChangeApplier(ILogger<PodcastChangeApplier> logger)
             podcast.BypassShortEpisodeChecking = podcastChangeRequest.BypassShortEpisodeChecking.Value;
         }
 
+        if (podcastChangeRequest.AlwaysPromoteAsHero != null)
+        {
+            podcast.AlwaysPromoteAsHero = podcastChangeRequest.AlwaysPromoteAsHero.Value;
+        }
+
         if (podcastChangeRequest.MinimumDuration != null)
         {
             if (string.IsNullOrWhiteSpace(podcastChangeRequest.MinimumDuration))

--- a/Cloud/Indexer/Indexer.csproj
+++ b/Cloud/Indexer/Indexer.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Common\RedditPodcastPoster.Common.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Configuration\RedditPodcastPoster.Configuration.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.ContentPublisher\RedditPodcastPoster.ContentPublisher.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.EdgeApi\RedditPodcastPoster.EdgeApi.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.People\RedditPodcastPoster.People.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Persistence\RedditPodcastPoster.Persistence.csproj" />

--- a/Cloud/Indexer/Ioc.cs
+++ b/Cloud/Indexer/Ioc.cs
@@ -13,6 +13,7 @@ using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
 using RedditPodcastPoster.Configuration.Options;
 using RedditPodcastPoster.ContentPublisher.Extensions;
+using RedditPodcastPoster.EdgeApi.Extensions;
 using RedditPodcastPoster.Episodes.Extensions;
 using RedditPodcastPoster.InternetArchive.Extensions;
 using RedditPodcastPoster.People.Extensions;
@@ -46,6 +47,7 @@ public static class Ioc
             .AddAppleServices()
             .AddCommonServices()
             .AddPodcastServices()
+            .AddEdgeApiClient(bypassCertificateValidation: false)
             .AddRemoteClient()
             .AddScoped(s => new iTunesSearchManager())
             .AddEliminationTerms()

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Services/Podcasts/PodcastChangeApplierAlwaysPromoteAsHeroTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Services/Podcasts/PodcastChangeApplierAlwaysPromoteAsHeroTests.cs
@@ -1,0 +1,30 @@
+using Api.Models;
+using Api.Services.Podcasts;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using Xunit;
+
+namespace FunctionHost.Tests.Api.Services.Podcasts;
+
+public class PodcastChangeApplierAlwaysPromoteAsHeroTests
+{
+    private readonly DomainTestFixture _fixture = new();
+    private readonly PodcastChangeApplier _applier = new(NullLogger<PodcastChangeApplier>.Instance);
+
+    [Fact(DisplayName =
+        "Podcast change request with alwaysPromoteAsHero true: applier sets the podcast flag, because curators toggle auto-hero without rewriting the hero list.")]
+    public void applies_always_promote_as_hero_flag()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        podcast.AlwaysPromoteAsHero = false;
+        var request = new PodcastChangeRequest { AlwaysPromoteAsHero = true };
+
+        // Act
+        _applier.Apply(podcast, request);
+
+        // Assert
+        podcast.AlwaysPromoteAsHero.Should().BeTrue();
+    }
+}

--- a/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHostTestSupport.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHostTestSupport.cs
@@ -118,6 +118,11 @@ internal static class FunctionHostTestSupport
             ["auth0:Domain"] = "test.auth0.com",
             ["auth0:Audience"] = "https://test-api",
             ["auth0:Issuer"] = "https://test.auth0.com/",
+            ["api:Endpoint"] = "https://api.test.example/",
+            ["auth0client:Domain"] = "test.auth0.com",
+            ["auth0client:Audience"] = "https://test-api",
+            ["auth0client:ClientId"] = "test-m2m-client-id",
+            ["auth0client:ClientSecret"] = "test-m2m-client-secret",
         };
 
         return new ConfigurationBuilder()


### PR DESCRIPTION
## Summary
- Add `AlwaysPromoteAsHero` on Podcast + API DTO/change applier (toggle saves only; no backfill).
- After Indexer adds in-week episodes, or URL submit / discovery curation creates one, call edge `POST /hero-curation/episodes` via `IHeroEpisodePromoter`.
- Wire `AddEdgeApiClient` on Indexer and Api; log `Hero auto-promote` with source and episode IDs.

## Test plan
- [ ] Unit tests: `HeroAutoPromoteSelectorRules`, `UrlSubmissionHeroAutoPromoteRules`, `PodcastChangeApplierAlwaysPromoteAsHeroTests`
- [ ] Flag a podcast, index a new in-week episode → App Insights `Hero auto-promote` + Worker DO append
- [ ] Submit URL / discovery-curate create on flagged podcast → same promote path
- [ ] Confirm enrich-only / flag-off / dry-run do not promote

Made with [Cursor](https://cursor.com)