### PR TITLE
fix(infra): keep api__Endpoint out of git via Key Vault

### DIFF
--- a/Infrastructure/functions.bicep
+++ b/Infrastructure/functions.bicep
@@ -12,6 +12,9 @@ param auth0ClientId string
 @secure()
 param auth0ClientSecret string
 @secure()
+@description('Edge API base URL written to api__Endpoint (deploy-time literal). Public default is https://api.cultpodcasts.com. Free-plan Bot Fight M2M bypass host lives only in Key Vault secret Api-Endpoint — never commit personal workers.dev domains.')
+param apiEndpoint string
+@secure()
 param blueskyPassword string
 @secure()
 param cloudflareAccountId string
@@ -158,7 +161,7 @@ var memoryProbe = {
 }
 
 var api= {
-    api__Endpoint: 'https://api.cultpodcasts.com'
+    api__Endpoint: apiEndpoint
 }
 
 var auth0StagingDomain= 'auth-staging.cultpodcasts.com'

--- a/Infrastructure/functions.bicepparam
+++ b/Infrastructure/functions.bicepparam
@@ -2,6 +2,7 @@ using './functions.bicep'
 
 param auth0ClientId= az.getSecret(readEnvironmentVariable('INPUT_SUBSCRIPTION-ID'), readEnvironmentVariable('MANAGEMENT_RESOURCEGROUP_NAME'), readEnvironmentVariable('AZURE_KEYVAULT_NAME'), 'Auth0-ClientId')
 param auth0ClientSecret= az.getSecret(readEnvironmentVariable('INPUT_SUBSCRIPTION-ID'), readEnvironmentVariable('MANAGEMENT_RESOURCEGROUP_NAME'), readEnvironmentVariable('AZURE_KEYVAULT_NAME'), 'Auth0-ClientSecret')
