### PR TITLE
feat(subjects): record PodcastDefault provenance in episode matches

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Models/Subjects/SubjectMatchSource.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Subjects/SubjectMatchSource.cs
@@ -4,5 +4,7 @@ namespace RedditPodcastPoster.Models.Subjects;
 public enum SubjectMatchSource
 {
     Title = 1,
-    Description
+    Description = 2,
+    /// <summary>Subject applied because it is the podcast's DefaultSubject (no title/description term hit).</summary>
+    PodcastDefault = 3
 }

--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectEnricherTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectEnricherTests.cs
@@ -27,33 +27,39 @@ public class SubjectEnricherTests
         _fixture.Customize<Episode>(x => x.Without(o => o.Subjects).Without(o => o.Matches));
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "When enrich finds no subject matches, it applies the podcast default subject.")]
     public async Task EnrichSubjects_WithNoMatches_AddsDefaultSubject()
     {
-        // arrange
+        // Arrange
         var episode = _fixture.Create<Episode>();
         var options = _fixture.Create<SubjectEnrichmentOptions>();
         _subjectMatches = new List<SubjectMatch>();
 
         var sut = _mocker.CreateInstance<SubjectEnricher>();
 
-        // act
+        // Act
         var result = await sut.EnrichSubjects(episode, options);
 
-        // assert
+        // Assert
         result.Additions.Should().ContainSingle();
         result.Additions.Should().Contain(options.DefaultSubject);
         result.Removals.Should().HaveCount(0);
+        episode.Matches.Should().ContainSingle(m =>
+            m.Subject == options.DefaultSubject && m.Source == SubjectMatchSource.PodcastDefault);
     }
 
