### PR TITLE
fix(api): treat GUID in podcast/{id}/{episodeId} as podcast id

### DIFF
--- a/Cloud/Api/Controllers/PodcastController.cs
+++ b/Cloud/Api/Controllers/PodcastController.cs
@@ -60,13 +60,13 @@ public class PodcastController(
         HttpRequestData req,
         string podcastIdentifier,
         CancellationToken ct
-    )
-    {
-        var podcastGetRequest = Guid.TryParse(podcastIdentifier, out var podcastId)
-            ? new PodcastGetRequest(podcastId)
-            : new PodcastGetRequest(podcastIdentifier, null);
-        return HandleRequest(req, ["curate"], podcastGetRequest, getPodcastHandler.Handle, Unauthorised, ct);
-    }
+    ) => HandleRequest(
+            req,
+            ["curate"],
+            PodcastGetRequest.FromRouteIdentifier(podcastIdentifier),
+            getPodcastHandler.Handle,
+            Unauthorised,
+            ct);
 
     [Function("PodcastGetWithEpisodeId")]
     public Task<HttpResponseData> GetWithEpisodeId(
@@ -78,7 +78,7 @@ public class PodcastController(
     ) => HandleRequest(
             req,
             ["curate"],
-            new PodcastGetRequest(podcastName, episodeId),
+            PodcastGetRequest.FromRouteIdentifier(podcastName, episodeId),
             getPodcastHandler.Handle,
             Unauthorised,
             ct);

--- a/Cloud/Api/Controllers/PodcastController.cs
+++ b/Cloud/Api/Controllers/PodcastController.cs
@@ -60,13 +60,17 @@ public class PodcastController(
         HttpRequestData req,
         string podcastIdentifier,
         CancellationToken ct
-    ) => HandleRequest(
+    )
+    {
+        var resolution = PodcastGetRouteResolver.ForSingleSegment(podcastIdentifier);
+        return HandleRequest(
             req,
             ["curate"],
-            PodcastGetRequest.FromRouteIdentifier(podcastIdentifier),
+            resolution.HandlerRequest,
             getPodcastHandler.Handle,
             Unauthorised,
             ct);
+    }
 
     [Function("PodcastGetWithEpisodeId")]
     public Task<HttpResponseData> GetWithEpisodeId(
@@ -75,17 +79,22 @@ public class PodcastController(
         string podcastName,
         Guid episodeId,
         CancellationToken ct
-    ) => HandleRequest(
+    )
+    {
+        var resolution = PodcastGetRouteResolver.ForNameAndEpisodeId(podcastName, episodeId);
+        return HandleRequest(
             req,
             ["curate"],
-            PodcastGetRequest.FromRouteIdentifier(podcastName, episodeId),
+            resolution.HandlerRequest,
             getPodcastHandler.Handle,
             Unauthorised,
             ct);
+    }
 
     // Rare fallback: App Service decodes %2F to '/', so names with '/' become
     // extra segments and miss the routes above (Azure/azure-functions-host#9290).
     // Also stops Guid-bind 500s when a split name wrongly hits PodcastGetWithEpisodeId.
+    // Prod often selects this catch-all for podcast/{guid}/{episodeGuid} as well.
     [Function("PodcastGetSlash")]
     public Task<HttpResponseData> GetByIdentifierCatchAll(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "podcast/{*podcastIdentifier}")]
@@ -94,10 +103,14 @@ public class PodcastController(
         CancellationToken ct
     )
     {
-        if (PodcastEpisodePathParser.TrySplitTrailingEpisodeId(
-                podcastIdentifier, out var podcastName, out var episodeId))
+        var resolution = PodcastGetRouteResolver.ForCatchAll(podcastIdentifier);
+        if (resolution.ContinuesAs == PodcastGetContinuation.GetWithEpisodeId)
         {
-            return GetWithEpisodeId(req, podcastName, episodeId, ct);
+            return GetWithEpisodeId(
+                req,
+                resolution.EpisodeRoutePodcastSegment!,
+                resolution.EpisodeRouteEpisodeId!.Value,
+                ct);
         }
 
         return GetByIdentifier(req, podcastIdentifier, ct);

--- a/Cloud/Api/Models/PodcastGetRequest.cs
+++ b/Cloud/Api/Models/PodcastGetRequest.cs
@@ -15,6 +15,20 @@ public class PodcastGetRequest
         PodcastId = podcastId;
     }
 
+    /// <summary>
+    /// Builds a get-request from a route segment that may be a podcast id or name.
+    /// Guid segments resolve by id (episode id is unused); names may include episode id for disambiguation.
+    /// </summary>
+    public static PodcastGetRequest FromRouteIdentifier(string podcastIdentifier, Guid? episodeId = null)
+    {
+        if (Guid.TryParse(podcastIdentifier, out var podcastId))
+        {
+            return new PodcastGetRequest(podcastId);
+        }
+
+        return new PodcastGetRequest(podcastIdentifier, episodeId);
+    }
+
     public string? PodcastName => podcastName == null ? null : PodcastRouteNameNormalizer.Normalize(podcastName);
     public Guid? EpisodeId { get; init; }
     public Guid? PodcastId { get; init; }

--- a/Cloud/Api/Models/PodcastGetRouteResolver.cs
+++ b/Cloud/Api/Models/PodcastGetRouteResolver.cs
@@ -1,0 +1,75 @@
+namespace Api.Models;
+
+/// <summary>
+/// Which Azure Function entry handled the HTTP request (App Insights "function" name).
+/// </summary>
+public enum PodcastGetFunction
+{
+    PodcastGet,
+    PodcastGetWithEpisodeId,
+    PodcastGetSlash
+}
+
+/// <summary>
+/// Which controller method the catch-all continues into (in-process; not a second Functions host invocation).
+/// </summary>
+public enum PodcastGetContinuation
+{
+    GetByIdentifier,
+    GetWithEpisodeId
+}
+
+/// <summary>
+/// Resolved podcast-get routing: which function entry ran, how the controller continues, and the
+/// request the get-handler / GetAsync service must receive.
+/// </summary>
+public sealed record PodcastGetRouteResolution(
+    PodcastGetFunction InvokedFunction,
+    PodcastGetContinuation ContinuesAs,
+    PodcastGetRequest HandlerRequest,
+    string? EpisodeRoutePodcastSegment = null,
+    Guid? EpisodeRouteEpisodeId = null);
+
+/// <summary>
+/// Maps podcast GET route shapes to handler requests. Prod often selects PodcastGetSlash for
+/// <c>podcast/{guid}/{guid}</c> (see App Insights), so catch-all must produce PodcastId lookups.
+/// </summary>
+public static class PodcastGetRouteResolver
+{
+    public static PodcastGetRouteResolution ForSingleSegment(string podcastIdentifier) =>
+        new(
+            PodcastGetFunction.PodcastGet,
+            PodcastGetContinuation.GetByIdentifier,
+            PodcastGetRequest.FromRouteIdentifier(podcastIdentifier));
+
+    public static PodcastGetRouteResolution ForNameAndEpisodeId(string podcastName, Guid episodeId) =>
+        new(
+            PodcastGetFunction.PodcastGetWithEpisodeId,
+            PodcastGetContinuation.GetWithEpisodeId,
+            PodcastGetRequest.FromRouteIdentifier(podcastName, episodeId),
+            podcastName,
+            episodeId);
+
+    /// <summary>
+    /// <c>podcast/{*podcastIdentifier}</c> (PodcastGetSlash) — used when hosts decode %2F or when
+    /// the catch-all wins over the typed two-segment route.
+    /// </summary>
+    public static PodcastGetRouteResolution ForCatchAll(string podcastIdentifier)
+    {
+        if (PodcastEpisodePathParser.TrySplitTrailingEpisodeId(
+                podcastIdentifier, out var podcastSegment, out var episodeId))
+        {
+            return new(
+                PodcastGetFunction.PodcastGetSlash,
+                PodcastGetContinuation.GetWithEpisodeId,
+                PodcastGetRequest.FromRouteIdentifier(podcastSegment, episodeId),
+                podcastSegment,
+                episodeId);
+        }
+
+        return new(
+            PodcastGetFunction.PodcastGetSlash,
+            PodcastGetContinuation.GetByIdentifier,
+            PodcastGetRequest.FromRouteIdentifier(podcastIdentifier));
+    }
+}

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Handlers/GetPodcastHandlerRouteRequestTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Handlers/GetPodcastHandlerRouteRequestTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Api.Handlers;
+using Api.Handlers.Podcasts;
+using Api.Models;
+using Api.Services.Podcasts;
+using Xunit;
+using Podcast = RedditPodcastPoster.Models.Podcasts.Podcast;
+
+namespace FunctionHost.Tests.Api.Handlers;
+
+public class GetPodcastHandlerRouteRequestTests
+{
+    [Fact(DisplayName =
+        "After PodcastGetSlash resolves podcastGuid/episodeGuid: GetPodcastHandler calls GetAsync with PodcastId (not PodcastName), because that is the request shape that must reach GetAsync.")]
+    public async Task catch_all_guid_pair_handler_passes_podcast_id_to_get_async()
+    {
+        // Arrange
+        var podcastId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var resolution = PodcastGetRouteResolver.ForCatchAll($"{podcastId:D}/{episodeId:D}");
+        PodcastGetRequest? captured = null;
+        var service = new Mock<IPodcastGetService>();
+        service
+            .Setup(s => s.GetAsync(It.IsAny<PodcastGetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PodcastGetRequest, CancellationToken>((request, _) => captured = request)
+            .ReturnsAsync(new PodcastGetResult(
+                PodcastGetStatus.Found,
+                new Podcast { Id = podcastId, Name = "Show" }));
+        var handler = new GetPodcastHandler(service.Object, NullLogger<GetPodcastHandler>.Instance);
+        var (req, _) = HttpTestHelpers.CreateRequestResponse("GET");
+
+        // Act
+        var result = await handler.Handle(
+            new HandlerContext(req.Object, null),
+            resolution.HandlerRequest,
+            CancellationToken.None);
+
+        // Assert
+        result.StatusCode.Should().Be(HttpStatusCode.OK);
+        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetSlash);
+        captured.Should().NotBeNull();
+        captured!.PodcastId.Should().Be(podcastId);
+        captured.PodcastName.Should().BeNull();
+        captured.ToString().Should().Be($"PodcastId: '{podcastId}'.");
+        service.Verify(
+            s => s.GetAsync(It.Is<PodcastGetRequest>(r => r.PodcastId == podcastId && r.PodcastName == null),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact(DisplayName =
+        "After PodcastGetSlash resolves name?/episodeGuid: GetPodcastHandler calls GetAsync with PodcastName + EpisodeId.")]
+    public async Task catch_all_name_and_episode_handler_passes_name_lookup_to_get_async()
+    {
+        // Arrange
+        const string podcastName = "Was I In A Cult?";
+        var episodeId = Guid.NewGuid();
+        var podcastId = Guid.NewGuid();
+        var resolution = PodcastGetRouteResolver.ForCatchAll($"{podcastName}/{episodeId:D}");
+        PodcastGetRequest? captured = null;
+        var service = new Mock<IPodcastGetService>();
+        service
+            .Setup(s => s.GetAsync(It.IsAny<PodcastGetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PodcastGetRequest, CancellationToken>((request, _) => captured = request)
+            .ReturnsAsync(new PodcastGetResult(
+                PodcastGetStatus.Found,
+                new Podcast { Id = podcastId, Name = podcastName }));
+        var handler = new GetPodcastHandler(service.Object, NullLogger<GetPodcastHandler>.Instance);
+        var (req, _) = HttpTestHelpers.CreateRequestResponse("GET");
+
+        // Act
+        var result = await handler.Handle(
+            new HandlerContext(req.Object, null),
+            resolution.HandlerRequest,
+            CancellationToken.None);
+
+        // Assert
+        result.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.PodcastId.Should().BeNull();
+        captured.PodcastName.Should().Be(podcastName);
+        captured.EpisodeId.Should().Be(episodeId);
+        service.Verify(
+            s => s.GetAsync(
+                It.Is<PodcastGetRequest>(r =>
+                    r.PodcastName == podcastName && r.EpisodeId == episodeId && r.PodcastId == null),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Handlers/GetPodcastHandlerRouteRequestTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Handlers/GetPodcastHandlerRouteRequestTests.cs
@@ -52,8 +52,8 @@ public class GetPodcastHandlerRouteRequestTests
     }
 
     [Fact(DisplayName =
-        "After PodcastGetSlash resolves name?/episodeGuid: GetPodcastHandler calls GetAsync with PodcastName + EpisodeId.")]
-    public async Task catch_all_name_and_episode_handler_passes_name_lookup_to_get_async()
+        "After PodcastGetSlash resolves podcast-name?/episodeId: GetPodcastHandler calls GetAsync with PodcastName + EpisodeId.")]
+    public async Task catch_all_question_mark_name_and_episode_handler_passes_name_lookup_to_get_async()
     {
         // Arrange
         const string podcastName = "Was I In A Cult?";
@@ -89,5 +89,39 @@ public class GetPodcastHandlerRouteRequestTests
                     r.PodcastName == podcastName && r.EpisodeId == episodeId && r.PodcastId == null),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact(DisplayName =
+        "After PodcastGetSlash resolves slash-containing podcast-name/episodeId: GetPodcastHandler calls GetAsync with PodcastName + EpisodeId.")]
+    public async Task catch_all_slash_name_and_episode_handler_passes_name_lookup_to_get_async()
+    {
+        // Arrange
+        const string podcastName = "True Crime Show w/ Guest Host";
+        var episodeId = Guid.NewGuid();
+        var podcastId = Guid.NewGuid();
+        var resolution = PodcastGetRouteResolver.ForCatchAll($"{podcastName}/{episodeId:D}");
+        PodcastGetRequest? captured = null;
+        var service = new Mock<IPodcastGetService>();
+        service
+            .Setup(s => s.GetAsync(It.IsAny<PodcastGetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PodcastGetRequest, CancellationToken>((request, _) => captured = request)
+            .ReturnsAsync(new PodcastGetResult(
+                PodcastGetStatus.Found,
+                new Podcast { Id = podcastId, Name = podcastName }));
+        var handler = new GetPodcastHandler(service.Object, NullLogger<GetPodcastHandler>.Instance);
+        var (req, _) = HttpTestHelpers.CreateRequestResponse("GET");
+
+        // Act
+        var result = await handler.Handle(
+            new HandlerContext(req.Object, null),
+            resolution.HandlerRequest,
+            CancellationToken.None);
+
+        // Assert
+        result.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.PodcastId.Should().BeNull();
+        captured.PodcastName.Should().Be(podcastName);
+        captured.EpisodeId.Should().Be(episodeId);
     }
 }

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastEpisodePathParserTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastEpisodePathParserTests.cs
@@ -6,21 +6,30 @@ namespace FunctionHost.Tests.Api.Models;
 
 public class PodcastEpisodePathParserTests
 {
-    [Fact(DisplayName =
-        "Trailing episode guid after a slash-containing podcast name: path splits into name + episode id, because hosts decode %2F into path separators.")]
-    public void splits_slash_containing_podcast_name_and_trailing_episode_id()
+    public static TheoryData<string> PodcastNamesWithSpecialCharacters() => new()
+    {
+        "Was I In A Cult?",
+        "True Crime Show w/ Guest Host",
+        "Cult? Show w/ Nested Slash",
+        "A/B Testing Podcast?"
+    };
+
+    [Theory(DisplayName =
+        "Trailing episode guid after a podcast name that contains ? and/or /: path splits into full name + episode id, because catch-all paths keep special characters in the name segment.")]
+    [MemberData(nameof(PodcastNamesWithSpecialCharacters))]
+    public void splits_special_character_podcast_name_and_trailing_episode_id(string podcastName)
     {
         // Arrange
         var episodeId = Guid.NewGuid();
-        var path = $"True Crime Show w/ Guest Host/{episodeId:D}";
+        var path = $"{podcastName}/{episodeId:D}";
 
         // Act
         var ok = PodcastEpisodePathParser.TrySplitTrailingEpisodeId(
-            path, out var podcastName, out var parsedEpisodeId);
+            path, out var parsedName, out var parsedEpisodeId);
 
         // Assert
         ok.Should().BeTrue();
-        podcastName.Should().Be("True Crime Show w/ Guest Host");
+        parsedName.Should().Be(podcastName);
         parsedEpisodeId.Should().Be(episodeId);
     }
 
@@ -48,6 +57,23 @@ public class PodcastEpisodePathParserTests
     {
         // Arrange
         const string path = "True Crime Show w/ Guest Host";
+
+        // Act
+        var ok = PodcastEpisodePathParser.TrySplitTrailingEpisodeId(
+            path, out var podcastName, out var parsedEpisodeId);
+
+        // Assert
+        ok.Should().BeFalse();
+        podcastName.Should().BeEmpty();
+        parsedEpisodeId.Should().Be(Guid.Empty);
+    }
+
+    [Fact(DisplayName =
+        "Question-mark podcast name without trailing episode guid: split fails so single-segment name lookup can run.")]
+    public void rejects_question_mark_name_without_trailing_guid()
+    {
+        // Arrange
+        const string path = "Was I In A Cult?";
 
         // Act
         var ok = PodcastEpisodePathParser.TrySplitTrailingEpisodeId(

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastGetRequestTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastGetRequestTests.cs
@@ -1,0 +1,58 @@
+using Api.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace FunctionHost.Tests.Api.Models;
+
+public class PodcastGetRequestTests
+{
+    [Fact(DisplayName =
+        "Route identifier that is a podcast guid: request resolves by PodcastId, because curator UIs pass ids from episode review.")]
+    public void guid_identifier_resolves_by_podcast_id()
+    {
+        // Arrange
+        var podcastId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+
+        // Act
+        var request = PodcastGetRequest.FromRouteIdentifier(podcastId.ToString("D"), episodeId);
+
+        // Assert
+        request.PodcastId.Should().Be(podcastId);
+        request.PodcastName.Should().BeNull();
+        request.EpisodeId.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "Route identifier that is a podcast name with episode id: request keeps name + episode id for disambiguation.")]
+    public void name_identifier_keeps_name_and_episode_id()
+    {
+        // Arrange
+        const string podcastName = "Was I In A Cult?";
+        var episodeId = Guid.NewGuid();
+
+        // Act
+        var request = PodcastGetRequest.FromRouteIdentifier(podcastName, episodeId);
+
+        // Assert
+        request.PodcastId.Should().BeNull();
+        request.PodcastName.Should().Be(podcastName);
+        request.EpisodeId.Should().Be(episodeId);
+    }
+
+    [Fact(DisplayName =
+        "Route identifier that is a podcast name without episode id: request looks up by name alone.")]
+    public void name_identifier_without_episode_id_looks_up_by_name()
+    {
+        // Arrange
+        const string podcastName = "Was I In A Cult?";
+
+        // Act
+        var request = PodcastGetRequest.FromRouteIdentifier(podcastName);
+
+        // Assert
+        request.PodcastId.Should().BeNull();
+        request.PodcastName.Should().Be(podcastName);
+        request.EpisodeId.Should().BeNull();
+    }
+}

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastGetRouteResolverTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastGetRouteResolverTests.cs
@@ -4,11 +4,29 @@ using Xunit;
 
 namespace FunctionHost.Tests.Api.Models;
 
+/// <summary>
+/// Route shapes for GET podcast:
+/// <list type="bullet">
+/// <item><c>podcast/{podcastId}</c> — PodcastGet</item>
+/// <item><c>podcast/{podcastName}</c> — PodcastGet (name may include ?)</item>
+/// <item><c>podcast/{podcastName}/{episodeId}</c> — typed or PodcastGetSlash; name may include ? and/or /</item>
+/// <item><c>podcast/{podcastId}/{episodeId}</c> — often PodcastGetSlash in prod; must resolve by PodcastId</item>
+/// </list>
+/// The trailing guid on two-segment routes is always an <b>episode</b> id (disambiguation), not a podcast id.
+/// </summary>
 public class PodcastGetRouteResolverTests
 {
+    public static TheoryData<string> PodcastNamesWithSpecialCharacters() => new()
+    {
+        "Was I In A Cult?",
+        "True Crime Show w/ Guest Host",
+        "Cult? Show w/ Nested Slash",
+        "A/B Testing Podcast?"
+    };
+
     [Fact(DisplayName =
-        "PodcastGetSlash catch-all for podcastGuid/episodeGuid: continues as GetWithEpisodeId and handler request uses PodcastId, because App Insights shows PodcastGetSlash for curator guid/guid URLs and name lookup of a guid 404s.")]
-    public void catch_all_guid_slash_guid_resolves_by_podcast_id()
+        "PodcastGetSlash catch-all for podcastId/episodeId: continues as GetWithEpisodeId and handler request uses PodcastId, because App Insights shows PodcastGetSlash for curator guid/guid URLs and name lookup of a guid 404s.")]
+    public void catch_all_podcast_id_slash_episode_id_resolves_by_podcast_id()
     {
         // Arrange
         var podcastId = Guid.NewGuid();
@@ -30,8 +48,8 @@ public class PodcastGetRouteResolverTests
     }
 
     [Fact(DisplayName =
-        "PodcastGetWithEpisodeId for podcastGuid/episodeGuid: handler request uses PodcastId, because the typed two-segment route must not treat a guid as a podcast name.")]
-    public void typed_route_guid_and_episode_resolves_by_podcast_id()
+        "PodcastGetWithEpisodeId for podcastId/episodeId: handler request uses PodcastId, because the typed two-segment route must not treat a guid as a podcast name.")]
+    public void typed_route_podcast_id_and_episode_id_resolves_by_podcast_id()
     {
         // Arrange
         var podcastId = Guid.NewGuid();
@@ -47,12 +65,12 @@ public class PodcastGetRouteResolverTests
         resolution.HandlerRequest.PodcastName.Should().BeNull();
     }
 
-    [Fact(DisplayName =
-        "PodcastGetSlash catch-all for name?/episodeGuid: continues as GetWithEpisodeId with PodcastName + EpisodeId for disambiguation.")]
-    public void catch_all_question_mark_name_and_episode_keeps_name_lookup()
+    [Theory(DisplayName =
+        "PodcastGetSlash catch-all for podcast-name/episodeId when the name contains ? and/or /: continues as GetWithEpisodeId with PodcastName + EpisodeId (name lookup + episode disambiguation).")]
+    [MemberData(nameof(PodcastNamesWithSpecialCharacters))]
+    public void catch_all_podcast_name_slash_episode_id_keeps_name_lookup(string podcastName)
     {
         // Arrange
-        const string podcastName = "Was I In A Cult?";
         var episodeId = Guid.NewGuid();
         var catchAllPath = $"{podcastName}/{episodeId:D}";
 
@@ -62,17 +80,19 @@ public class PodcastGetRouteResolverTests
         // Assert
         resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetSlash);
         resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetWithEpisodeId);
+        resolution.EpisodeRoutePodcastSegment.Should().Be(podcastName);
+        resolution.EpisodeRouteEpisodeId.Should().Be(episodeId);
         resolution.HandlerRequest.PodcastId.Should().BeNull();
         resolution.HandlerRequest.PodcastName.Should().Be(podcastName);
         resolution.HandlerRequest.EpisodeId.Should().Be(episodeId);
     }
 
-    [Fact(DisplayName =
-        "PodcastGetWithEpisodeId for name?/episodeGuid: handler request keeps PodcastName + EpisodeId.")]
-    public void typed_route_question_mark_name_and_episode_keeps_name_lookup()
+    [Theory(DisplayName =
+        "PodcastGetWithEpisodeId for podcast-name/episodeId when the name contains ? and/or /: handler request keeps PodcastName + EpisodeId.")]
+    [MemberData(nameof(PodcastNamesWithSpecialCharacters))]
+    public void typed_route_podcast_name_and_episode_id_keeps_name_lookup(string podcastName)
     {
         // Arrange
-        const string podcastName = "Was I In A Cult?";
         var episodeId = Guid.NewGuid();
 
         // Act
@@ -80,34 +100,15 @@ public class PodcastGetRouteResolverTests
 
         // Assert
         resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetWithEpisodeId);
-        resolution.HandlerRequest.PodcastId.Should().BeNull();
-        resolution.HandlerRequest.PodcastName.Should().Be(podcastName);
-        resolution.HandlerRequest.EpisodeId.Should().Be(episodeId);
-    }
-
-    [Fact(DisplayName =
-        "PodcastGetSlash catch-all for slash-containing name/episodeGuid: continues as GetWithEpisodeId with the full name and episode id.")]
-    public void catch_all_slash_containing_name_and_episode_keeps_name_lookup()
-    {
-        // Arrange
-        const string podcastName = "True Crime Show w/ Guest Host";
-        var episodeId = Guid.NewGuid();
-        var catchAllPath = $"{podcastName}/{episodeId:D}";
-
-        // Act
-        var resolution = PodcastGetRouteResolver.ForCatchAll(catchAllPath);
-
-        // Assert
-        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetSlash);
         resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetWithEpisodeId);
+        resolution.HandlerRequest.PodcastId.Should().BeNull();
         resolution.HandlerRequest.PodcastName.Should().Be(podcastName);
         resolution.HandlerRequest.EpisodeId.Should().Be(episodeId);
-        resolution.HandlerRequest.PodcastId.Should().BeNull();
     }
 
     [Fact(DisplayName =
-        "PodcastGet single-segment guid: handler request uses PodcastId.")]
-    public void single_segment_guid_resolves_by_podcast_id()
+        "PodcastGet single-segment podcast id: handler request uses PodcastId.")]
+    public void single_segment_podcast_id_resolves_by_podcast_id()
     {
         // Arrange
         var podcastId = Guid.NewGuid();
@@ -122,14 +123,12 @@ public class PodcastGetRouteResolverTests
         resolution.HandlerRequest.PodcastName.Should().BeNull();
     }
 
