### PR TITLE
fix: demote noisy filter and categorise scan logs to Information

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Common/Podcasts/PodcastFilter.cs
+++ b/Class-Libraries/RedditPodcastPoster.Common/Podcasts/PodcastFilter.cs
@@ -10,7 +10,7 @@ public class PodcastFilter(ILogger<PodcastFilter> logger) : IPodcastFilter
 {
     public FilterResult Filter(Podcast podcast, IEnumerable<Episode> episodes, List<string> eliminationTerms)
     {
-        logger.LogWarning(
+        logger.LogInformation(
             "{method}: Filtering episodes for podcast '{podcastName}'. Count: {Count}. Elimination-terms count: {EliminationTermsCount}. Episode-ids: {EpisodeIds}",
             nameof(Filter), podcast.Name, episodes.Count(), eliminationTerms.Count,
             episodes.Where(x => !x.Removed).Select(x => x.Id));

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/CategorisePodcastLogger.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Categorisation/CategorisePodcastLogger.cs
@@ -4,9 +4,8 @@ using RedditPodcastPoster.Models.Subjects;
 namespace RedditPodcastPoster.Subjects.Categorisation;
 
 /// <summary>
-/// Emits a stable Warning-level podcast categorise line so App Insights can show
+/// Emits a stable Information-level podcast categorise line so App Insights can show
 /// which episodes were categorised and the subject delta in one KQL-friendly message.
-/// Warning is intentional: Information is heavily sampled in production.
 /// </summary>
 public static class CategorisePodcastLogger
 {
@@ -18,11 +17,11 @@ public static class CategorisePodcastLogger
         string podcastName,
         IReadOnlyList<CategoriseEpisodeDelta> episodes)
     {
-        logger.LogWarning("{Message}", FormatMessage(podcastId, podcastName, episodes));
+        logger.LogInformation("{Message}", FormatMessage(podcastId, podcastName, episodes));
     }
 
     /// <summary>
-    /// Same content as the rendered Warning message (for unit tests / docs).
+    /// Same content as the rendered log message (for unit tests / docs).
     /// </summary>
     public static string FormatMessage(
         Guid podcastId,


### PR DESCRIPTION
## Summary
- Demote routine `Filtering episodes for podcast…` scan logs in `PodcastFilter` from Warning to Information (keep Warning for actual elimination-term removals)
- Demote `Categorise podcast:` summary lines from Warning to Information

## Test plan
- [ ] Run indexer filter path and confirm empty/no-op filter scans no longer appear as Warnings in App Insights
- [ ] Confirm a real elimination-term match still logs Warning (`Removing episode… due to match with…`)
- [ ] Confirm `Categorise podcast:` lines (including unchanged `persisted=False`) appear as Information, not Warning
