### PR TITLE
fix(heroes): demote auto-promote diagnostics; CF bot-challenge exception log

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/ApiClient.cs
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/ApiClient.cs
@@ -62,7 +62,7 @@ public class ApiClient(
             return;
         }
 
-        logger.LogInformation(
+        logger.LogWarning(
             "Hero auto-promote: AppendHeroEpisodes succeeded for {Count} episode(s). EpisodeIds: {EpisodeIds}.",
             episodeIds.Count,
             episodeIdList);

--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/ApiClient.cs
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/ApiClient.cs
@@ -53,6 +53,19 @@ public class ApiClient(
         if (!response.IsSuccessStatusCode)
         {
             var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            if (CloudflareChallengeResponse.LooksLikeBotChallenge(response.StatusCode, body))
+            {
+                var truncatedBody = CloudflareChallengeResponse.TruncateBody(body);
+                var challengeException = CloudflareChallengeResponse.CreateException(response.StatusCode, body);
+                logger.LogError(
+                    challengeException,
+                    "Hero auto-promote: AppendHeroEpisodes blocked by Cloudflare bot-mode challenge. Status={StatusCode}. EpisodeIds: {EpisodeIds}. Body: {Body}",
+                    response.StatusCode,
+                    episodeIdList,
+                    truncatedBody);
+                throw challengeException;
+            }
+
             logger.LogError(
                 "Hero auto-promote: AppendHeroEpisodes failed with status {StatusCode}. EpisodeIds: {EpisodeIds}. Body: {Body}",
                 response.StatusCode,
@@ -62,7 +75,7 @@ public class ApiClient(
             return;
         }
 
-        logger.LogWarning(
+        logger.LogInformation(
             "Hero auto-promote: AppendHeroEpisodes succeeded for {Count} episode(s). EpisodeIds: {EpisodeIds}.",
             episodeIds.Count,
             episodeIdList);

--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/CloudflareChallengeResponse.cs
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/Clients/CloudflareChallengeResponse.cs
@@ -1,0 +1,73 @@
+using System.Net;
+
+namespace RedditPodcastPoster.EdgeApi.Clients;
+
+/// <summary>
+/// Detects Cloudflare Bot Fight / "Just a moment…" challenge HTML so hero auto-promote can log an Exception (App Insights failure).
+/// </summary>
+public static class CloudflareChallengeResponse
+{
+    public const int MaxBodyCharsInLog = 500;
+
+    public static bool LooksLikeBotChallenge(HttpStatusCode statusCode, string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return false;
+        }
+
+        var text = body.AsSpan().TrimStart();
+        if (text.Length == 0)
+        {
+            return false;
+        }
+
+        // Ordinary app JSON Forbidden / Unauthorized must not be treated as a bot challenge.
+        if (text[0] is '{' or '[')
+        {
+            return false;
+        }
+
+        var haystack = body;
+        if (ContainsIgnoreCase(haystack, "Just a moment") ||
+            ContainsIgnoreCase(haystack, "cf-challenge") ||
+            ContainsIgnoreCase(haystack, "cf-browser-verification") ||
+            ContainsIgnoreCase(haystack, "Enable JavaScript and cookies to continue") ||
+            ContainsIgnoreCase(haystack, "Checking your browser"))
+        {
+            return true;
+        }
+
+        // Forbidden/Unauthorized with non-JSON HTML-ish body is typically the edge challenge page.
+        if (statusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized or HttpStatusCode.ServiceUnavailable)
+        {
+            return ContainsIgnoreCase(haystack, "<html") ||
+                   ContainsIgnoreCase(haystack, "<!doctype html") ||
+                   ContainsIgnoreCase(haystack, "cloudflare");
+        }
+
+        return false;
+    }
+
+    public static string TruncateBody(string? body, int maxChars = MaxBodyCharsInLog)
+    {
+        if (string.IsNullOrEmpty(body))
+        {
+            return string.Empty;
+        }
+
+        return body.Length <= maxChars
+            ? body
+            : body[..maxChars] + "…";
+    }
+
+    public static InvalidOperationException CreateException(HttpStatusCode statusCode, string? body)
+    {
+        var truncated = TruncateBody(body);
+        return new InvalidOperationException(
+            $"Cloudflare bot-mode challenge blocked AppendHeroEpisodes (status {(int)statusCode} {statusCode}). Body: {truncated}");
+    }
+
+    private static bool ContainsIgnoreCase(string haystack, string needle) =>
+        haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+}

--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/Heroes/EdgeHeroEpisodePromoter.cs
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/Heroes/EdgeHeroEpisodePromoter.cs
@@ -19,7 +19,7 @@ public sealed class EdgeHeroEpisodePromoter(
         try
         {
             await apiClient.AppendHeroEpisodes(episodeIds, cancellationToken);
-            logger.LogInformation(
+            logger.LogWarning(
                 "Hero auto-promote: posted {Count} episode(s) to edge hero curation. EpisodeIds: {EpisodeIds}.",
                 episodeIds.Count,
                 episodeIdList);

--- a/Class-Libraries/RedditPodcastPoster.EdgeApi/Heroes/EdgeHeroEpisodePromoter.cs
+++ b/Class-Libraries/RedditPodcastPoster.EdgeApi/Heroes/EdgeHeroEpisodePromoter.cs
@@ -19,7 +19,7 @@ public sealed class EdgeHeroEpisodePromoter(
         try
         {
             await apiClient.AppendHeroEpisodes(episodeIds, cancellationToken);
-            logger.LogWarning(
+            logger.LogInformation(
                 "Hero auto-promote: posted {Count} episode(s) to edge hero curation. EpisodeIds: {EpisodeIds}.",
                 episodeIds.Count,
                 episodeIdList);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Heroes/IHeroEpisodePromoter.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Heroes/IHeroEpisodePromoter.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes.Logging;
 using RedditPodcastPoster.Models.Episodes;
 using RedditPodcastPoster.Models.Podcasts;
 
@@ -13,6 +15,19 @@ public interface IHeroEpisodePromoter
 }
 
 /// <summary>
+/// Why a newly created/indexed episode was not auto-appended to heroes.
+/// </summary>
+public enum HeroAutoPromoteSkipReason
+{
+    None = 0,
+    FlagOff,
+    Ignored,
+    Removed,
+    OutsideWeekWindow,
+    NotCreated
+}
+
+/// <summary>
 /// Selects newly indexed episode IDs eligible for auto-hero when the podcast is flagged.
 /// </summary>
 public static class HeroAutoPromoteSelector
@@ -24,19 +39,87 @@ public static class HeroAutoPromoteSelector
         IEnumerable<Episode> addedEpisodes,
         DateTime utcNow)
     {
-        if (podcast.AlwaysPromoteAsHero != true)
-        {
-            return [];
-        }
-
-        var cutoff = utcNow - WeekWindow;
         return addedEpisodes
-            .Where(ep =>
-                !ep.Ignored &&
-                !ep.Removed &&
-                ep.Release >= cutoff)
+            .Where(ep => GetSkipReason(podcast, ep, utcNow) == HeroAutoPromoteSkipReason.None)
             .Select(ep => ep.Id)
             .Distinct()
             .ToArray();
+    }
+
+    /// <summary>
+    /// Explains why an episode would not be auto-promoted (or <see cref="HeroAutoPromoteSkipReason.None"/> if eligible).
+    /// </summary>
+    public static HeroAutoPromoteSkipReason GetSkipReason(
+        Podcast podcast,
+        Episode episode,
+        DateTime utcNow)
+    {
+        if (podcast.AlwaysPromoteAsHero != true)
+        {
+            return HeroAutoPromoteSkipReason.FlagOff;
+        }
+
+        if (episode.Ignored)
+        {
+            return HeroAutoPromoteSkipReason.Ignored;
+        }
+
+        if (episode.Removed)
+        {
+            return HeroAutoPromoteSkipReason.Removed;
+        }
+
+        var cutoff = utcNow - WeekWindow;
+        if (episode.Release < cutoff)
+        {
+            return HeroAutoPromoteSkipReason.OutsideWeekWindow;
+        }
+
+        return HeroAutoPromoteSkipReason.None;
+    }
+
+    public static DateTime GetCutoff(DateTime utcNow) => utcNow - WeekWindow;
+}
+
+/// <summary>
+/// Stable Warning-level diagnostics for hero auto-promote (Information is sampled in production).
+/// Prefix <c>Hero auto-promote</c> is the App Insights filter key.
+/// </summary>
+public static class HeroAutoPromoteLogger
+{
+    public const string MessagePrefix = "Hero auto-promote:";
+
+    public static void LogAttempt(
+        ILogger logger,
+        EpisodeCreationSource creationSource,
+        Guid podcastId,
+        IReadOnlyList<Guid> episodeIds)
+    {
+        logger.LogWarning(
+            "Hero auto-promote: source={CreationSource}, podcastId={PodcastId}, episodeIds={EpisodeIds}.",
+            creationSource,
+            podcastId,
+            string.Join(',', episodeIds));
+    }
+
+    public static void LogSkipped(
+        ILogger logger,
+        HeroAutoPromoteSkipReason reason,
+        Guid episodeId,
+        Guid podcastId,
+        bool? alwaysPromoteAsHero,
+        DateTime? release = null,
+        DateTime? cutoff = null,
+        string? episodeResult = null)
+    {
+        logger.LogWarning(
+            "Hero auto-promote: skipped reason={SkipReason}, episodeId={EpisodeId}, podcastId={PodcastId}, episodeResult={EpisodeResult}, alwaysPromoteAsHero={AlwaysPromoteAsHero}, release={Release}, cutoff={Cutoff}.",
+            reason,
+            episodeId,
+            podcastId,
+            episodeResult,
+            alwaysPromoteAsHero,
+            release,
+            cutoff);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Heroes/IHeroEpisodePromoter.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Heroes/IHeroEpisodePromoter.cs
@@ -82,8 +82,9 @@ public static class HeroAutoPromoteSelector
 }
 
 /// <summary>
-/// Stable Warning-level diagnostics for hero auto-promote (Information is sampled in production).
+/// Stable Information-level diagnostics for hero auto-promote.
 /// Prefix <c>Hero auto-promote</c> is the App Insights filter key.
+/// Cloudflare bot-challenge failures are logged separately at Error with an Exception in <c>ApiClient.AppendHeroEpisodes</c>.
 /// </summary>
 public static class HeroAutoPromoteLogger
 {
@@ -95,7 +96,7 @@ public static class HeroAutoPromoteLogger
         Guid podcastId,
         IReadOnlyList<Guid> episodeIds)
     {
-        logger.LogWarning(
+        logger.LogInformation(
             "Hero auto-promote: source={CreationSource}, podcastId={PodcastId}, episodeIds={EpisodeIds}.",
             creationSource,
             podcastId,
@@ -112,7 +113,7 @@ public static class HeroAutoPromoteLogger
         DateTime? cutoff = null,
         string? episodeResult = null)
     {
-        logger.LogWarning(
+        logger.LogInformation(
             "Hero auto-promote: skipped reason={SkipReason}, episodeId={EpisodeId}, podcastId={PodcastId}, episodeResult={EpisodeResult}, alwaysPromoteAsHero={AlwaysPromoteAsHero}, release={Release}, cutoff={Cutoff}.",
             reason,
             episodeId,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Heroes/HeroAutoPromoteSelectorRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Heroes/HeroAutoPromoteSelectorRules.cs
@@ -1,4 +1,6 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.Episodes.Logging;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.Models.Episodes;
 using RedditPodcastPoster.Models.Podcasts;
@@ -35,10 +37,12 @@ public class HeroAutoPromoteSelectorRules
 
         // Assert
         ids.Should().Equal(episodeId);
+        HeroAutoPromoteSelector.GetSkipReason(podcast, episode, DomainTestFixture.UtcToday)
+            .Should().Be(HeroAutoPromoteSkipReason.None);
     }
 
     [Fact(DisplayName =
-        "Always-promote off: selector returns no ids for newly indexed episodes, because only flagged podcasts auto-promote.")]
+        "Always-promote off: selector returns no ids and skip reason is FlagOff, because only flagged podcasts auto-promote.")]
     public void skips_when_flag_off()
     {
         // Arrange
@@ -56,13 +60,15 @@ public class HeroAutoPromoteSelectorRules
             podcast,
             [episode],
             DomainTestFixture.UtcToday);
+        var reason = HeroAutoPromoteSelector.GetSkipReason(podcast, episode, DomainTestFixture.UtcToday);
 
         // Assert
         ids.Should().BeEmpty();
+        reason.Should().Be(HeroAutoPromoteSkipReason.FlagOff);
     }
 
     [Fact(DisplayName =
-        "Always-promote podcast with an episode older than one week: selector returns no ids, because heroes only cover the current week window.")]
+        "Always-promote podcast with an episode older than one week: skip reason is OutsideWeekWindow, because heroes only cover the current week window.")]
     public void skips_episodes_older_than_week()
     {
         // Arrange
@@ -80,14 +86,16 @@ public class HeroAutoPromoteSelectorRules
             podcast,
             [episode],
             DomainTestFixture.UtcToday);
+        var reason = HeroAutoPromoteSelector.GetSkipReason(podcast, episode, DomainTestFixture.UtcToday);
 
         // Assert
         ids.Should().BeEmpty();
+        reason.Should().Be(HeroAutoPromoteSkipReason.OutsideWeekWindow);
     }
 
     [Fact(DisplayName =
-        "Always-promote podcast with ignored or removed newly indexed episodes: selector returns no ids, because those episodes are not hero-eligible.")]
-    public void skips_ignored_or_removed()
+        "Always-promote podcast with ignored newly indexed episode: skip reason is Ignored, because ignored episodes are not hero-eligible.")]
+    public void skips_ignored()
     {
         // Arrange
         var podcast = _fixture.CreatePodcast();
@@ -98,6 +106,23 @@ public class HeroAutoPromoteSelectorRules
             e.Ignored = true;
             e.Removed = false;
         });
+
+        // Act
+        var reason = HeroAutoPromoteSelector.GetSkipReason(podcast, ignored, DomainTestFixture.UtcToday);
+
+        // Assert
+        HeroAutoPromoteSelector.SelectEpisodeIds(podcast, [ignored], DomainTestFixture.UtcToday)
+            .Should().BeEmpty();
+        reason.Should().Be(HeroAutoPromoteSkipReason.Ignored);
+    }
+
+    [Fact(DisplayName =
+        "Always-promote podcast with removed newly indexed episode: skip reason is Removed, because removed episodes are not hero-eligible.")]
+    public void skips_removed()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        podcast.AlwaysPromoteAsHero = true;
         var removed = _fixture.CreateEpisode(e =>
         {
             e.Release = DomainTestFixture.UtcDaysAgo(1);
@@ -106,12 +131,96 @@ public class HeroAutoPromoteSelectorRules
         });
 
         // Act
-        var ids = HeroAutoPromoteSelector.SelectEpisodeIds(
-            podcast,
-            [ignored, removed],
-            DomainTestFixture.UtcToday);
+        var reason = HeroAutoPromoteSelector.GetSkipReason(podcast, removed, DomainTestFixture.UtcToday);
 
         // Assert
-        ids.Should().BeEmpty();
+        HeroAutoPromoteSelector.SelectEpisodeIds(podcast, [removed], DomainTestFixture.UtcToday)
+            .Should().BeEmpty();
+        reason.Should().Be(HeroAutoPromoteSkipReason.Removed);
+    }
+
+    [Fact(DisplayName =
+        "Hero auto-promote skip diagnostic: LogSkipped emits Warning with Hero auto-promote prefix and reason, because Information is sampled in production.")]
+    public void log_skipped_emits_warning_with_stable_prefix()
+    {
+        // Arrange
+        var logger = new CapturingLogger();
+        var episodeId = _fixture.CreateGuid();
+        var podcastId = _fixture.CreateGuid();
+        var release = DomainTestFixture.UtcDaysAgo(8);
+        var cutoff = HeroAutoPromoteSelector.GetCutoff(DomainTestFixture.UtcToday);
+
+        // Act
+        HeroAutoPromoteLogger.LogSkipped(
+            logger,
+            HeroAutoPromoteSkipReason.OutsideWeekWindow,
+            episodeId,
+            podcastId,
+            alwaysPromoteAsHero: true,
+            release: release,
+            cutoff: cutoff,
+            episodeResult: "Created");
+
+        // Assert
+        logger.Warnings.Should().ContainSingle(m =>
+            m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
+            m.Contains("skipped") &&
+            m.Contains("OutsideWeekWindow") &&
+            m.Contains(episodeId.ToString()) &&
+            m.Contains(podcastId.ToString()));
+        logger.Informations.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName =
+        "Hero auto-promote attempt diagnostic: LogAttempt emits Warning with source and episode ids, matching EpisodeCreationLogger severity.")]
+    public void log_attempt_emits_warning_with_stable_prefix()
+    {
+        // Arrange
+        var logger = new CapturingLogger();
+        var podcastId = _fixture.CreateGuid();
+        var episodeId = _fixture.CreateGuid();
+
+        // Act
+        HeroAutoPromoteLogger.LogAttempt(
+            logger,
+            EpisodeCreationSource.SubmitUrl,
+            podcastId,
+            [episodeId]);
+
+        // Assert
+        logger.Warnings.Should().ContainSingle(m =>
+            m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
+            m.Contains("SubmitUrl") &&
+            m.Contains(podcastId.ToString()) &&
+            m.Contains(episodeId.ToString()));
+        logger.Informations.Should().BeEmpty();
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = [];
+        public List<string> Informations { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var message = formatter(state, exception);
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(message);
+            }
+            else if (logLevel == LogLevel.Information)
+            {
+                Informations.Add(message);
+            }
+        }
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Heroes/HeroAutoPromoteSelectorRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/BusinessRules/Heroes/HeroAutoPromoteSelectorRules.cs
@@ -140,8 +140,8 @@ public class HeroAutoPromoteSelectorRules
     }
 
     [Fact(DisplayName =
-        "Hero auto-promote skip diagnostic: LogSkipped emits Warning with Hero auto-promote prefix and reason, because Information is sampled in production.")]
-    public void log_skipped_emits_warning_with_stable_prefix()
+        "Hero auto-promote skip diagnostic: LogSkipped emits Information with Hero auto-promote prefix and reason, because skip diagnostics are not elevated above attempt logs.")]
+    public void log_skipped_emits_information_with_stable_prefix()
     {
         // Arrange
         var logger = new CapturingLogger();
@@ -162,18 +162,18 @@ public class HeroAutoPromoteSelectorRules
             episodeResult: "Created");
 
         // Assert