-    [Fact(DisplayName =
-        "PodcastGet single-segment name: handler request uses PodcastName.")]
-    public void single_segment_name_resolves_by_podcast_name()
+    [Theory(DisplayName =
+        "PodcastGet single-segment podcast name (including ? and /): handler request uses PodcastName.")]
+    [MemberData(nameof(PodcastNamesWithSpecialCharacters))]
+    public void single_segment_podcast_name_resolves_by_podcast_name(string podcastName)
     {
-        // Arrange
-        const string podcastName = "Was I In A Cult?";
-
-        // Act
+        // Arrange / Act
         var resolution = PodcastGetRouteResolver.ForSingleSegment(podcastName);
 
         // Assert
@@ -137,11 +136,12 @@ public class PodcastGetRouteResolverTests
         resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetByIdentifier);
         resolution.HandlerRequest.PodcastName.Should().Be(podcastName);
         resolution.HandlerRequest.PodcastId.Should().BeNull();
+        resolution.HandlerRequest.EpisodeId.Should().BeNull();
     }
 
     [Fact(DisplayName =
-        "PodcastGetSlash catch-all without trailing episode guid: continues as GetByIdentifier with the full path as the identifier.")]
-    public void catch_all_without_trailing_episode_continues_as_by_identifier()
+        "PodcastGetSlash catch-all for slash-containing name without trailing episode id: continues as GetByIdentifier with the full path as the podcast name.")]
+    public void catch_all_slash_name_without_trailing_episode_continues_as_by_identifier()
     {
         // Arrange
         const string podcastName = "True Crime Show w/ Guest Host";

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastGetRouteResolverTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Models/PodcastGetRouteResolverTests.cs
@@ -1,0 +1,159 @@
+using Api.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace FunctionHost.Tests.Api.Models;
+
+public class PodcastGetRouteResolverTests
+{
+    [Fact(DisplayName =
+        "PodcastGetSlash catch-all for podcastGuid/episodeGuid: continues as GetWithEpisodeId and handler request uses PodcastId, because App Insights shows PodcastGetSlash for curator guid/guid URLs and name lookup of a guid 404s.")]
+    public void catch_all_guid_slash_guid_resolves_by_podcast_id()
+    {
+        // Arrange
+        var podcastId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var catchAllPath = $"{podcastId:D}/{episodeId:D}";
+
+        // Act
+        var resolution = PodcastGetRouteResolver.ForCatchAll(catchAllPath);
+
+        // Assert
+        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetSlash);
+        resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetWithEpisodeId);
+        resolution.EpisodeRoutePodcastSegment.Should().Be(podcastId.ToString("D"));
+        resolution.EpisodeRouteEpisodeId.Should().Be(episodeId);
+        resolution.HandlerRequest.PodcastId.Should().Be(podcastId);
+        resolution.HandlerRequest.PodcastName.Should().BeNull();
+        resolution.HandlerRequest.EpisodeId.Should().BeNull();
+        resolution.HandlerRequest.ToString().Should().Be($"PodcastId: '{podcastId}'.");
+    }
+
+    [Fact(DisplayName =
+        "PodcastGetWithEpisodeId for podcastGuid/episodeGuid: handler request uses PodcastId, because the typed two-segment route must not treat a guid as a podcast name.")]
+    public void typed_route_guid_and_episode_resolves_by_podcast_id()
+    {
+        // Arrange
+        var podcastId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+
+        // Act
+        var resolution = PodcastGetRouteResolver.ForNameAndEpisodeId(podcastId.ToString("D"), episodeId);
+
+        // Assert
+        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetWithEpisodeId);
+        resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetWithEpisodeId);
+        resolution.HandlerRequest.PodcastId.Should().Be(podcastId);
+        resolution.HandlerRequest.PodcastName.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "PodcastGetSlash catch-all for name?/episodeGuid: continues as GetWithEpisodeId with PodcastName + EpisodeId for disambiguation.")]
+    public void catch_all_question_mark_name_and_episode_keeps_name_lookup()
+    {
+        // Arrange
+        const string podcastName = "Was I In A Cult?";
+        var episodeId = Guid.NewGuid();
+        var catchAllPath = $"{podcastName}/{episodeId:D}";
+
+        // Act
+        var resolution = PodcastGetRouteResolver.ForCatchAll(catchAllPath);
+
+        // Assert
+        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetSlash);
+        resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetWithEpisodeId);
+        resolution.HandlerRequest.PodcastId.Should().BeNull();
+        resolution.HandlerRequest.PodcastName.Should().Be(podcastName);
+        resolution.HandlerRequest.EpisodeId.Should().Be(episodeId);
+    }
+
+    [Fact(DisplayName =
+        "PodcastGetWithEpisodeId for name?/episodeGuid: handler request keeps PodcastName + EpisodeId.")]
+    public void typed_route_question_mark_name_and_episode_keeps_name_lookup()
+    {
+        // Arrange
+        const string podcastName = "Was I In A Cult?";
+        var episodeId = Guid.NewGuid();
+
+        // Act
+        var resolution = PodcastGetRouteResolver.ForNameAndEpisodeId(podcastName, episodeId);
+
+        // Assert
+        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetWithEpisodeId);
+        resolution.HandlerRequest.PodcastId.Should().BeNull();
+        resolution.HandlerRequest.PodcastName.Should().Be(podcastName);
+        resolution.HandlerRequest.EpisodeId.Should().Be(episodeId);
+    }
+
+    [Fact(DisplayName =
+        "PodcastGetSlash catch-all for slash-containing name/episodeGuid: continues as GetWithEpisodeId with the full name and episode id.")]
+    public void catch_all_slash_containing_name_and_episode_keeps_name_lookup()
+    {
+        // Arrange
+        const string podcastName = "True Crime Show w/ Guest Host";
+        var episodeId = Guid.NewGuid();
+        var catchAllPath = $"{podcastName}/{episodeId:D}";
+
+        // Act
+        var resolution = PodcastGetRouteResolver.ForCatchAll(catchAllPath);
+
+        // Assert
+        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetSlash);
+        resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetWithEpisodeId);
+        resolution.HandlerRequest.PodcastName.Should().Be(podcastName);
+        resolution.HandlerRequest.EpisodeId.Should().Be(episodeId);
+        resolution.HandlerRequest.PodcastId.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "PodcastGet single-segment guid: handler request uses PodcastId.")]
+    public void single_segment_guid_resolves_by_podcast_id()
+    {
+        // Arrange
+        var podcastId = Guid.NewGuid();
+
+        // Act
+        var resolution = PodcastGetRouteResolver.ForSingleSegment(podcastId.ToString("D"));
+
+        // Assert
+        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGet);
+        resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetByIdentifier);
+        resolution.HandlerRequest.PodcastId.Should().Be(podcastId);
+        resolution.HandlerRequest.PodcastName.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "PodcastGet single-segment name: handler request uses PodcastName.")]
+    public void single_segment_name_resolves_by_podcast_name()
+    {
+        // Arrange
+        const string podcastName = "Was I In A Cult?";
+
+        // Act
+        var resolution = PodcastGetRouteResolver.ForSingleSegment(podcastName);
+
+        // Assert
+        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGet);
+        resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetByIdentifier);
+        resolution.HandlerRequest.PodcastName.Should().Be(podcastName);
+        resolution.HandlerRequest.PodcastId.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "PodcastGetSlash catch-all without trailing episode guid: continues as GetByIdentifier with the full path as the identifier.")]
+    public void catch_all_without_trailing_episode_continues_as_by_identifier()
+    {
+        // Arrange
+        const string podcastName = "True Crime Show w/ Guest Host";
+
+        // Act
+        var resolution = PodcastGetRouteResolver.ForCatchAll(podcastName);
+
+        // Assert
+        resolution.InvokedFunction.Should().Be(PodcastGetFunction.PodcastGetSlash);
+        resolution.ContinuesAs.Should().Be(PodcastGetContinuation.GetByIdentifier);
+        resolution.HandlerRequest.PodcastName.Should().Be(podcastName);
+        resolution.HandlerRequest.PodcastId.Should().BeNull();
+        resolution.EpisodeRouteEpisodeId.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- `GET podcast/{podcastName}/{episodeId}` always built `PodcastGetRequest(name, episodeId)`
- Curator episode review passes **podcast GUIDs**; looking up name == guid returns 404
- `PodcastGetRequest.FromRouteIdentifier` parses guids as `PodcastId` (aligned with single-segment get)
- Unit tests for guid vs name route shaping

## Test plan
- [ ] `dotnet test` FunctionHost.Tests filter PodcastGetRequestTests
- [ ] After deploy: `GET /podcast/{podcastGuid}/{episodeGuid}` returns 200 for a real pair
- [ ] Name + episode still works for ambiguous / `?`-ending names