### PR TITLE
feat: wire Edge hero promote on index.exe and submit.exe

### DIFF
--- a/Cloud/Unit-Tests/FunctionHost.Tests/EdgeApiClientRegistrationTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/EdgeApiClientRegistrationTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using RedditPodcastPoster.EdgeApi.Extensions;
+using RedditPodcastPoster.EdgeApi.Heroes;
+using RedditPodcastPoster.PodcastServices.Abstractions.Heroes;
+using RedditPodcastPoster.PodcastServices.Extensions;
+using RedditPodcastPoster.PodcastServices.Heroes;
+using Xunit;
+
+namespace FunctionHost.Tests;
+
+public class EdgeApiClientRegistrationTests
+{
+    [Fact(DisplayName =
+        "AddEdgeApiClient after AddPodcastServices: last IHeroEpisodePromoter registration is EdgeHeroEpisodePromoter, because Index/SubmitUrl consoles and Cloud hosts must override the null promoter to notify the hero DO.")]
+    public void add_edge_api_client_registers_edge_hero_episode_promoter()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddPodcastServices();
+
+        // Act
+        services.AddEdgeApiClient(bypassCertificateValidation: false);
+
+        // Assert
+        services.Last(d => d.ServiceType == typeof(IHeroEpisodePromoter))
+            .ImplementationType.Should().Be(typeof(EdgeHeroEpisodePromoter));
+        services.Count(d => d.ServiceType == typeof(IHeroEpisodePromoter) &&
+                            d.ImplementationType == typeof(NullHeroEpisodePromoter))
+            .Should().Be(1);
+    }
+
+    [Fact(DisplayName =
+        "Indexer host IoC: IHeroEpisodePromoter resolves as EdgeHeroEpisodePromoter, because hourly indexing must append auto-hero episodes to the edge DO.")]
+    public async Task indexer_host_resolves_edge_hero_episode_promoter()
+    {
+        // Arrange
+        var services = FunctionHostTestSupport.CreateServiceCollection(global::Indexer.Ioc.ConfigureServices);
+
+        // Act
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true
+        });
+        await using var scope = provider.CreateAsyncScope();
+        var promoter = scope.ServiceProvider.GetRequiredService<IHeroEpisodePromoter>();
+
+        // Assert
+        promoter.Should().BeOfType<EdgeHeroEpisodePromoter>();
+    }
+
+    [Fact(DisplayName =
+        "Api host IoC: IHeroEpisodePromoter resolves as EdgeHeroEpisodePromoter, because submit-url and curation paths must append auto-hero episodes to the edge DO.")]
+    public async Task api_host_resolves_edge_hero_episode_promoter()
+    {
+        // Arrange
+        var services = FunctionHostTestSupport.CreateServiceCollection(global::Api.Ioc.ConfigureServices);
+
+        // Act
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true
+        });
+        await using var scope = provider.CreateAsyncScope();
+        var promoter = scope.ServiceProvider.GetRequiredService<IHeroEpisodePromoter>();
+
+        // Assert
+        promoter.Should().BeOfType<EdgeHeroEpisodePromoter>();
+    }
+}

--- a/Console-Apps/Index/Index.csproj
+++ b/Console-Apps/Index/Index.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Common\RedditPodcastPoster.Common.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.EdgeApi\RedditPodcastPoster.EdgeApi.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.EntitySearchIndexer\RedditPodcastPoster.EntitySearchIndexer.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Indexing\RedditPodcastPoster.Indexing.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />

--- a/Console-Apps/Index/Program.cs
+++ b/Console-Apps/Index/Program.cs
@@ -7,6 +7,7 @@ using Index;
 using iTunesSearch.Library;
 using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.EdgeApi.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
 using RedditPodcastPoster.Episodes.Extensions;
 using RedditPodcastPoster.Indexing.Extensions;
@@ -40,6 +41,7 @@ builder.Services
     .AddRepositories()
     .AddCommonServices()
     .AddPodcastServices()
+    .AddEdgeApiClient(bypassCertificateValidation: false)
     .AddAppleServices()
     .AddYouTubeServices(ApplicationUsage.Cli)
     .AddSpotifyServices()