-        logger.Warnings.Should().ContainSingle(m =>
+        logger.Informations.Should().ContainSingle(m =>
             m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
             m.Contains("skipped") &&
             m.Contains("OutsideWeekWindow") &&
             m.Contains(episodeId.ToString()) &&
             m.Contains(podcastId.ToString()));
-        logger.Informations.Should().BeEmpty();
+        logger.Warnings.Should().BeEmpty();
     }
 
     [Fact(DisplayName =
-        "Hero auto-promote attempt diagnostic: LogAttempt emits Warning with source and episode ids, matching EpisodeCreationLogger severity.")]
-    public void log_attempt_emits_warning_with_stable_prefix()
+        "Hero auto-promote attempt diagnostic: LogAttempt emits Information with source and episode ids, because attempt diagnostics share severity with skip logs.")]
+    public void log_attempt_emits_information_with_stable_prefix()
     {
         // Arrange
         var logger = new CapturingLogger();
@@ -188,12 +188,12 @@ public class HeroAutoPromoteSelectorRules
             [episodeId]);
 
         // Assert
-        logger.Warnings.Should().ContainSingle(m =>
+        logger.Informations.Should().ContainSingle(m =>
             m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
             m.Contains("SubmitUrl") &&
             m.Contains(podcastId.ToString()) &&
             m.Contains(episodeId.ToString()));
-        logger.Informations.Should().BeEmpty();
+        logger.Warnings.Should().BeEmpty();
     }
 
     private sealed class CapturingLogger : ILogger

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/Updaters/PodcastUpdater.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/Updaters/PodcastUpdater.cs
@@ -179,18 +179,42 @@ public class PodcastUpdater(
 
             await episodeRepository.Save(mergeResult.AddedEpisodes);
 
-            var heroIds = HeroAutoPromoteSelector.SelectEpisodeIds(
-                podcast,
-                mergeResult.AddedEpisodes,
-                DateTime.UtcNow);
-            if (heroIds.Count > 0)
+            if (podcast.AlwaysPromoteAsHero == true)
             {
-                logger.LogInformation(
-                    "Hero auto-promote: source={CreationSource}, podcastId={PodcastId}, episodeIds={EpisodeIds}.",
-                    EpisodeCreationSource.Indexer,
-                    podcast.Id,
-                    string.Join(',', heroIds));
-                await heroEpisodePromoter.PromoteAsync(heroIds);
+                var utcNow = DateTime.UtcNow;
+                var cutoff = HeroAutoPromoteSelector.GetCutoff(utcNow);
+                var heroIds = new List<Guid>();
+                foreach (var added in mergeResult.AddedEpisodes)
+                {
+                    var skipReason = HeroAutoPromoteSelector.GetSkipReason(podcast, added, utcNow);
+                    if (skipReason != HeroAutoPromoteSkipReason.None)
+                    {
+                        HeroAutoPromoteLogger.LogSkipped(
+                            logger,
+                            skipReason,
+                            added.Id,
+                            podcast.Id,
+                            podcast.AlwaysPromoteAsHero,
+                            release: added.Release,
+                            cutoff: skipReason == HeroAutoPromoteSkipReason.OutsideWeekWindow
+                                ? cutoff
+                                : null,
+                            episodeResult: "Created");
+                        continue;
+                    }
+
+                    heroIds.Add(added.Id);
+                }
+
+                if (heroIds.Count > 0)
+                {
+                    HeroAutoPromoteLogger.LogAttempt(
+                        logger,
+                        EpisodeCreationSource.Indexer,
+                        podcast.Id,
+                        heroIds);
+                    await heroEpisodePromoter.PromoteAsync(heroIds);
+                }
             }
         }
 

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionHeroAutoPromoteRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionHeroAutoPromoteRules.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using RedditPodcastPoster.Episodes.Logging;
@@ -144,7 +145,7 @@ public class UrlSubmissionHeroAutoPromoteRules
     }
 
     [Fact(DisplayName =
-        "URL submit creates an episode when always-promote is off: promoter is not called, because only flagged podcasts auto-append to heroes.")]
+        "URL submit creates an episode when always-promote is off: promoter is not called and Warning logs FlagOff, because only flagged podcasts auto-append to heroes.")]
     public async Task created_when_flag_off_does_not_promote()
     {
         // Arrange
@@ -171,11 +172,13 @@ public class UrlSubmissionHeroAutoPromoteRules
                 Podcast: podcast));
 
         var heroEpisodePromoter = new Mock<IHeroEpisodePromoter>();