-
-    [Fact]
+    [Fact(DisplayName =
+        "When enrich finds only invisible subject matches, it also applies the podcast default and records PodcastDefault provenance.")]
     public async Task EnrichSubjects_WithOnlyInvisibleMatches_AddsDefaultSubject()
     {
-        // arrange
+        // Arrange
         var invisibleSubjectName = "_invisible";
+        var defaultSubject = _fixture.Create<string>();
         var episode = _fixture.Create<Episode>();
-        var options = _fixture.Create<SubjectEnrichmentOptions>();
+        var options = _fixture.Build<SubjectEnrichmentOptions>()
+            .With(x => x.DefaultSubject, defaultSubject)
+            .Create();
         var invisibleSubject = new Subject(invisibleSubjectName);
         var subjectMatch = new SubjectMatch(
             invisibleSubject,
@@ -61,22 +67,27 @@ public class SubjectEnricherTests
         );
         _subjectMatches = [subjectMatch];
         var sut = _mocker.CreateInstance<SubjectEnricher>();
-        // act
+
+        // Act
         var result = await sut.EnrichSubjects(episode, options);
-        // assert
+
+        // Assert
         result.Additions.Should().HaveCount(2);
-        result.Additions.Should().BeEquivalentTo([options.DefaultSubject, invisibleSubjectName]);
+        result.Additions.Should().BeEquivalentTo([defaultSubject, invisibleSubjectName]);
         result.Removals.Should().HaveCount(0);
-        episode.Subjects.Should().Contain(options.DefaultSubject);
+        episode.Subjects.Should().Contain(defaultSubject);
         episode.Subjects.Should().Contain(invisibleSubjectName);
+        episode.Matches.Should().ContainSingle(m =>
+            m.Subject == defaultSubject && m.Source == SubjectMatchSource.PodcastDefault);
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "When episode already has subjects covering matcher results (including invisible), enrich adds nothing.")]
     public async Task EnrichSubjects_WithExistingAndInvisibleMatchesEquallingPrematched_AddsDefaultSubject()
     {
-        // arrange
+        // Arrange
         var invisibleSubjectName = "_invisible";
-        var existing = "existing";
+        var existing = _fixture.Create<string>();
         var episode = _fixture.Build<Episode>().With(x => x.Subjects, [existing, invisibleSubjectName]).Create();
         var options = _fixture.Create<SubjectEnrichmentOptions>();
         var invisibleSubject = new Subject(invisibleSubjectName);
@@ -87,44 +98,53 @@ public class SubjectEnricherTests
         var existingSubjectMatch = new SubjectMatch(new Subject(existing), [new MatchResult(existing, 1)]);
         _subjectMatches = [invisibleSubjectMatch, existingSubjectMatch];
         var sut = _mocker.CreateInstance<SubjectEnricher>();
-        // act
+
+        // Act
         var result = await sut.EnrichSubjects(episode, options);
-        // assert
+
+        // Assert
         result.Additions.Should().HaveCount(0);
         result.Removals.Should().HaveCount(0);
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "When enrich finds subject matches, those subject names are returned as additions.")]
     public async Task EnrichSubjects_WithMatches_AddsMatchedSubjects()
     {
-        // arrange
+        // Arrange
         var episode = _fixture.Create<Episode>();
         var options = _fixture.Create<SubjectEnrichmentOptions>();
         var sut = _mocker.CreateInstance<SubjectEnricher>();
-        // act
+
+        // Act
         var result = await sut.EnrichSubjects(episode, options);
-        // assert
+
+        // Assert
         result.Additions.Should().BeEquivalentTo(_subjectMatches.Select(x => x.Subject.Name));
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "When a matched subject is also the podcast default, enrich lists the default subject first among additions.")]
     public async Task EnrichSubjects_WithMatchesAndDefaultSubject_AddsDefaultSubjectFirst()
     {
-        // arrange
+        // Arrange
         var episode = _fixture.Create<Episode>();
         var options = _fixture.Build<SubjectEnrichmentOptions>()
             .With(x => x.DefaultSubject, _subjectMatches.First().Subject.Name).Create();
         var sut = _mocker.CreateInstance<SubjectEnricher>();
-        // act
+
+        // Act
         var result = await sut.EnrichSubjects(episode, options);
-        // assert
+
+        // Assert
         result.Additions.Should().StartWith(options.DefaultSubject);
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "When the user removed a subject, enrich does not re-add that subject from matcher results.")]
     public async Task EnrichSubjects_DoesNotReAddUserRemovedSubject()
     {
-        // arrange
+        // Arrange
         var removedSubject = _subjectMatches.First().Subject.Name;
         var episode = _fixture.Build<Episode>()
             .With(x => x.Subjects, [])
@@ -133,19 +153,20 @@ public class SubjectEnricherTests
         var options = _fixture.Create<SubjectEnrichmentOptions>();
         var sut = _mocker.CreateInstance<SubjectEnricher>();
 
-        // act
+        // Act
         var result = await sut.EnrichSubjects(episode, options);
 
-        // assert
+        // Assert
         result.Additions.Should().NotContain(removedSubject);
         episode.Subjects.Should().NotContain(removedSubject);
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "When the user removed the podcast default subject, enrich does not apply that default.")]
     public async Task EnrichSubjects_DoesNotApplyDefaultSubjectWhenUserRemovedIt()
     {
-        // arrange
-        var defaultSubject = "Cults";
+        // Arrange
+        var defaultSubject = _fixture.Create<string>();
         var episode = _fixture.Build<Episode>()
             .With(x => x.Subjects, [])
             .With(x => x.RemovedSubjects, [defaultSubject])
@@ -156,47 +177,51 @@ public class SubjectEnricherTests
         _subjectMatches = [];
         var sut = _mocker.CreateInstance<SubjectEnricher>();
 
-        // act
+        // Act
         var result = await sut.EnrichSubjects(episode, options);
 
-        // assert
+        // Assert
         result.Additions.Should().BeEmpty();
         episode.Subjects.Should().BeEmpty();
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "When matcher returns title and description evidence, enrich populates episode matches from that evidence.")]
     public async Task EnrichSubjects_PopulatesMatchesForMatchedSubjects()
     {
-        // arrange
+        // Arrange
+        var subjectName = _fixture.Create<string>();
+        var term = _fixture.Create<string>();
         var episode = _fixture.Create<Episode>();
         var options = _fixture.Create<SubjectEnrichmentOptions>();
         _subjectMatches =
         [
             new SubjectMatch(
-                new Subject("Cults"),
+                new Subject(subjectName),
                 [
-                    new MatchResult("cult", 1, SubjectMatchSource.Title),
-                    new MatchResult("cult", 1, SubjectMatchSource.Description)
+                    new MatchResult(term, 1, SubjectMatchSource.Title),
+                    new MatchResult(term, 1, SubjectMatchSource.Description)
                 ])
         ];
         var sut = _mocker.CreateInstance<SubjectEnricher>();
 
-        // act
+        // Act
         await sut.EnrichSubjects(episode, options);
 
-        // assert
+        // Assert
         episode.Matches.Should().HaveCount(2);
         episode.Matches.Should().Contain(m =>
-            m.Subject == "Cults" && m.Term == "cult" && m.Source == SubjectMatchSource.Title);
+            m.Subject == subjectName && m.Term == term && m.Source == SubjectMatchSource.Title);
         episode.Matches.Should().Contain(m =>
-            m.Subject == "Cults" && m.Term == "cult" && m.Source == SubjectMatchSource.Description);
+            m.Subject == subjectName && m.Term == term && m.Source == SubjectMatchSource.Description);
     }
 