--- a/Console-Apps/Index/appsettings.json
+++ b/Console-Apps/Index/appsettings.json
@@ -2,5 +2,8 @@
   "postingCriteria": {
     "minimumDuration": "0:08:00",
     "TweetDays": 2
+  },
+  "api": {
+    "Endpoint": "https://api.cultpodcasts.com"
   }
 }

--- a/Console-Apps/SubmitUrl/Program.cs
+++ b/Console-Apps/SubmitUrl/Program.cs
@@ -8,6 +8,7 @@ using SubmitUrl;
 using RedditPodcastPoster.BBC.Extensions;
 using RedditPodcastPoster.Common.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.EdgeApi.Extensions;
 using RedditPodcastPoster.EntitySearchIndexer.Extensions;
 using RedditPodcastPoster.Episodes.Extensions;
 using RedditPodcastPoster.InternetArchive.Extensions;
@@ -41,6 +42,7 @@ builder.Services
     .AddRepositories()
     .AddCommonServices()
     .AddPodcastServices()
+    .AddEdgeApiClient(bypassCertificateValidation: false)
     .AddSpotifyServices()
     .AddAppleServices()
     .AddYouTubeServices(ApplicationUsage.Cli)

--- a/Console-Apps/SubmitUrl/SubmitUrl.csproj
+++ b/Console-Apps/SubmitUrl/SubmitUrl.csproj
@@ -15,11 +15,18 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Common\RedditPodcastPoster.Common.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.EdgeApi\RedditPodcastPoster.EdgeApi.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.EntitySearchIndexer\RedditPodcastPoster.EntitySearchIndexer.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.People\RedditPodcastPoster.People.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.PodcastServices\RedditPodcastPoster.PodcastServices.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.UrlSubmission\RedditPodcastPoster.UrlSubmission.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Console-Apps/SubmitUrl/appsettings.json
+++ b/Console-Apps/SubmitUrl/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "api": {
+    "Endpoint": "https://api.cultpodcasts.com"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -129,9 +129,18 @@ Use colon notation in user-secrets; Azure uses `__` instead of `:`.
   "twitter:AccessTokenSecret": "xxxx",
 
   "bluesky:Identifier": "xxxx",
-  "bluesky:Password": "xxxx"
+  "bluesky:Password": "xxxx",
+
+  "api:Endpoint": "https://api.cultpodcasts.com",
+
+  "auth0client:Domain": "xxxx.auth0.com",
+  "auth0client:Audience": "https://xxxx",
+  "auth0client:ClientId": "xxxx",
+  "auth0client:ClientSecret": "xxxx"
 }
 ```
+
+`Index` / `SubmitUrl` (and Cloud Indexer/Api) call the edge hero API via `AddEdgeApiClient`. Non-secret `api:Endpoint` is also in those consoles' `appsettings.json`; M2M Auth0 (`auth0client:*`) belongs in user-secrets (same shared `UserSecretsId`).
 
 Additional production-only settings (Auth0, YouTube, Listen Notes, Taddy, push notification keys, etc.) are in `Infrastructure/functions.bicep`. Production secrets are read from Key Vault at **deploy time** (`functions.bicepparam`) and written as **literal** app-setting values — the running app never calls Key Vault. For YouTube key layout, local user-secrets, and interim manual apply steps, see [docs/youtube-keys.md](docs/youtube-keys.md).
 


### PR DESCRIPTION
## Summary
- Wire `AddEdgeApiClient` into Index and SubmitUrl consoles so local runs can promote episodes via the edge hero API (follow-up to #925, which merged without this console wiring).
- Add `api:Endpoint` to console `appsettings.json`, EdgeApi project refs, and `EdgeApiClientRegistrationTests`.
- Document `api:Endpoint` / `auth0client:*` console secrets in the README.

## Test plan
- [ ] Confirm PR diff is only console Edge wiring + registration tests + README (no cloud deploy changes)
- [ ] `dotnet test` on `Cloud/Unit-Tests/FunctionHost.Tests` (or affected tests including `EdgeApiClientRegistrationTests`)
- [ ] Smoke: Index/SubmitUrl start with user-secrets `auth0client:*` and non-secret `api:Endpoint`