+param apiEndpoint= az.getSecret(readEnvironmentVariable('INPUT_SUBSCRIPTION-ID'), readEnvironmentVariable('MANAGEMENT_RESOURCEGROUP_NAME'), readEnvironmentVariable('AZURE_KEYVAULT_NAME'), 'Api-Endpoint')
 param blueskyPassword= az.getSecret(readEnvironmentVariable('INPUT_SUBSCRIPTION-ID'), readEnvironmentVariable('MANAGEMENT_RESOURCEGROUP_NAME'), readEnvironmentVariable('AZURE_KEYVAULT_NAME'), 'Bluesky-Password')
 param cloudflareAccountId= az.getSecret(readEnvironmentVariable('INPUT_SUBSCRIPTION-ID'), readEnvironmentVariable('MANAGEMENT_RESOURCEGROUP_NAME'), readEnvironmentVariable('AZURE_KEYVAULT_NAME'), 'Cloudflare-AccountId')
 param cloudflareKVApiToken= az.getSecret(readEnvironmentVariable('INPUT_SUBSCRIPTION-ID'), readEnvironmentVariable('MANAGEMENT_RESOURCEGROUP_NAME'), readEnvironmentVariable('AZURE_KEYVAULT_NAME'), 'Cloudflare-KVApiToken')

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Use colon notation in user-secrets; Azure uses `__` instead of `:`.
 }
 ```
 
-`Index` / `SubmitUrl` (and Cloud Indexer/Api) call the edge hero API via `AddEdgeApiClient`. Non-secret `api:Endpoint` is also in those consoles' `appsettings.json`; M2M Auth0 (`auth0client:*`) belongs in user-secrets (same shared `UserSecretsId`).
+`Index` / `SubmitUrl` (and Cloud Indexer/Api) call the edge hero API via `AddEdgeApiClient`. Committed `api:Endpoint` / source defaults stay **`https://api.cultpodcasts.com`**. Production `api__Endpoint` is a **Key Vault secret** (`Api-Endpoint` → `@secure()` bicep param) — same deploy-time pattern as other secrets. **Never commit personal `*.workers.dev` hosts** (or any alternate edge host) in bicep, appsettings, or docs; set them only in KV / Azure app settings / local user-secrets when Free-plan Bot Fight Mode blocks M2M against the custom domain. Long-term: Pro WAF skip for Bearer on `/hero-curation` so M2M can use `api.cultpodcasts.com`. See [docs/deployment.md](docs/deployment.md) (§ Edge API endpoint) and Api `docs/hero-curation-m2m-edge.md`. M2M Auth0 (`auth0client:*`) belongs in user-secrets (same shared `UserSecretsId`).
 
 Additional production-only settings (Auth0, YouTube, Listen Notes, Taddy, push notification keys, etc.) are in `Infrastructure/functions.bicep`. Production secrets are read from Key Vault at **deploy time** (`functions.bicepparam`) and written as **literal** app-setting values — the running app never calls Key Vault. For YouTube key layout, local user-secrets, and interim manual apply steps, see [docs/youtube-keys.md](docs/youtube-keys.md).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -229,3 +229,30 @@ az functionapp function list -g AutomatedInfra -n discover-infra -o table
 ```
 
 Expected for discover: `DiscoveryTrigger`, `Discover`, `Orchestration`.
+
+## Edge API endpoint (`api__Endpoint`)
+
+Functions and consoles call the Cloudflare Api Worker for M2M hero auto-promote (`POST /hero-curation/episodes`).
+
+| Layer | Value |
+|-------|--------|
+| Committed source (`functions.bicep` param via KV, console `appsettings.json`) | Public host **`https://api.cultpodcasts.com`** as the documented default — **never** a personal `*.workers.dev` URL |
+| Key Vault `cultpodcasts-deployment` secret **`Api-Endpoint`** | Deploy-time source for `api__Endpoint` (same pattern as other `@secure()` params in `functions.bicepparam`) |
+| Live Azure app setting `api__Endpoint` | Literal string on `api-infra` / `indexer-infra` (and discover via core settings). May temporarily point at the Worker’s **workers.dev** host to bypass Free-plan **Bot Fight Mode**, which cannot be skipped with WAF custom rules on Free |
+
+### Operators — set / change without putting the host in git
+
+```powershell
+# 1) Store (or rotate) in Key Vault — value is NOT committed
+az keyvault secret set --vault-name cultpodcasts-deployment --name 'Api-Endpoint' --value 'https://api.cultpodcasts.com'
+# Free-plan M2M bypass (optional): use the Worker workers.dev URL from `wrangler deployments list` / dashboard — do not paste it into the repo.
+
+# 2a) Prefer next bicep provision (reads Api-Endpoint → literal app setting), or
+# 2b) Apply immediately without git:
+az functionapp config appsettings set -g AutomatedInfra -n api-infra --settings api__Endpoint="$(az keyvault secret show --vault-name cultpodcasts-deployment --name Api-Endpoint --query value -o tsv)"
+az functionapp config appsettings set -g AutomatedInfra -n indexer-infra --settings api__Endpoint="$(az keyvault secret show --vault-name cultpodcasts-deployment --name Api-Endpoint --query value -o tsv)"
+```
+
+Local console override (Bot Fight testing only): `dotnet user-secrets set "api:Endpoint" "<host>"` — not `appsettings.json`.
+
+**Long-term:** upgrade the zone to Pro and add a WAF skip for Bearer on `/hero-curation`, then set `Api-Endpoint` back to `https://api.cultpodcasts.com`. Detail: Api repo `docs/hero-curation-m2m-edge.md`.


### PR DESCRIPTION
## Summary
- Wire `api__Endpoint` through Key Vault secret `Api-Endpoint` (`@secure()` bicep param + `functions.bicepparam`), matching other deploy-time secrets.
- Document that Free-plan Bot Fight M2M bypass may use an alternate edge host **only** via KV / Azure app settings / user-secrets — never commit personal `*.workers.dev` URLs.
- Committed console `appsettings.json` stay on `https://api.cultpodcasts.com`. Live Azure already points at workers.dev for api-infra/indexer-infra; KV `Api-Endpoint` set to match so future bicep provision preserves the bypass.

## Test plan
- [ ] Confirm no `jonbreen.workers.dev` in RPP source
- [ ] `az keyvault secret show --vault-name cultpodcasts-deployment --name Api-Endpoint` returns the live edge base (not committed)
- [ ] `api-infra` / `indexer-infra` `api__Endpoint` unchanged (workers.dev bypass kept)
- [ ] Docs section in `docs/deployment.md` matches operator steps

Made with [Cursor](https://cursor.com)