-    [Fact]
-    public async Task EnrichSubjects_OmitsDefaultSubjectWithoutMatchEvidence()
+    [Fact(DisplayName =
+        "When enrich applies the podcast default subject with no title/description hits, matches records PodcastDefault provenance.")]
+    public async Task EnrichSubjects_RecordsPodcastDefaultMatchForDefaultSubject()
     {
-        // arrange
-        var defaultSubject = "Cults";
+        // Arrange
+        var defaultSubject = _fixture.Create<string>();
         var episode = _fixture.Create<Episode>();
         var options = _fixture.Build<SubjectEnrichmentOptions>()
             .With(x => x.DefaultSubject, defaultSubject)
@@ -204,19 +229,24 @@ public class SubjectEnricherTests
         _subjectMatches = [];
         var sut = _mocker.CreateInstance<SubjectEnricher>();
 
-        // act
+        // Act
         await sut.EnrichSubjects(episode, options);
 
-        // assert
+        // Assert
         episode.Subjects.Should().Contain(defaultSubject);
-        episode.Matches.Should().BeEmpty();
+        episode.Matches.Should().ContainSingle(m =>
+            m.Subject == defaultSubject &&
+            m.Term == string.Empty &&
+            m.Source == SubjectMatchSource.PodcastDefault);
     }
 
-    [Fact]
+    [Fact(DisplayName =
+        "When the user removed a subject, enrich does not populate match evidence for that subject.")]
     public async Task EnrichSubjects_DoesNotPopulateMatchesForUserRemovedSubject()
     {
-        // arrange
-        var removedSubject = "Cults";
+        // Arrange
+        var removedSubject = _fixture.Create<string>();
+        var term = _fixture.Create<string>();
         var episode = _fixture.Build<Episode>()
             .With(x => x.Subjects, [])
             .With(x => x.RemovedSubjects, [removedSubject])
@@ -226,17 +256,17 @@ public class SubjectEnricherTests
         {
             new(
                 new Subject(removedSubject),
-                [new MatchResult("cult", 1, SubjectMatchSource.Title)])
+                [new MatchResult(term, 1, SubjectMatchSource.Title)])
         };
         _mocker.GetMock<ISubjectMatcher>()
             .Setup(x => x.MatchSubjects(It.IsAny<Episode>(), It.IsAny<SubjectEnrichmentOptions?>()))
             .ReturnsAsync(subjectMatches);
         var sut = _mocker.CreateInstance<SubjectEnricher>();
 