+        var logger = new CapturingLogger();
         var processor = CreateProcessor(
             podcastProcessor.Object,
             podcastRepository,
             episodeRepository,
-            heroEpisodePromoter: heroEpisodePromoter.Object);
+            heroEpisodePromoter: heroEpisodePromoter.Object,
+            logger: logger);
 
         var categorisedItem = new CategorisedItem(
             podcast,
@@ -196,6 +199,10 @@ public class UrlSubmissionHeroAutoPromoteRules
         heroEpisodePromoter.Verify(
             x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
             Times.Never);
+        logger.Warnings.Should().Contain(m =>
+            m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
+            m.Contains("FlagOff") &&
+            m.Contains(newEpisode.Id.ToString()));
     }
 
     [Fact(DisplayName =
@@ -254,7 +261,7 @@ public class UrlSubmissionHeroAutoPromoteRules
     }
 
     [Fact(DisplayName =
-        "URL submit enriches an existing episode on an always-promote podcast: promoter is not called, because auto-promote is create-only and does not backfill.")]
+        "URL submit enriches an existing episode on an always-promote podcast: promoter is not called and Warning logs NotCreated, because auto-promote is create-only and does not backfill.")]
     public async Task enriched_existing_episode_does_not_promote()
     {
         // Arrange
@@ -281,11 +288,13 @@ public class UrlSubmissionHeroAutoPromoteRules
                 Podcast: podcast));
 
         var heroEpisodePromoter = new Mock<IHeroEpisodePromoter>();
