### PR TITLE
feat(social): short-URL-only X/Bluesky posts when shortener KV has share image

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Factories/BlueskyEmbedCardPostFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Factories/BlueskyEmbedCardPostFactory.cs
@@ -104,7 +104,12 @@ public class BlueskyEmbedCardPostFactory(
             postBuilder.AppendLine($"{shortUrl}");
         }
 
-        var permittedTitleLength = 300 - (postBuilder.Length + (includeShortInText ? 26 : 0));
+        // Short URL is already in postBuilder when includeShortInText. Extra 26 was for dual-link
+        // budgeting; share-image posts are short-only so skip it and allow a longer title.
+        var reserveSecondUrlBudget = !hasShareImage
+            && _blueskyOptions.WithEpisodeUrl
+            && (podcastEpisode.HasMultipleServices() || podcastEpisode.Episode.Subjects.Any());
+        var permittedTitleLength = 300 - (postBuilder.Length + (reserveSecondUrlBudget ? 26 : 0));
 
         if (episodeTitle.Length > permittedTitleLength)
         {

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Factories/BlueskyEmbedCardPostFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Factories/BlueskyEmbedCardPostFactory.cs
@@ -33,7 +33,7 @@ public class BlueskyEmbedCardPostFactory(
     public const string? ReleaseFormat = "d MMM yyyy";
     private readonly BlueskyOptions _blueskyOptions = blueskyOptions.Value;
 
-    public async Task<BlueskyEmbedCardPost> Create(PodcastEpisode podcastEpisode, Uri? shortUrl)
+    public async Task<BlueskyEmbedCardPost> Create(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false)
     {
         var postModel = postModelFactory.ToPostModel((podcastEpisode.Podcast, [podcastEpisode.Episode]));
         var episodeTitle = await textSanitiser.SanitiseTitle(postModel);
@@ -96,15 +96,15 @@ public class BlueskyEmbedCardPostFactory(
             postBuilder.AppendLine(endHashTags);
         }
 
-        if (shortUrl != null &&
-            _blueskyOptions.WithEpisodeUrl &&
-            (podcastEpisode.HasMultipleServices() ||
-             podcastEpisode.Episode.Subjects.Any()))
+        var includeShortInText = hasShareImage
+            || (_blueskyOptions.WithEpisodeUrl &&
+                (podcastEpisode.HasMultipleServices() || podcastEpisode.Episode.Subjects.Any()));
+        if (shortUrl != null && includeShortInText)
         {
             postBuilder.AppendLine($"{shortUrl}");
         }
 
-        var permittedTitleLength = 300 - (postBuilder.Length + (_blueskyOptions.WithEpisodeUrl ? 26 : 0));
+        var permittedTitleLength = 300 - (postBuilder.Length + (includeShortInText ? 26 : 0));
 
         if (episodeTitle.Length > permittedTitleLength)
         {
@@ -149,7 +149,13 @@ public class BlueskyEmbedCardPostFactory(
         else
         {
             throw new InvalidOperationException(
-                $"No url for podcast-id '${podcastEpisode.Podcast.Id}' and episode-id '${podcastEpisode.Episode.Images}'.");
+                $"No url for podcast-id '${podcastEpisode.Podcast.Id}' and episode-id '${podcastEpisode.Episode.Id}'.");
+        }
+
+        // Share-image shorts: card opens s.cultpodcasts.com; UrlService still drives thumb fetch.
+        if (hasShareImage && shortUrl != null)
+        {
+            url = shortUrl;
         }
 
         var tweet = postBuilder.ToString();

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Factories/IBlueskyEmbedCardPostFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Factories/IBlueskyEmbedCardPostFactory.cs
@@ -5,5 +5,5 @@ namespace RedditPodcastPoster.Bluesky.Factories;
 
 public interface IBlueskyEmbedCardPostFactory
 {
-    Task<BlueskyEmbedCardPost> Create(PodcastEpisode podcastEpisode, Uri? shortUrl);
+    Task<BlueskyEmbedCardPost> Create(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false);
 }

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Managers/BlueskyPostManager.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Managers/BlueskyPostManager.cs
@@ -80,7 +80,7 @@ public class BlueskyPostManager(
                     logger.LogInformation("Bluesky Post init.");
                     try
                     {
-                        var status = await poster.Post(podcastEpisode, shortnerResult.Url);
+                        var status = await poster.Post(podcastEpisode, shortnerResult.Url, shortnerResult.HasShareImage);
                         logger.LogInformation("Bluesky Post complete. Bluesky-post-status: '{status}'.", status);
                         var posted = status == BlueskySendStatus.Success;
 

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Posters/BlueskyPoster.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Posters/BlueskyPoster.cs
@@ -17,9 +17,9 @@ public class BlueskyPoster(
     ILogger<BlueskyPoster> logger)
     : IBlueskyPoster
 {
-    public async Task<BlueskySendStatus> Post(PodcastEpisode podcastEpisode, Uri? shortUrl)
+    public async Task<BlueskySendStatus> Post(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false)
     {
-        var embedPost = await embedCardPostFactory.Create(podcastEpisode, shortUrl);
+        var embedPost = await embedCardPostFactory.Create(podcastEpisode, shortUrl, hasShareImage);
         BlueskySendStatus sendStatus;
         var embedCardRequest = await embedCardRequestFactory.CreateEmbedCardRequest(podcastEpisode, embedPost);
         var language = string.IsNullOrWhiteSpace(podcastEpisode.Episode.Language)

--- a/Class-Libraries/RedditPodcastPoster.Bluesky/Posters/IBlueskyPoster.cs
+++ b/Class-Libraries/RedditPodcastPoster.Bluesky/Posters/IBlueskyPoster.cs
@@ -5,5 +5,5 @@ namespace RedditPodcastPoster.Bluesky.Posters;
 
 public interface IBlueskyPoster
 {
-    Task<BlueskySendStatus> Post(PodcastEpisode podcastEpisode, Uri? shortUrl);
+    Task<BlueskySendStatus> Post(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false);
 }

--- a/Class-Libraries/RedditPodcastPoster.Cloudflare/Models/MetaData.cs
+++ b/Class-Libraries/RedditPodcastPoster.Cloudflare/Models/MetaData.cs
@@ -12,4 +12,22 @@ public class MetaData
 
     [JsonPropertyName("duration")]
     public required TimeSpan Duration { get; set; }
+
+    /// <summary>
+    /// Search-index image encoding (y{q} / s{id} / a{n}{path} / full URL).
+    /// Only set on new shortener KV writes from now on; existing records are left unchanged.
+    /// </summary>
+    [JsonPropertyName("image")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Image { get; set; }
+
+    /// <summary>Required to expand YouTube <c>y{q}</c> tokens for og:image.</summary>
+    [JsonPropertyName("youtubeId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? YoutubeId { get; set; }
+
+    /// <summary><c>wide</c> or <c>square</c> for twitter:card selection.</summary>
+    [JsonPropertyName("imageAspect")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ImageAspect { get; set; }
 }

--- a/Class-Libraries/RedditPodcastPoster.Cloudflare/Models/WriteResult.cs
+++ b/Class-Libraries/RedditPodcastPoster.Cloudflare/Models/WriteResult.cs
@@ -1,3 +1,3 @@
 namespace RedditPodcastPoster.Cloudflare.Models;
 
-public record WriteResult(bool Success, Uri? Url = null);
+public record WriteResult(bool Success, Uri? Url = null, bool HasShareImage = false);

--- a/Class-Libraries/RedditPodcastPoster.Twitter/Builders/ITweetBuilder.cs
+++ b/Class-Libraries/RedditPodcastPoster.Twitter/Builders/ITweetBuilder.cs
@@ -4,5 +4,5 @@ namespace RedditPodcastPoster.Twitter.Builders;
 
 public interface ITweetBuilder
 {
-    Task<string> BuildTweet(PodcastEpisode podcastEpisode, Uri? shortUrl);
+    Task<string> BuildTweet(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false);
 }

--- a/Class-Libraries/RedditPodcastPoster.Twitter/Builders/TweetBuilder.cs
+++ b/Class-Libraries/RedditPodcastPoster.Twitter/Builders/TweetBuilder.cs
@@ -96,10 +96,12 @@ public class TweetBuilder(
             tweetBuilder.AppendLine(endHashTags);
         }
 
-        var reserveShortUrl = hasShareImage
-            || (_twitterOptions.WithEpisodeUrl &&
-                (podcastEpisode.HasMultipleServices() || podcastEpisode.Episode.Subjects.Any()));
-        var permittedTitleLength = 257 - (tweetBuilder.Length + (reserveShortUrl ? 26 : 0));
+        // 257 already budgets one t.co URL. Extra 26 only when a second (short) URL will also be appended.
+        // Share-image posts are short-URL-only — no second-URL reserve, so the title can be longer.
+        var reserveSecondUrl = !hasShareImage
+            && _twitterOptions.WithEpisodeUrl
+            && (podcastEpisode.HasMultipleServices() || podcastEpisode.Episode.Subjects.Any());
+        var permittedTitleLength = 257 - (tweetBuilder.Length + (reserveSecondUrl ? 26 : 0));
 
         if (episodeTitle.Length > permittedTitleLength)
         {

--- a/Class-Libraries/RedditPodcastPoster.Twitter/Builders/TweetBuilder.cs
+++ b/Class-Libraries/RedditPodcastPoster.Twitter/Builders/TweetBuilder.cs
@@ -33,7 +33,7 @@ public class TweetBuilder(
     public const string? ReleaseFormat = "d MMM yyyy";
     private readonly TwitterOptions _twitterOptions = twitterOptions.Value;
 
-    public async Task<string> BuildTweet(PodcastEpisode podcastEpisode, Uri? shortUrl)
+    public async Task<string> BuildTweet(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false)
     {
         var postModel = postModelFactory.ToPostModel((podcastEpisode.Podcast, [podcastEpisode.Episode]));
         var episodeTitle = await textSanitiser.SanitiseTitle(postModel);
@@ -96,7 +96,10 @@ public class TweetBuilder(
             tweetBuilder.AppendLine(endHashTags);
         }
 
-        var permittedTitleLength = 257 - (tweetBuilder.Length + (_twitterOptions.WithEpisodeUrl ? 26 : 0));
+        var reserveShortUrl = hasShareImage
+            || (_twitterOptions.WithEpisodeUrl &&
+                (podcastEpisode.HasMultipleServices() || podcastEpisode.Episode.Subjects.Any()));
+        var permittedTitleLength = 257 - (tweetBuilder.Length + (reserveShortUrl ? 26 : 0));
 
         if (episodeTitle.Length > permittedTitleLength)
         {
@@ -107,10 +110,17 @@ public class TweetBuilder(
                     $"Unable to form tweet body from '\"{episodeTitle}\"{Environment.NewLine}{tweetBuilder}', calculated title-length: {min} which is less than {MinTitleLength}.");
             }
 
-            episodeTitle = episodeTitle[..min] + "ΓÇª";
+            episodeTitle = episodeTitle[..min] + "…";
         }
 
         tweetBuilder.Insert(0, $"\"{episodeTitle}\"{Environment.NewLine}");
+
+        if (hasShareImage && shortUrl != null)
+        {
+            tweetBuilder.Append(shortUrl);
+            return tweetBuilder.ToString();
+        }
+
         if (podcastEpisode.Episode.Urls.YouTube != null)
         {
             tweetBuilder.Append(podcastEpisode.Episode.Urls.YouTube);
@@ -135,14 +145,13 @@ public class TweetBuilder(
         {
             throw new InvalidOperationException("No link found to tweet");
         }
+
         if (shortUrl != null && _twitterOptions.WithEpisodeUrl && (podcastEpisode.HasMultipleServices() ||
                                                            podcastEpisode.Episode.Subjects.Any()))
         {
             tweetBuilder.Append($"{Environment.NewLine}{shortUrl}");
         }
 
-
-        var tweet = tweetBuilder.ToString();
-        return tweet;
+        return tweetBuilder.ToString();
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Twitter/Posters/ITweetPoster.cs
+++ b/Class-Libraries/RedditPodcastPoster.Twitter/Posters/ITweetPoster.cs
@@ -5,5 +5,5 @@ namespace RedditPodcastPoster.Twitter.Posters;
 
 public interface ITweetPoster
 {
-    Task<PostTweetResponse> PostTweet(PodcastEpisode podcastEpisode, Uri? shortUrl);
+    Task<PostTweetResponse> PostTweet(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false);
 }

--- a/Class-Libraries/RedditPodcastPoster.Twitter/Posters/TweetPoster.cs
+++ b/Class-Libraries/RedditPodcastPoster.Twitter/Posters/TweetPoster.cs
@@ -15,9 +15,9 @@ public class TweetPoster(
     ILogger<TweetPoster> logger)
     : ITweetPoster
 {
-    public async Task<PostTweetResponse> PostTweet(PodcastEpisode podcastEpisode, Uri? shortUrl)
+    public async Task<PostTweetResponse> PostTweet(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false)
     {
-        var tweet = await tweetBuilder.BuildTweet(podcastEpisode, shortUrl);
+        var tweet = await tweetBuilder.BuildTweet(podcastEpisode, shortUrl, hasShareImage);
         PostTweetResponse tweetStatus;
         try
         {

--- a/Class-Libraries/RedditPodcastPoster.Twitter/Posters/Tweeter.cs
+++ b/Class-Libraries/RedditPodcastPoster.Twitter/Posters/Tweeter.cs
@@ -55,7 +55,7 @@ public class Tweeter(
                         logger.LogError("Unsuccessful shortening-url.");
                     }
 
-                    var tweetStatus = await tweetPoster.PostTweet(podcastEpisode, shortnerResult.Url);
+                    var tweetStatus = await tweetPoster.PostTweet(podcastEpisode, shortnerResult.Url, shortnerResult.HasShareImage);
                     tweeted = tweetStatus.TweetSendStatus == TweetSendStatus.Sent;
                     tooManyRequests = tweetStatus.TweetSendStatus == TweetSendStatus.TooManyRequests;
                 }

--- a/Class-Libraries/RedditPodcastPoster.UrlShortening/Services/ShortnerService.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlShortening/Services/ShortnerService.cs
@@ -27,58 +27,63 @@ public class ShortnerService(
     public async Task<WriteResult> Write(IEnumerable<PodcastEpisode> podcastEpisodes)
     {
         logger.LogInformation("{WriteName}. Writing to KV. Bulk write: {Count} episodes.", nameof(Write), podcastEpisodes.Count());
-        var items = podcastEpisodes.Select(x =>
-            new ShortUrlRecord(
-                x.Podcast.PodcastNameInSafeUrlForm(),
-                x.Episode.Id,
-                x.Episode.Id.ToBase64(),
-                x.Episode.Title,
-                DateOnly.FromDateTime(x.Episode.Release),
-                x.Episode.Length));
-        var kvRecords = items.Select(item => new KVRecord
+        var toWrite = new List<KVRecord>();
+        foreach (var podcastEpisode in podcastEpisodes)
         {
-            Key = item.Base64EpisodeKey,
-            Value = $"{item.PodcastName}/{item.EpisodeId}",
-            Metadata = new MetaData
-            { EpisodeTitle = item.EpisodeTitle, ReleaseDate = item.ReleaseDate, Duration = item.Duration }
-        }).ToArray();
-        return await kvClient.Write(kvRecords, _shortnerOptions.KVShortnerNamespaceId);
+            var key = podcastEpisode.Episode.Id.ToBase64();
+            var existing = await kvClient.ReadWithMetaData(key, _shortnerOptions.KVShortnerNamespaceId);
+            if (existing != null)
+            {
+                logger.LogInformation(
+                    "{WriteName}. Skipping existing shortner key '{Key}' (leave alone).", nameof(Write), key);
+                continue;
+            }
+
+            toWrite.Add(CreateRecord(podcastEpisode));
+        }
+
+        if (toWrite.Count == 0)
+        {
+            return new WriteResult(true);
+        }
+
+        return await kvClient.Write(toWrite, _shortnerOptions.KVShortnerNamespaceId);
     }
 
     public async Task<WriteResult> Write(PodcastEpisode podcastEpisode, bool isDryRun = false)
     {
         logger.LogInformation(
             "{WriteName}. Writing to KV. Individual write. Episode-id '{EpisodeId}'.", nameof(Write), podcastEpisode.Episode.Id);
-        var item = new ShortUrlRecord(
-            podcastEpisode.Podcast.PodcastNameInSafeUrlForm(),
-            podcastEpisode.Episode.Id,
-            podcastEpisode.Episode.Id.ToBase64(),
-            podcastEpisode.Episode.Title,
-            DateOnly.FromDateTime(podcastEpisode.Episode.Release),
-            podcastEpisode.Episode.Length);
-        var kvRecord = new KVRecord
+        var key = podcastEpisode.Episode.Id.ToBase64();
+        var shortUrl = new Uri($"{_shortnerOptions.ShortnerUrl}{key}");
+
+        if (!isDryRun)
         {
-            Key = item.Base64EpisodeKey,
-            Value = $"{item.PodcastName}/{item.EpisodeId}",
-            Metadata = new MetaData { 
-                EpisodeTitle = item.EpisodeTitle, 
-                ReleaseDate = item.ReleaseDate, 
-                Duration = item.Duration 
+            var existing = await kvClient.ReadWithMetaData(key, _shortnerOptions.KVShortnerNamespaceId);
+            if (existing != null)
+            {
+                logger.LogInformation(
+                    "{WriteName}. Shortner key '{Key}' already exists; leaving unchanged.", nameof(Write), key);
+                var hasShareImage = !string.IsNullOrEmpty(existing.Metadata?.Image);
+                return new WriteResult(true, shortUrl, hasShareImage);
             }
-        };
+        }
+
+        var kvRecord = CreateRecord(podcastEpisode);
+        var newHasShareImage = !string.IsNullOrEmpty(kvRecord.Metadata?.Image);
 
         if (!isDryRun)
         {
             var result = await kvClient.Write(kvRecord, _shortnerOptions.KVShortnerNamespaceId);
             if (result.Success)
             {
-                var url = new Uri($"{_shortnerOptions.ShortnerUrl}{podcastEpisode.Episode.Id.ToBase64()}");
-                result = result with { Url = url };
+                result = result with { Url = shortUrl, HasShareImage = newHasShareImage };
             }
             return result;
         }
-        logger.LogInformation(JsonSerializer.Serialize(kvRecord));
-        return new WriteResult(true);
+
+        logger.LogInformation(JsonSerializer.Serialize(kvRecord, JsonSerializerOptions));
+        return new WriteResult(true, shortUrl, newHasShareImage);
     }
 
     public async Task<KVRecord?> Read(string requestKey)
@@ -93,6 +98,30 @@ public class ShortnerService(
 
     public async Task<DeleteResult> Delete(IEnumerable<PodcastEpisode> podcastEpisodes)
     {
-        return await kvClient.Delete(podcastEpisodes.Select(x=>x.Episode.Id.ToBase64()), _shortnerOptions.KVShortnerNamespaceId);
+        return await kvClient.Delete(podcastEpisodes.Select(x => x.Episode.Id.ToBase64()), _shortnerOptions.KVShortnerNamespaceId);
+    }
+
+    private static KVRecord CreateRecord(PodcastEpisode podcastEpisode)
+    {
+        var item = new ShortUrlRecord(
+            podcastEpisode.Podcast.PodcastNameInSafeUrlForm(),
+            podcastEpisode.Episode.Id,
+            podcastEpisode.Episode.Id.ToBase64(),
+            podcastEpisode.Episode.Title,
+            DateOnly.FromDateTime(podcastEpisode.Episode.Release),
+            podcastEpisode.Episode.Length);
+        var metadata = new MetaData
+        {
+            EpisodeTitle = item.EpisodeTitle,
+            ReleaseDate = item.ReleaseDate,
+            Duration = item.Duration
+        };
+        ShortnerShareImageMetadata.Apply(metadata, podcastEpisode.Episode);
+        return new KVRecord
+        {
+            Key = item.Base64EpisodeKey,
+            Value = $"{item.PodcastName}/{item.EpisodeId}",
+            Metadata = metadata
+        };
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.UrlShortening/Services/ShortnerShareImageMetadata.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlShortening/Services/ShortnerShareImageMetadata.cs
@@ -1,0 +1,201 @@
+using RedditPodcastPoster.Cloudflare.Models;
+using RedditPodcastPoster.Models.Episodes;
+
+namespace RedditPodcastPoster.UrlShortening.Services;
+
+/// <summary>
+/// Builds optional share-image fields for new shortener KV metadata
+/// (search-index encoding + twitter card aspect). Compaction mirrors
+/// <c>SearchEpisodeImage</c> / website <c>expandImage</c>.
+/// </summary>
+public static class ShortnerShareImageMetadata
+{
+    public const string AspectWide = "wide";
+    public const string AspectSquare = "square";
+
+    private const string YouTubePrefix = "https://i.ytimg.com/vi/";
+    private const string SpotifyPrefix = "https://i.scdn.co/image/";
+    private const string AppleScheme = "https://is";
+    private const string AppleHostTail = "-ssl.mzstatic.com/image/thumb/";
+
+    private static readonly (string FileName, char Code)[] YouTubeQualities =
+    [
+        ("maxresdefault.jpg", 'x'),
+        ("sddefault.jpg", 's'),
+        ("hqdefault.jpg", 'h'),
+        ("mqdefault.jpg", 'm'),
+        ("default.jpg", 'd')
+    ];
+
+    public static void Apply(MetaData metadata, Episode episode)
+    {
+        var youTubeId = string.IsNullOrWhiteSpace(episode.YouTubeId) ? null : episode.YouTubeId;
+        var image = CompactFromEpisode(episode.Images, youTubeId);
+        if (string.IsNullOrEmpty(image))
+        {
+            return;
+        }
+
+        metadata.Image = image;
+        metadata.YoutubeId = youTubeId;
+        metadata.ImageAspect = ResolveAspect(episode, image, youTubeId);
+    }
+
+    public static string ResolveAspect(Episode episode, string imageTokenOrUrl, string? youTubeId)
+    {
+        if (IsYouTubeThumb(imageTokenOrUrl) || !string.IsNullOrWhiteSpace(youTubeId))
+        {
+            return AspectWide;
+        }
+
+        if (IsBbcIplayer(episode.Urls.BBC) || episode.Urls.InternetArchive is not null)
+        {
+            return AspectWide;
+        }
+
+        return AspectSquare;
+    }
+
+    /// <summary>Same selection as SearchEpisodeImage.From: youtube ?? spotify ?? apple ?? other, then compact.</summary>
+    private static string? CompactFromEpisode(EpisodeImages? images, string? youTubeId)
+    {
+        var selected = images?.YouTube ?? images?.Spotify ?? images?.Apple ?? images?.Other;
+        if (selected is null)
+        {
+            return null;
+        }
+
+        var url = selected.ToString();
+        return Compact(url, youTubeId) ?? url;
+    }
+
+    private static string? Compact(string url, string? youTubeId)
+    {
+        var token = TryYouTube(url, youTubeId) ?? TrySpotify(url) ?? TryApple(url);
+        return token is not null && Expand(token, youTubeId) == url ? token : null;
+    }
+
+    private static string Expand(string image, string? youTubeId)
+    {
+        if (string.IsNullOrEmpty(image) || image.StartsWith("http", StringComparison.Ordinal))
+        {
+            return image;
+        }
+
+        var payload = image[1..];
+        switch (image[0])
+        {
+            case 'y':
+                foreach (var (fileName, code) in YouTubeQualities)
+                {
+                    if (payload.Length == 1 && payload[0] == code && !string.IsNullOrWhiteSpace(youTubeId))
+                    {
+                        return $"{YouTubePrefix}{youTubeId}/{fileName}";
+                    }
+                }
+
+                return image;
+            case 's' when payload.Length > 0:
+                return $"{SpotifyPrefix}{payload}";
+            case 'a' when payload.Length >= 1:
+                return $"{AppleScheme}{payload[0]}{AppleHostTail}{payload[1..]}";
+            default:
+                return image;
+        }
+    }
+
+    private static string? TryYouTube(string url, string? youTubeId)
+    {
+        if (string.IsNullOrWhiteSpace(youTubeId))
+        {
+            return null;
+        }
+
+        var prefix = $"{YouTubePrefix}{youTubeId}/";
+        if (!url.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var fileName = url[prefix.Length..];
+        foreach (var (name, code) in YouTubeQualities)
+        {
+            if (fileName == name)
+            {
+                return $"y{code}";
+            }
+        }
+
+        return null;
+    }
+
+    private static string? TrySpotify(string url)
+    {
+        if (!url.StartsWith(SpotifyPrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var id = url[SpotifyPrefix.Length..];
+        if (id.Length == 0 || id.Contains('/') || id.Contains('?') || id.Contains('#'))
+        {
+            return null;
+        }
+
+        return $"s{id}";
+    }
+
+    private static string? TryApple(string url)
+    {
+        if (!url.StartsWith(AppleScheme, StringComparison.Ordinal) || url.Length <= AppleScheme.Length)
+        {
+            return null;
+        }
+
+        var digit = url[AppleScheme.Length];
+        if (digit is < '1' or > '5')
+        {
+            return null;
+        }
+
+        var afterDigit = url[(AppleScheme.Length + 1)..];
+        if (!afterDigit.StartsWith(AppleHostTail, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var path = afterDigit[AppleHostTail.Length..];
+        return $"a{digit}{path}";
+    }
+
+    private static bool IsYouTubeThumb(string image)
+    {
+        if (image.Length >= 2 && image[0] == 'y' && "xshmd".Contains(image[1]))
+        {
+            return true;
+        }
+
+        return Uri.TryCreate(image, UriKind.Absolute, out var url) &&
+               url.Host.Equals("i.ytimg.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsBbcIplayer(Uri? bbc)
+    {
+        if (bbc is null)
+        {
+            return false;
+        }
+
+        var host = bbc.Host;
+        var isBbc = host.EndsWith("bbc.com", StringComparison.OrdinalIgnoreCase) ||
+                    host.EndsWith("bbc.co.uk", StringComparison.OrdinalIgnoreCase);
+        if (!isBbc)
+        {
+            return false;
+        }
+
+        var path = bbc.AbsolutePath;
+        return path.StartsWith("/iplayer/", StringComparison.OrdinalIgnoreCase) ||
+               path.StartsWith("/news/av-embeds/", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Cloud/Api/Services/Episodes/EpisodePublishService.cs
+++ b/Cloud/Api/Services/Episodes/EpisodePublishService.cs
@@ -75,7 +75,7 @@ public class EpisodePublishService(
                 {
                     try
                     {
-                        var result = await tweetPoster.PostTweet(podcastEpisode, shortnerResult.Url);
+                        var result = await tweetPoster.PostTweet(podcastEpisode, shortnerResult.Url, shortnerResult.HasShareImage);
                         if (result.TweetSendStatus != TweetSendStatus.Sent)
                         {
                             logger.LogError("Tweet result: '{PostTweetResponse}'.", result);
@@ -100,7 +100,7 @@ public class EpisodePublishService(
                 {
                     try
                     {
-                        var result = await blueskyPoster.Post(podcastEpisode, shortnerResult.Url);
+                        var result = await blueskyPoster.Post(podcastEpisode, shortnerResult.Url, shortnerResult.HasShareImage);
                         if (result != BlueskySendStatus.Success)
                         {
                             logger.LogError("Bluesky-post result: '{result}'.", result);

--- a/Cloud/Unit-Tests/Indexer.Tests/BlueskyEmbedCardPostFactoryShortUrlOnlyTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/BlueskyEmbedCardPostFactoryShortUrlOnlyTests.cs
@@ -1,0 +1,153 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using RedditPodcastPoster.Bluesky.Configuration;
+using RedditPodcastPoster.Bluesky.Factories;
+using RedditPodcastPoster.Common.Factories;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.Models.Posting;
+using RedditPodcastPoster.People.Resolvers;
+using RedditPodcastPoster.Subjects.HashTags;
+using RedditPodcastPoster.Text.Enrichers;
+using RedditPodcastPoster.Text.Sanitisers;
+using Xunit;
+
+namespace Indexer.Tests;
+
+public class BlueskyEmbedCardPostFactoryShortUrlOnlyTests
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "When shortener KV has a share image, Bluesky embed URL is the short URL while UrlService stays YouTube for thumb fetch.")]
+    public async Task Has_share_image_embed_url_is_short_url_service_youtube()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast);
+        var podcastEpisode = new PodcastEpisode(podcast, episode);
+        var shortUrl = new Uri($"https://s.cultpodcasts.com/{_fixture.CreateGuid():N}");
+        var sut = CreateSut(withEpisodeUrl: false);
+
+        // Act
+        var post = await sut.Create(podcastEpisode, shortUrl, hasShareImage: true);
+
+        // Assert
+        post.Url.Should().Be(shortUrl);
+        post.UrlService.Should().Be(Service.YouTube);
+        post.Text.Should().Contain(shortUrl.ToString());
+        post.Text.Should().NotContain(episode.Urls.YouTube!.Host);
+    }
+
+    [Fact(DisplayName =
+        "When shortener KV has no share image, Bluesky embed URL remains the primary platform URL.")]
+    public async Task No_share_image_embed_url_is_platform()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast);
+        var podcastEpisode = new PodcastEpisode(podcast, episode);
+        var shortUrl = new Uri($"https://s.cultpodcasts.com/{_fixture.CreateGuid():N}");
+        var sut = CreateSut(withEpisodeUrl: false);
+
+        // Act
+        var post = await sut.Create(podcastEpisode, shortUrl, hasShareImage: false);
+
+        // Assert
+        post.Url.Should().Be(episode.Urls.YouTube);
+        post.UrlService.Should().Be(Service.YouTube);
+    }
+
+    [Fact(DisplayName =
+        "When shortener KV has a share image for a Spotify-primary episode, UrlService stays Spotify for thumb fetch.")]
+    public async Task Has_share_image_spotify_episode_keeps_spotify_url_service()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        var episode = _fixture.CreateStoredEpisodeWithSpotifyOnly(podcast);
+        var podcastEpisode = new PodcastEpisode(podcast, episode);
+        var shortUrl = new Uri($"https://s.cultpodcasts.com/{_fixture.CreateGuid():N}");
+        var sut = CreateSut(withEpisodeUrl: false);
+
+        // Act
+        var post = await sut.Create(podcastEpisode, shortUrl, hasShareImage: true);
+
+        // Assert
+        post.Url.Should().Be(shortUrl);
+        post.UrlService.Should().Be(Service.Spotify);
+    }
+
+    private BlueskyEmbedCardPostFactory CreateSut(bool withEpisodeUrl)
+    {
+        var textSanitiser = new Mock<ITextSanitiser>();
+        textSanitiser
+            .Setup(x => x.SanitiseTitle(It.IsAny<PostModel>()))
+            .ReturnsAsync((PostModel pm) => pm.EpisodeTitle);
+        textSanitiser
+            .Setup(x => x.SanitisePodcastName(It.IsAny<PostModel>()))
+            .Returns((PostModel pm) => pm.PodcastName);
+
+        var hashTagEnricher = new Mock<IHashTagEnricher>();
+        hashTagEnricher
+            .Setup(x => x.AddHashTag(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns((string input, string _, string? _) => (input, false));
+
+        var hashTagProvider = new Mock<IHashTagProvider>();
+        hashTagProvider
+            .Setup(x => x.GetHashTags(It.IsAny<List<string>>()))
+            .ReturnsAsync(new List<HashTag>());
+
+        var postModelFactory = new Mock<IPostModelFactory>();
+        postModelFactory
+            .Setup(x => x.ToPostModel(It.IsAny<(Podcast, IEnumerable<Episode>)>(), It.IsAny<bool>()))
+            .Returns((
+                (Podcast Podcast, IEnumerable<Episode> Episodes) pe,
+                bool _) => new PostModel(
+                pe.Podcast.Name,
+                string.Empty,
+                string.Empty,
+                pe.Episodes.Select(e => new EpisodePost(
+                    e.Title,
+                    e.Urls.YouTube,
+                    e.Urls.Spotify,
+                    e.Urls.Apple,
+                    e.Release.ToString("d MMM yyyy"),
+                    e.Length.ToString(@"\[h\:mm\:ss\]"),
+                    e.Description,
+                    e.Id.ToString(),
+                    e.Release,
+                    e.Subjects.ToArray(),
+                    e.Urls.BBC,
+                    e.Urls.InternetArchive)),
+                null,
+                [],
+                []));
+
+        var personGuestHandleResolver = new Mock<IPersonGuestHandleResolver>();
+        personGuestHandleResolver
+            .Setup(x => x.Resolve(It.IsAny<Episode>()))
+            .ReturnsAsync((Array.Empty<string>(), Array.Empty<string>()));
+
+        var options = Options.Create(new BlueskyOptions
+        {
+            Identifier = "id",
+            Password = "pw",
+            WithEpisodeUrl = withEpisodeUrl,
+            ReuseSession = false,
+            MaxFailures = 1,
+            MaxPosts = 1
+        });
+
+        return new BlueskyEmbedCardPostFactory(
+            textSanitiser.Object,
+            hashTagEnricher.Object,
+            hashTagProvider.Object,
+            postModelFactory.Object,
+            personGuestHandleResolver.Object,
+            options,
+            Mock.Of<ILogger<IBlueskyEmbedCardPostFactory>>());
+    }
+}

--- a/Cloud/Unit-Tests/Indexer.Tests/BlueskyEmbedCardPostFactoryShortUrlOnlyTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/BlueskyEmbedCardPostFactoryShortUrlOnlyTests.cs
@@ -80,6 +80,34 @@ public class BlueskyEmbedCardPostFactoryShortUrlOnlyTests
         post.UrlService.Should().Be(Service.Spotify);
     }
 
+    [Fact(DisplayName =
+        "When shortener KV has a share image, the Bluesky title can be longer because only one URL is in the post text.")]
+    public async Task Has_share_image_allows_longer_bluesky_title_than_dual_url_budget()
+    {
+        // Arrange — length literal is the truncation boundary under test
+        var longTitle = new string('x', 280);
+        var podcast = _fixture.CreatePodcast(p => p.Name = "Show");
+        var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast, title: longTitle);
+        episode.Subjects = ["Subject"];
+        var podcastEpisode = new PodcastEpisode(podcast, episode);
+        var shortUrl = new Uri($"https://s.cultpodcasts.com/{_fixture.CreateGuid():N}");
+        var sut = CreateSut(withEpisodeUrl: true);
+
+        // Act
+        var shortOnly = await sut.Create(podcastEpisode, shortUrl, hasShareImage: true);
+        var withSecondUrlBudget = await sut.Create(podcastEpisode, shortUrl, hasShareImage: false);
+
+        // Assert
+        QuotedTitleLength(shortOnly.Text).Should().BeGreaterThan(QuotedTitleLength(withSecondUrlBudget.Text));
+    }
+
+    private static int QuotedTitleLength(string post)
+    {
+        var start = post.IndexOf('"') + 1;
+        var end = post.IndexOf('"', start);
+        return end - start;
+    }
+
     private BlueskyEmbedCardPostFactory CreateSut(bool withEpisodeUrl)
     {
         var textSanitiser = new Mock<ITextSanitiser>();

--- a/Cloud/Unit-Tests/Indexer.Tests/Indexer.Tests.csproj
+++ b/Cloud/Unit-Tests/Indexer.Tests/Indexer.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,8 +25,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Indexer\Indexer.csproj" />
+    <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.Bluesky\RedditPodcastPoster.Bluesky.csproj" />
     <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.EntitySearchIndexer\RedditPodcastPoster.EntitySearchIndexer.csproj" />
+    <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.Episodes.TestSupport\RedditPodcastPoster.Episodes.TestSupport.csproj" />
     <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.Search\RedditPodcastPoster.Search.csproj" />
+    <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.Twitter\RedditPodcastPoster.Twitter.csproj" />
+    <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.UrlShortening\RedditPodcastPoster.UrlShortening.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Cloud/Unit-Tests/Indexer.Tests/ShortnerShareImageMetadataTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/ShortnerShareImageMetadataTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using RedditPodcastPoster.Cloudflare.Models;
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.UrlShortening.Services;
+using Xunit;
+
+namespace Indexer.Tests;
+
+public class ShortnerShareImageMetadataTests
+{
+    [Fact(DisplayName =
+        "New shortener metadata stores search-index YouTube image token as wide for og/twitter cards.")]
+    public void Stores_youtube_search_token_as_wide()
+    {
+        // Arrange
+        const string youTubeId = "griffinsong42";
+        var episode = new Episode
+        {
+            YouTubeId = youTubeId,
+            Images = new EpisodeImages
+            {
+                YouTube = new Uri($"https://i.ytimg.com/vi/{youTubeId}/maxresdefault.jpg")
+            }
+        };
+        var metadata = new MetaData
+        {
+            EpisodeTitle = "Sample title",
+            ReleaseDate = new DateOnly(2026, 7, 29),
+            Duration = TimeSpan.FromMinutes(30)
+        };
+
+        // Act
+        ShortnerShareImageMetadata.Apply(metadata, episode);
+
+        // Assert
+        metadata.Image.Should().Be("yx");
+        metadata.YoutubeId.Should().Be(youTubeId);
+        metadata.ImageAspect.Should().Be(ShortnerShareImageMetadata.AspectWide);
+    }
+
+    [Fact(DisplayName =
+        "New shortener metadata stores Spotify search-index token as square when there is no YouTube/iPlayer/Archive.")]
+    public void Stores_spotify_token_as_square()
+    {
+        // Arrange
+        var episode = new Episode
+        {
+            Images = new EpisodeImages
+            {
+                Spotify = new Uri("https://i.scdn.co/image/ab6765ferngully00cover")
+            }
+        };
+        var metadata = new MetaData
+        {
+            EpisodeTitle = "Sample title",
+            ReleaseDate = new DateOnly(2026, 7, 29),
+            Duration = TimeSpan.FromMinutes(30)
+        };
+
+        // Act
+        ShortnerShareImageMetadata.Apply(metadata, episode);
+
+        // Assert
+        metadata.Image.Should().Be("sab6765ferngully00cover");
+        metadata.YoutubeId.Should().BeNull();
+        metadata.ImageAspect.Should().Be(ShortnerShareImageMetadata.AspectSquare);
+    }
+
+    [Fact(DisplayName =
+        "BBC Sounds keeps square aspect; BBC iPlayer is wide even with square cover art.")]
+    public void Bbc_sounds_square_iplayer_wide()
+    {
+        // Arrange
+        var cover = new Uri("https://i.scdn.co/image/ab6765cover");
+        var sounds = new Episode
+        {
+            Images = new EpisodeImages { Spotify = cover },
+            Urls = new ServiceUrls { BBC = new Uri("https://www.bbc.co.uk/sounds/play/p0example") }
+        };
+        var iplayer = new Episode
+        {
+            Images = new EpisodeImages { Spotify = cover },
+            Urls = new ServiceUrls { BBC = new Uri("https://www.bbc.co.uk/iplayer/episode/p0example") }
+        };
+
+        // Act
+        var soundsAspect = ShortnerShareImageMetadata.ResolveAspect(sounds, "sab6765cover", null);
+        var iplayerAspect = ShortnerShareImageMetadata.ResolveAspect(iplayer, "sab6765cover", null);
+
+        // Assert
+        soundsAspect.Should().Be(ShortnerShareImageMetadata.AspectSquare);
+        iplayerAspect.Should().Be(ShortnerShareImageMetadata.AspectWide);
+    }
+
+    [Fact(DisplayName =
+        "Apply leaves image fields unset when the episode has no cover art.")]
+    public void Leaves_image_fields_null_when_no_art()
+    {
+        // Arrange
+        var episode = new Episode();
+        var metadata = new MetaData
+        {
+            EpisodeTitle = "Sample title",
+            ReleaseDate = new DateOnly(2026, 7, 29),
+            Duration = TimeSpan.FromMinutes(30)
+        };
+
+        // Act
+        ShortnerShareImageMetadata.Apply(metadata, episode);
+
+        // Assert
+        metadata.Image.Should().BeNull();
+        metadata.YoutubeId.Should().BeNull();
+        metadata.ImageAspect.Should().BeNull();
+    }
+}

--- a/Cloud/Unit-Tests/Indexer.Tests/TweetBuilderShortUrlOnlyTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/TweetBuilderShortUrlOnlyTests.cs
@@ -60,6 +60,34 @@ public class TweetBuilderShortUrlOnlyTests
         tweet.Should().Contain(platformUrl.ToString());
     }
 
+    [Fact(DisplayName =
+        "When shortener KV has a share image, the tweet title can be longer because only one URL is posted.")]
+    public async Task Has_share_image_allows_longer_tweet_title_than_dual_url_post()
+    {
+        // Arrange — length literal is the truncation boundary under test
+        var longTitle = new string('x', 220);
+        var podcast = _fixture.CreatePodcast(p => p.Name = "Show");
+        var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast, title: longTitle);
+        episode.Subjects = ["Subject"];
+        var podcastEpisode = new PodcastEpisode(podcast, episode);
+        var shortUrl = new Uri($"https://s.cultpodcasts.com/{_fixture.CreateGuid():N}");
+        var sut = CreateSut(withEpisodeUrl: true);
+
+        // Act
+        var shortOnly = await sut.BuildTweet(podcastEpisode, shortUrl, hasShareImage: true);
+        var dualUrl = await sut.BuildTweet(podcastEpisode, shortUrl, hasShareImage: false);
+
+        // Assert
+        QuotedTitleLength(shortOnly).Should().BeGreaterThan(QuotedTitleLength(dualUrl));
+    }
+
+    private static int QuotedTitleLength(string post)
+    {
+        var start = post.IndexOf('"') + 1;
+        var end = post.IndexOf('"', start);
+        return end - start;
+    }
+
     private TweetBuilder CreateSut(bool withEpisodeUrl)
     {
         var textSanitiser = new Mock<ITextSanitiser>();

--- a/Cloud/Unit-Tests/Indexer.Tests/TweetBuilderShortUrlOnlyTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/TweetBuilderShortUrlOnlyTests.cs
@@ -1,0 +1,132 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using RedditPodcastPoster.Common.Factories;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.Models.Posting;
+using RedditPodcastPoster.People.Resolvers;
+using RedditPodcastPoster.Subjects.HashTags;
+using RedditPodcastPoster.Text.Enrichers;
+using RedditPodcastPoster.Text.Sanitisers;
+using RedditPodcastPoster.Twitter.Builders;
+using RedditPodcastPoster.Twitter.Configuration;
+using Xunit;
+
+namespace Indexer.Tests;
+
+public class TweetBuilderShortUrlOnlyTests
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "When shortener KV has a share image, the tweet body uses only the short URL and omits platform links.")]
+    public async Task Has_share_image_tweet_is_short_url_only()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast);
+        var podcastEpisode = new PodcastEpisode(podcast, episode);
+        var shortUrl = new Uri($"https://s.cultpodcasts.com/{_fixture.CreateGuid():N}");
+        var platformHost = episode.Urls.YouTube!.Host;
+        var sut = CreateSut(withEpisodeUrl: false);
+
+        // Act
+        var tweet = await sut.BuildTweet(podcastEpisode, shortUrl, hasShareImage: true);
+
+        // Assert
+        tweet.Should().Contain(shortUrl.ToString());
+        tweet.Should().NotContain(platformHost);
+    }
+
+    [Fact(DisplayName =
+        "When shortener KV has no share image, the tweet body still includes the primary platform URL.")]
+    public async Task No_share_image_tweet_includes_platform_url()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast);
+        var podcastEpisode = new PodcastEpisode(podcast, episode);
+        var shortUrl = new Uri($"https://s.cultpodcasts.com/{_fixture.CreateGuid():N}");
+        var platformUrl = episode.Urls.YouTube!;
+        var sut = CreateSut(withEpisodeUrl: false);
+
+        // Act
+        var tweet = await sut.BuildTweet(podcastEpisode, shortUrl, hasShareImage: false);
+
+        // Assert
+        tweet.Should().Contain(platformUrl.ToString());
+    }
+
+    private TweetBuilder CreateSut(bool withEpisodeUrl)
+    {
+        var textSanitiser = new Mock<ITextSanitiser>();
+        textSanitiser
+            .Setup(x => x.SanitiseTitle(It.IsAny<PostModel>()))
+            .ReturnsAsync((PostModel pm) => pm.EpisodeTitle);
+        textSanitiser
+            .Setup(x => x.SanitisePodcastName(It.IsAny<PostModel>()))
+            .Returns((PostModel pm) => pm.PodcastName);
+
+        var hashTagEnricher = new Mock<IHashTagEnricher>();
+        hashTagEnricher
+            .Setup(x => x.AddHashTag(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns((string input, string _, string? _) => (input, false));
+
+        var hashTagProvider = new Mock<IHashTagProvider>();
+        hashTagProvider
+            .Setup(x => x.GetHashTags(It.IsAny<List<string>>()))
+            .ReturnsAsync(new List<HashTag>());
+
+        var postModelFactory = new Mock<IPostModelFactory>();
+        postModelFactory
+            .Setup(x => x.ToPostModel(It.IsAny<(Podcast, IEnumerable<Episode>)>(), It.IsAny<bool>()))
+            .Returns((
+                (Podcast Podcast, IEnumerable<Episode> Episodes) pe,
+                bool _) => new PostModel(
+                pe.Podcast.Name,
+                string.Empty,
+                string.Empty,
+                pe.Episodes.Select(e => new EpisodePost(
+                    e.Title,
+                    e.Urls.YouTube,
+                    e.Urls.Spotify,
+                    e.Urls.Apple,
+                    e.Release.ToString("d MMM yyyy"),
+                    e.Length.ToString(@"\[h\:mm\:ss\]"),
+                    e.Description,
+                    e.Id.ToString(),
+                    e.Release,
+                    e.Subjects.ToArray(),
+                    e.Urls.BBC,
+                    e.Urls.InternetArchive)),
+                null,
+                [],
+                []));
+
+        var personGuestHandleResolver = new Mock<IPersonGuestHandleResolver>();
+        personGuestHandleResolver
+            .Setup(x => x.Resolve(It.IsAny<Episode>()))
+            .ReturnsAsync((Array.Empty<string>(), Array.Empty<string>()));
+
+        var options = Options.Create(new TwitterOptions
+        {
+            ConsumerKey = "k",
+            ConsumerSecret = "s",
+            AccessToken = "t",
+            AccessTokenSecret = "ts",
+            WithEpisodeUrl = withEpisodeUrl
+        });
+
+        return new TweetBuilder(
+            textSanitiser.Object,
+            hashTagEnricher.Object,
+            hashTagProvider.Object,
+            postModelFactory.Object,
+            personGuestHandleResolver.Object,
+            options,
+            Mock.Of<ILogger<TweetBuilder>>());
+    }
+}

--- a/Console-Apps/Poster/PostProcessor.cs
+++ b/Console-Apps/Poster/PostProcessor.cs
@@ -141,12 +141,12 @@ public class PostProcessor(
 
             if (!request.SkipTweet)
             {
-                await TweetEpisode(podcastEpisode, shortnerResult.Url);
+                await TweetEpisode(podcastEpisode, shortnerResult.Url, shortnerResult.HasShareImage);
             }
 
             if (!request.SkipBluesky)
             {
-                await PostBluesky(podcastEpisode, shortnerResult.Url);
+                await PostBluesky(podcastEpisode, shortnerResult.Url, shortnerResult.HasShareImage);
             }
         }
         else
@@ -200,7 +200,7 @@ public class PostProcessor(
                             logger.LogError("Unsuccessful shortening-url.");
                         }
 
-                        await TweetEpisode(mostRecent, shortnerResult.Url);
+                        await TweetEpisode(mostRecent, shortnerResult.Url, shortnerResult.HasShareImage);
                     }
                 }
 
@@ -218,7 +218,7 @@ public class PostProcessor(
                             logger.LogError("Unsuccessful shortening-url.");
                         }
 
-                        await PostBluesky(mostRecent, shortnerResult.Url);
+                        await PostBluesky(mostRecent, shortnerResult.Url, shortnerResult.HasShareImage);
                     }
                 }
             }
@@ -237,18 +237,18 @@ public class PostProcessor(
         }
     }
 
-    private async Task PostBluesky(PodcastEpisode podcastEpisode, Uri? shortUrl)
+    private async Task PostBluesky(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false)
     {
-        var result = await blueSkyPoster.Post(podcastEpisode, shortUrl);
+        var result = await blueSkyPoster.Post(podcastEpisode, shortUrl, hasShareImage);
         if (result != BlueskySendStatus.Success)
         {
             logger.LogError("Error sending bluesky post. Reason: '{reason}'.", result);
         }
     }
 
-    private async Task TweetEpisode(PodcastEpisode podcastEpisode, Uri? shortUrl)
+    private async Task TweetEpisode(PodcastEpisode podcastEpisode, Uri? shortUrl, bool hasShareImage = false)
     {
-        var result = await tweetPoster.PostTweet(podcastEpisode, shortUrl);
+        var result = await tweetPoster.PostTweet(podcastEpisode, shortUrl, hasShareImage);
         if (result.TweetSendStatus != TweetSendStatus.Sent)
         {
             switch (result.TweetSendStatus)


### PR DESCRIPTION
## Summary
- New shortener KV writes store episode share-image metadata (`image` / `youtubeId` / `imageAspect`); existing keys are left alone.
- When `WriteResult.HasShareImage` is true, X and Bluesky posts link only to `s.cultpodcasts.com` (no YouTube/Spotify/Apple URL). Bluesky keeps platform `UrlService` for thumb fetch.
- Without a share image, platform-link behaviour is unchanged.

## Test plan
- [ ] `dotnet test Cloud/Unit-Tests/Indexer.Tests` (share-image + ShortUrlOnly tests)
- [ ] Dry-run / staging post for an episode with artwork → tweet/Bluesky body is short URL only
- [ ] Episode without resolvable art → platform URL still posted
- [ ] Confirm existing shortener keys are not rewritten on re-post