-        // act
+        // Act
         await sut.EnrichSubjects(episode, options);
 
-        // assert
+        // Assert
         episode.Matches.Should().NotContain(m =>
             m.Subject.Equals(removedSubject, StringComparison.OrdinalIgnoreCase));
         episode.Subjects.Should().NotContain(removedSubject);

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Enrichers/SubjectEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Enrichers/SubjectEnricher.cs
@@ -98,12 +98,15 @@ public class SubjectEnricher(
                 options.DefaultSubject, episode.Title, episode.Id);
         }
 
-        SyncSubjectMatches(episode, subjectMatches);
+        SyncSubjectMatches(episode, subjectMatches, options?.DefaultSubject);
 
         return new EnrichSubjectsResult(additions.Select(x => x.Subject.Name).ToArray(), removals.ToArray());
     }
 
-    private static void SyncSubjectMatches(Episode episode, IList<SubjectMatch> subjectMatches)
+    private static void SyncSubjectMatches(
+        Episode episode,
+        IList<SubjectMatch> subjectMatches,
+        string? defaultSubject)
     {
         episode.Matches.RemoveAll(m => episode.IsSubjectRemovedByUser(m.Subject));
 
@@ -135,6 +138,46 @@ public class SubjectEnricher(
                 });
             }
         }
+
+        SyncPodcastDefaultMatch(episode, defaultSubject);
+    }
+
+    /// <summary>
+    /// When the podcast default subject is on the episode without title/description evidence,
+    /// record a <see cref="SubjectMatchSource.PodcastDefault"/> match so provenance is visible.
+    /// </summary>
+    private static void SyncPodcastDefaultMatch(Episode episode, string? defaultSubject)
+    {
+        episode.Matches.RemoveAll(m =>
+            m.Source == SubjectMatchSource.PodcastDefault &&
+            !episode.Subjects.Contains(m.Subject, StringComparer.OrdinalIgnoreCase));
+
+        if (string.IsNullOrWhiteSpace(defaultSubject) ||
+            episode.IsSubjectRemovedByUser(defaultSubject) ||
+            !episode.Subjects.Contains(defaultSubject, StringComparer.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var hasTermEvidence = episode.Matches.Any(m =>
+            m.Subject.Equals(defaultSubject, StringComparison.OrdinalIgnoreCase) &&
+            (m.Source == SubjectMatchSource.Title || m.Source == SubjectMatchSource.Description));
+
+        episode.Matches.RemoveAll(m =>
+            m.Subject.Equals(defaultSubject, StringComparison.OrdinalIgnoreCase) &&
+            m.Source == SubjectMatchSource.PodcastDefault);
+
+        if (hasTermEvidence)
+        {
+            return;
+        }
+
+        episode.Matches.Add(new EpisodeSubjectMatch
+        {
+            Subject = defaultSubject,
+            Term = string.Empty,
+            Source = SubjectMatchSource.PodcastDefault
+        });
     }
 
     private (IList<SubjectMatch>, IList<string>) CompareSubjects(


### PR DESCRIPTION
## Summary
- Add `SubjectMatchSource.PodcastDefault` for subjects applied from a podcast's `DefaultSubject`.
- When enrich applies the default with no title/description term hits, write a `matches` row with `source: PodcastDefault` (empty term).
- If the default subject also has term evidence, keep Title/Description rows only.

## Test plan
- [ ] `dotnet test` on `RedditPodcastPoster.Subjects.Tests` (SubjectEnricherTests)
- [ ] Accept/enrich an episode on a podcast with `DefaultSubject` and no term hit → `matches` includes `PodcastDefault`
- [ ] Subject with title/description hits still records `Title`/`Description` only

Made with [Cursor](https://cursor.com)