+        var logger = new CapturingLogger();
         var processor = CreateProcessor(
             podcastProcessor.Object,
             podcastRepository,
             episodeRepository,
-            heroEpisodePromoter: heroEpisodePromoter.Object);
+            heroEpisodePromoter: heroEpisodePromoter.Object,
+            logger: logger);
 
         var categorisedItem = new CategorisedItem(
             podcast,
@@ -306,6 +315,73 @@ public class UrlSubmissionHeroAutoPromoteRules
         heroEpisodePromoter.Verify(
             x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
             Times.Never);
+        logger.Warnings.Should().Contain(m =>
+            m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
+            m.Contains("NotCreated") &&
+            m.Contains(enrichedEpisode.Id.ToString()) &&
+            m.Contains(podcast.Id.ToString()));
+    }
+
+    [Fact(DisplayName =
+        "URL submit creates an always-promote episode outside the week window: promoter is not called and Warning logs OutsideWeekWindow with cutoff.")]
+    public async Task created_outside_week_window_logs_skip()
+    {
+        // Arrange
+        var episodeRepository = new InMemoryEpisodeRepository();
+        var podcastRepository = new InMemoryPodcastRepository();
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.AlwaysPromoteAsHero = true;
+        podcastRepository.Seed(podcast);
+
+        var newEpisode = _fixture.CreateSpotifyCatalogueEpisode(b => b
+            .WithDuration(_fixture.CreateDuration())
+            .WithRelease(DomainTestFixture.UtcDateDaysAgo(8)));
+        newEpisode.PodcastId = podcast.Id;
+        newEpisode.Ignored = false;
+        newEpisode.Removed = false;
+
+        var podcastProcessor = new Mock<IPodcastProcessor>();
+        podcastProcessor
+            .Setup(x => x.AddEpisodeToExistingPodcast(It.IsAny<CategorisedItem>()))
+            .ReturnsAsync(new SubmitResult(
+                SubmitResultState.Created,
+                SubmitResultState.None,
+                Episode: newEpisode,
+                Podcast: podcast));
+
+        var heroEpisodePromoter = new Mock<IHeroEpisodePromoter>();
+        var logger = new CapturingLogger();
+        var processor = CreateProcessor(
+            podcastProcessor.Object,
+            podcastRepository,
+            episodeRepository,
+            heroEpisodePromoter: heroEpisodePromoter.Object,
+            logger: logger);
+
+        var categorisedItem = new CategorisedItem(
+            podcast,
+            [],
+            null,
+            null,
+            null,
+            null,
+            null,
+            Service.Spotify);
+
+        // Act
+        await processor.ProcessCategorisedItem(
+            categorisedItem,
+            new SubmitOptions(null, MatchOtherServices: true, PersistToDatabase: true));
+
+        // Assert
+        heroEpisodePromoter.Verify(
+            x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        logger.Warnings.Should().Contain(m =>
+            m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
+            m.Contains("OutsideWeekWindow") &&
+            m.Contains(newEpisode.Id.ToString()) &&
+            m.Contains("cutoff="));
     }
 
     private static CategorisedItemProcessor CreateProcessor(
@@ -313,7 +389,8 @@ public class UrlSubmissionHeroAutoPromoteRules
         InMemoryPodcastRepository podcastRepository,
         InMemoryEpisodeRepository episodeRepository,
         IPodcastAndEpisodeFactory? factory = null,
-        IHeroEpisodePromoter? heroEpisodePromoter = null)
+        IHeroEpisodePromoter? heroEpisodePromoter = null,
+        ILogger<CategorisedItem>? logger = null)
     {
         factory ??= new Mock<IPodcastAndEpisodeFactory>().Object;
         heroEpisodePromoter ??= new Mock<IHeroEpisodePromoter>().Object;
@@ -323,6 +400,28 @@ public class UrlSubmissionHeroAutoPromoteRules
             episodeRepository,
             factory,
             heroEpisodePromoter,
-            NullLogger<CategorisedItem>.Instance);
+            logger ?? NullLogger<CategorisedItem>.Instance);
+    }
+
+    private sealed class CapturingLogger : ILogger<CategorisedItem>
+    {
+        public List<string> Warnings { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(formatter(state, exception));
+            }
+        }
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionHeroAutoPromoteRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission.Tests/BusinessRules/UrlSubmission/UrlSubmissionHeroAutoPromoteRules.cs
@@ -145,7 +145,7 @@ public class UrlSubmissionHeroAutoPromoteRules
     }
 
     [Fact(DisplayName =
-        "URL submit creates an episode when always-promote is off: promoter is not called and Warning logs FlagOff, because only flagged podcasts auto-append to heroes.")]
+        "URL submit creates an episode when always-promote is off: promoter is not called and Information logs FlagOff, because only flagged podcasts auto-append to heroes.")]
     public async Task created_when_flag_off_does_not_promote()
     {
         // Arrange
@@ -199,7 +199,7 @@ public class UrlSubmissionHeroAutoPromoteRules
         heroEpisodePromoter.Verify(
             x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
             Times.Never);
-        logger.Warnings.Should().Contain(m =>
+        logger.Informations.Should().Contain(m =>
             m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
             m.Contains("FlagOff") &&
             m.Contains(newEpisode.Id.ToString()));
@@ -261,7 +261,7 @@ public class UrlSubmissionHeroAutoPromoteRules
     }
 
     [Fact(DisplayName =
-        "URL submit enriches an existing episode on an always-promote podcast: promoter is not called and Warning logs NotCreated, because auto-promote is create-only and does not backfill.")]
+        "URL submit enriches an existing episode on an always-promote podcast: promoter is not called and Information logs NotCreated, because auto-promote is create-only and does not backfill.")]
     public async Task enriched_existing_episode_does_not_promote()
     {
         // Arrange
@@ -315,7 +315,7 @@ public class UrlSubmissionHeroAutoPromoteRules
         heroEpisodePromoter.Verify(
             x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
             Times.Never);
-        logger.Warnings.Should().Contain(m =>
+        logger.Informations.Should().Contain(m =>
             m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
             m.Contains("NotCreated") &&
             m.Contains(enrichedEpisode.Id.ToString()) &&
@@ -323,7 +323,7 @@ public class UrlSubmissionHeroAutoPromoteRules
     }
 
     [Fact(DisplayName =
-        "URL submit creates an always-promote episode outside the week window: promoter is not called and Warning logs OutsideWeekWindow with cutoff.")]
+        "URL submit creates an always-promote episode outside the week window: promoter is not called and Information logs OutsideWeekWindow with cutoff.")]
     public async Task created_outside_week_window_logs_skip()
     {
         // Arrange
@@ -377,7 +377,7 @@ public class UrlSubmissionHeroAutoPromoteRules
         heroEpisodePromoter.Verify(
             x => x.PromoteAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
             Times.Never);
-        logger.Warnings.Should().Contain(m =>
+        logger.Informations.Should().Contain(m =>
             m.StartsWith(HeroAutoPromoteLogger.MessagePrefix) &&
             m.Contains("OutsideWeekWindow") &&
             m.Contains(newEpisode.Id.ToString()) &&
@@ -405,7 +405,7 @@ public class UrlSubmissionHeroAutoPromoteRules
 
     private sealed class CapturingLogger : ILogger<CategorisedItem>
     {
-        public List<string> Warnings { get; } = [];
+        public List<string> Informations { get; } = [];
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
@@ -418,9 +418,9 @@ public class UrlSubmissionHeroAutoPromoteRules
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
-            if (logLevel == LogLevel.Warning)
+            if (logLevel == LogLevel.Information)
             {
-                Warnings.Add(formatter(state, exception));
+                Informations.Add(formatter(state, exception));
             }
         }
     }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/CategorisedItemProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/CategorisedItemProcessor.cs
@@ -91,13 +91,13 @@ public class CategorisedItemProcessor(
             }
         }
 
+        var podcast = submitResult.Podcast ?? categorisedItem.MatchingPodcast;
+
         if (submitResult is { EpisodeResult: SubmitResultState.Created, Episode: not null })
         {
             var podcastId = submitResult.Episode.PodcastId != Guid.Empty
                 ? submitResult.Episode.PodcastId
-                : submitResult.Podcast?.Id
-                  ?? categorisedItem.MatchingPodcast?.Id
-                  ?? Guid.Empty;
+                : podcast?.Id ?? Guid.Empty;
             EpisodeCreationLogger.LogCreated(
                 logger,
                 submitResult.Episode,
@@ -106,17 +106,24 @@ public class CategorisedItemProcessor(
                 categorisedItem.Authority,
                 caller: "CategorisedItemProcessor.ProcessCategorisedItem");
 
-            if (submitOptions.PersistToDatabase)
+            if (submitOptions.PersistToDatabase && podcast != null)
             {
-                var podcast = submitResult.Podcast ?? categorisedItem.MatchingPodcast;
-                if (podcast != null)
-                {
-                    await PromoteCreatedEpisodeIfEligible(
-                        podcast,
-                        submitResult.Episode,
-                        submitOptions.CreationSource);
-                }
+                await PromoteCreatedEpisodeIfEligible(
+                    podcast,
+                    submitResult.Episode,
+                    submitOptions.CreationSource);
             }
+        }
+        else if (podcast is { AlwaysPromoteAsHero: true })
+        {
+            HeroAutoPromoteLogger.LogSkipped(
+                logger,
+                HeroAutoPromoteSkipReason.NotCreated,
+                submitResult.Episode?.Id ?? Guid.Empty,
+                podcast.Id,
+                podcast.AlwaysPromoteAsHero,
+                release: submitResult.Episode?.Release,
+                episodeResult: submitResult.EpisodeResult.ToString());
         }
 
         LogSubmitEpisodeState(submitResult);
@@ -128,20 +135,30 @@ public class CategorisedItemProcessor(
         Episode episode,
         EpisodeCreationSource creationSource)
     {
-        var heroIds = HeroAutoPromoteSelector.SelectEpisodeIds(
-            podcast,
-            [episode],
-            DateTime.UtcNow);
-        if (heroIds.Count == 0)
+        var utcNow = DateTime.UtcNow;
+        var skipReason = HeroAutoPromoteSelector.GetSkipReason(podcast, episode, utcNow);
+        if (skipReason != HeroAutoPromoteSkipReason.None)
         {
+            var cutoff = skipReason == HeroAutoPromoteSkipReason.OutsideWeekWindow
+                ? HeroAutoPromoteSelector.GetCutoff(utcNow)
+                : (DateTime?)null;
+            HeroAutoPromoteLogger.LogSkipped(
+                logger,
+                skipReason,
+                episode.Id,
+                podcast.Id,
+                podcast.AlwaysPromoteAsHero,
+                release: episode.Release,
+                cutoff: cutoff,
+                episodeResult: SubmitResultState.Created.ToString());
             return;
         }
 
-        logger.LogInformation(
-            "Hero auto-promote: source={CreationSource}, podcastId={PodcastId}, episodeIds={EpisodeIds}.",
+        HeroAutoPromoteLogger.LogAttempt(
+            logger,
             creationSource,
             podcast.Id,
-            string.Join(',', heroIds));
-        await heroEpisodePromoter.PromoteAsync(heroIds);
+            [episode.Id]);
+        await heroEpisodePromoter.PromoteAsync([episode.Id]);
     }
 }

--- a/Cloud/Unit-Tests/FunctionHost.Tests/BusinessRules/Heroes/CloudflareChallengeResponseRules.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/BusinessRules/Heroes/CloudflareChallengeResponseRules.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using FluentAssertions;
+using RedditPodcastPoster.EdgeApi.Clients;
+using Xunit;
+
+namespace FunctionHost.Tests.BusinessRules.Heroes;
+
+public class CloudflareChallengeResponseRules
+{
+    [Fact(DisplayName =
+        "AppendHeroEpisodes response with Forbidden HTML containing Just a moment: detector treats it as Cloudflare bot challenge, because Bot Fight Mode never reached the Worker.")]
+    public void forbidden_just_a_moment_html_is_bot_challenge()
+    {
+        // Arrange
+        const string body =
+            "<!DOCTYPE html><html><title>Just a moment...</title><div id=\"cf-challenge\">Checking your browser</div></html>";
+
+        // Act
+        var isChallenge = CloudflareChallengeResponse.LooksLikeBotChallenge(HttpStatusCode.Forbidden, body);
+        var exception = CloudflareChallengeResponse.CreateException(HttpStatusCode.Forbidden, body);
+
+        // Assert
+        isChallenge.Should().BeTrue();
+        exception.Should().BeOfType<InvalidOperationException>();
+        exception.Message.Should().Contain("Cloudflare bot-mode challenge");
+        exception.Message.Should().Contain("403");
+        exception.Message.Should().Contain("Just a moment");
+    }
+
+    [Fact(DisplayName =
+        "AppendHeroEpisodes response with Forbidden JSON app body: detector does not treat it as bot challenge, because ordinary API Forbidden must stay a plain Error log.")]
+    public void forbidden_json_body_is_not_bot_challenge()
+    {
+        // Arrange
+        const string body = """{"error":"Forbidden","message":"Missing scope"}""";
+
+        // Act
+        var isChallenge = CloudflareChallengeResponse.LooksLikeBotChallenge(HttpStatusCode.Forbidden, body);
+
+        // Assert
+        isChallenge.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "AppendHeroEpisodes challenge exception truncates long HTML bodies, because App Insights exception messages must stay bounded.")]
+    public void create_exception_truncates_long_body()
+    {
+        // Arrange
+        var body = "<html>Just a moment..." + new string('x', CloudflareChallengeResponse.MaxBodyCharsInLog + 50);
+
+        // Act
+        var truncated = CloudflareChallengeResponse.TruncateBody(body);
+        var exception = CloudflareChallengeResponse.CreateException(HttpStatusCode.Forbidden, body);
+
+        // Assert
+        truncated.Length.Should().Be(CloudflareChallengeResponse.MaxBodyCharsInLog + 1);
+        truncated.Should().EndWith("…");
+        truncated.Length.Should().BeLessThan(body.Length);
+        exception.Message.Should().Contain("…");
+        exception.Message.Should().NotContain(body);
+    }
+}


