### PR TITLE
fix(tools): load EnrichYouTubeOnlyPodcasts config from published PATH layout

### DIFF
--- a/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubePodcastProcessor.cs
+++ b/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubePodcastProcessor.cs
@@ -94,7 +94,12 @@ public class EnrichYouTubePodcastProcessor(
             podcast.YouTubePlaylistQueryIsExpensive.Value &&
             !request.AcknowledgeExpensiveYouTubePlaylistQuery)
         {
-            logger.LogError("Query for playlist '{podcastYouTubePlaylistId}' is expensive.", podcast.YouTubePlaylistId);
+            var playlistLabel = string.IsNullOrWhiteSpace(podcast.YouTubePlaylistId)
+                ? $"channel uploads for '{podcast.Name}'"
+                : $"'{podcast.YouTubePlaylistId}'";
+            logger.LogError(
+                "Query for playlist {playlistLabel} is expensive. Re-run with -a / --acknowledge-expensive-query.",
+                playlistLabel);
             return;
         }
 

--- a/Console-Apps/EnrichYouTubeOnlyPodcasts/Program.cs
+++ b/Console-Apps/EnrichYouTubeOnlyPodcasts/Program.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,12 +16,12 @@ using RedditPodcastPoster.Text.Extensions;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.Environment.ContentRootPath = Directory.GetCurrentDirectory();
-
-builder.Configuration.SetBasePath(GetBasePath());
+var appDirectory = AppContext.BaseDirectory;
+builder.Environment.ContentRootPath = appDirectory;
 
 builder.Configuration
-    .AddJsonFile("appsettings.json", false)
+    .AddJsonFile(Path.Combine(appDirectory, "appsettings.json"), true)
+    .AddJsonFile(Path.Combine(appDirectory, "EnrichYouTubeOnlyPodcasts.appsettings.json"), true)
     .AddEnvironmentVariables("RedditPodcastPoster_")
     .AddCommandLine(args)
     .AddSecrets(Assembly.GetExecutingAssembly());
@@ -52,10 +51,4 @@ async Task<int> Run(EnrichYouTubePodcastRequest request)
     var processor = host.Services.GetService<EnrichYouTubePodcastProcessor>();
     await processor!.Run(request);
     return 0;
-}
-
-string GetBasePath()
-{
-    using var processModule = Process.GetCurrentProcess().MainModule;
-    return Path.GetDirectoryName(processModule?.FileName) ?? throw new InvalidOperationException();
 }


### PR DESCRIPTION
## Summary
- Load optional `appsettings.json` and `EnrichYouTubeOnlyPodcasts.appsettings.json` from the exe directory so the PATH-published tool no longer fails looking for a shared `appsettings.json`.
- Clarify the expensive-query guard message when the podcast has no curated playlist id (channel uploads), and point users at `-a`.

## Test plan
- [ ] Run published `EnrichYouTubeOnlyPodcasts --help` from `artifacts\tools` and confirm it starts without FileNotFoundException for `appsettings.json`
- [ ] Run `enrichyouTubeOnlyPodcasts -n "<podcast with expensive flag and empty playlist id>"` and confirm the error mentions channel uploads + `-a`
- [ ] Re-run with `-a` and confirm enrichment proceeds past the expensive-query guard