### PR DESCRIPTION
## Summary
- Revert hero auto-promote attempt / success / skip diagnostics from Warning back to Information (`HeroAutoPromoteLogger`, `EdgeHeroEpisodePromoter`, `ApiClient` success).
- Keep useful skip reason Information logs (`FlagOff`, `NotCreated`, `OutsideWeekWindow`, etc.).
- On `AppendHeroEpisodes` failure: if the response looks like a Cloudflare Bot Fight / "Just a moment…" challenge, `LogError` with an `InvalidOperationException` (status + truncated body) so App Insights surfaces an exception failure. Ordinary JSON Forbidden stays Error without that challenge exception.
- BusinessRules tests updated for Information severity; added `CloudflareChallengeResponse` detector rules.

## Test plan
- [x] `dotnet test` filter `HeroAutoPromote` / `UrlSubmissionHeroAutoPromote` / `CloudflareChallenge` green
- [x] `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged` OK
- [ ] Redeploy **api-infra** (and **indexer-infra** if indexer path should pick this up) — RPP EdgeApi client change
- [ ] After deploy: challenge HTML path should appear as App Insights **exception** / Error with message containing `Cloudflare bot-mode challenge`
- [ ] Successful promote still logs Information (`AppendHeroEpisodes succeeded` / `posted … to edge hero curation`)