### PR TITLE
feat(content): publish search-suggestions index to R2 weekly

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher.Tests/BusinessRules/SearchSuggestionsIndexBuilderRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher.Tests/BusinessRules/SearchSuggestionsIndexBuilderRules.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using RedditPodcastPoster.ContentPublisher.Builders;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.Models.Subjects;
+
+namespace RedditPodcastPoster.ContentPublisher.Tests.BusinessRules;
+
+public class SearchSuggestionsIndexBuilderRules
+{
+    [Fact(DisplayName =
+        "Search suggestions index: when a subject has a name and aliases, then the flat index includes a primary-name row and one row per alias with searchText lowercased, because typeahead matches pre-normalized text.")]
+    public void subject_name_and_aliases_emit_flat_rows()
+    {
+        // Arrange
+        var subject = new Subject("Primary Topic") { Aliases = ["PT", "Primary Alias"] };
+        var generatedAt = DateTime.UtcNow;
+
+        // Act
+        var corpus = SearchSuggestionsIndexBuilder.Build([subject], [], generatedAt);
+
+        // Assert
+        corpus.GeneratedAtUtc.Should().Be(generatedAt);
+        corpus.Entries.Should().BeEquivalentTo(
+        [
+            new { Type = "subject", Canonical = "Primary Topic", SearchText = "primary alias", Alias = "Primary Alias" },
+            new { Type = "subject", Canonical = "Primary Topic", SearchText = "primary topic", Alias = (string?)null },
+            new { Type = "subject", Canonical = "Primary Topic", SearchText = "pt", Alias = "PT" }
+        ], options => options.WithStrictOrdering());
+    }
+
+    [Fact(DisplayName =
+        "Search suggestions index: when a subject has associatedSubjects, then those names are not indexed, because associated subjects are excluded from typeahead.")]
+    public void associated_subjects_are_excluded()
+    {
+        // Arrange
+        var subject = new Subject("Primary Topic")
+        {
+            Aliases = ["PT"],
+            AssociatedSubjects = ["Related Topic"]
+        };
+
+        // Act
+        var corpus = SearchSuggestionsIndexBuilder.Build([subject], []);
+
+        // Assert
+        corpus.Entries.Should().NotContain(e =>
+            e.SearchText == "related topic" || e.Canonical == "Related Topic");
+        corpus.Entries.Should().ContainSingle(e => e.SearchText == "primary topic");
+        corpus.Entries.Should().ContainSingle(e => e.SearchText == "pt");
+    }
+
+    [Fact(DisplayName =
+        "Search suggestions index: when a podcast is not removed, then its name is indexed as a podcast row with lowercased searchText.")]
+    public void active_podcast_name_is_indexed()
+    {
+        // Arrange
+        var podcast = new Podcast { Name = "Example Show" };
+
+        // Act
+        var corpus = SearchSuggestionsIndexBuilder.Build([], [podcast]);
+
+        // Assert
+        corpus.Entries.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new
+            {
+                Type = "podcast",
+                Canonical = "Example Show",
+                SearchText = "example show",
+                Alias = (string?)null
+            });
+    }
+
+    [Fact(DisplayName =
+        "Search suggestions index: when a podcast is marked removed, then it is omitted from the index, because removed shows must not appear in typeahead.")]
+    public void removed_podcast_is_omitted()
+    {
+        // Arrange
+        var active = new Podcast { Name = "Active Show" };
+        var removed = new Podcast { Name = "Retired Show", Removed = true };
+
+        // Act
+        var corpus = SearchSuggestionsIndexBuilder.Build([], [active, removed]);
+
+        // Assert
+        corpus.Entries.Should().ContainSingle()
+            .Which.Canonical.Should().Be("Active Show");
+    }
+
+    [Fact(DisplayName =
+        "Search suggestions index: when duplicate type+canonical+searchText rows would be emitted, then only one row is kept, because the match key must be unique.")]
+    public void duplicate_match_keys_are_deduped()
+    {
+        // Arrange
+        var subject = new Subject("Primary Topic") { Aliases = ["Primary Topic", " primary topic "] };
+
+        // Act
+        var corpus = SearchSuggestionsIndexBuilder.Build([subject], []);
+
+        // Assert
+        corpus.Entries.Should().ContainSingle(e => e.Type == "subject" && e.SearchText == "primary topic");
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher.Tests/GlobalUsings.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher.Tests/RedditPodcastPoster.ContentPublisher.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher.Tests/RedditPodcastPoster.ContentPublisher.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RedditPodcastPoster.ContentPublisher\RedditPodcastPoster.ContentPublisher.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Builders/ISearchSuggestionsIndexBuilder.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Builders/ISearchSuggestionsIndexBuilder.cs
@@ -1,0 +1,8 @@
+using RedditPodcastPoster.ContentPublisher.Models;
+
+namespace RedditPodcastPoster.ContentPublisher.Builders;
+
+public interface ISearchSuggestionsIndexBuilder
+{
+    Task<SearchSuggestionsCorpus> BuildAsync(CancellationToken cancellationToken = default);
+}

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Builders/SearchSuggestionsIndexBuilder.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Builders/SearchSuggestionsIndexBuilder.cs
@@ -1,0 +1,108 @@
+using RedditPodcastPoster.ContentPublisher.Models;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.Models.Subjects;
+using RedditPodcastPoster.Persistence.Abstractions.Repositories;
+
+namespace RedditPodcastPoster.ContentPublisher.Builders;
+
+/// <summary>
+/// Builds the flat typeahead match index from subjects (name + aliases) and
+/// non-removed podcast names. AssociatedSubjects are intentionally excluded.
+/// </summary>
+public class SearchSuggestionsIndexBuilder(
+    ISubjectRepository subjectRepository,
+    IPodcastRepository podcastRepository) : ISearchSuggestionsIndexBuilder
+{
+    public async Task<SearchSuggestionsCorpus> BuildAsync(CancellationToken cancellationToken = default)
+    {
+        var subjects = new List<Subject>();
+        await foreach (var subject in subjectRepository.GetAll().WithCancellation(cancellationToken))
+        {
+            subjects.Add(subject);
+        }
+
+        var podcasts = new List<Podcast>();
+        await foreach (var podcast in podcastRepository.GetAll().WithCancellation(cancellationToken))
+        {
+            podcasts.Add(podcast);
+        }
+
+        return Build(subjects, podcasts);
+    }
+
+    /// <summary>
+    /// Pure builder for tests and callers that already hold in-memory collections.
+    /// </summary>
+    public static SearchSuggestionsCorpus Build(
+        IEnumerable<Subject> subjects,
+        IEnumerable<Podcast> podcasts,
+        DateTime? generatedAtUtc = null)
+    {
+        var entries = new List<SearchSuggestionEntry>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        void Add(string type, string canonical, string sourceText, string? alias = null)
+        {
+            var trimmedCanonical = canonical.Trim();
+            var searchText = sourceText.Trim().ToLowerInvariant();
+            if (trimmedCanonical.Length == 0 || searchText.Length == 0)
+            {
+                return;
+            }
+
+            var key = $"{type}\0{trimmedCanonical}\0{searchText}";
+            if (!seen.Add(key))
+            {
+                return;
+            }
+
+            entries.Add(new SearchSuggestionEntry(type, trimmedCanonical, searchText, alias));
+        }
+
+        foreach (var subject in subjects)
+        {
+            if (string.IsNullOrWhiteSpace(subject.Name))
+            {
+                continue;
+            }
+
+            var name = subject.Name.Trim();
+            Add("subject", name, name);
+
+            foreach (var rawAlias in subject.Aliases ?? Array.Empty<string>())
+            {
+                var alias = rawAlias.Trim();
+                if (alias.Length == 0)
+                {
+                    continue;
+                }
+
+                Add("subject", name, alias, alias);
+            }
+        }
+
+        foreach (var podcast in podcasts)
+        {
+            if (string.IsNullOrWhiteSpace(podcast.Name))
+            {
+                continue;
+            }
+
+            if (podcast.Removed == true)
+            {
+                continue;
+            }
+
+            var name = podcast.Name.Trim();
+            Add("podcast", name, name);
+        }
+
+        var ordered = entries
+            .OrderBy(e => e.SearchText, StringComparer.Ordinal)
+            .ThenBy(e => e.Type, StringComparer.Ordinal)
+            .ThenBy(e => e.Canonical, StringComparer.Ordinal)
+            .ToArray();
+
+        return new SearchSuggestionsCorpus(generatedAtUtc ?? DateTime.UtcNow, ordered);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Configuration/ContentOptions.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Configuration/ContentOptions.cs
@@ -10,4 +10,5 @@ public class ContentOptions
     public required string FlairsKey { get; set; }
     public required string LanguagesKey { get; set; }
     public required string DiscoveryInfoKey { get; set; }
+    public required string SearchSuggestionsKey { get; set; }
 }

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using RedditPodcastPoster.Cloudflare.Extensions;
 using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.ContentPublisher.Builders;
 using RedditPodcastPoster.ContentPublisher.Configuration;
 using RedditPodcastPoster.ContentPublisher.Publishers;
 using RedditPodcastPoster.People.Extensions;
@@ -17,12 +18,14 @@ public static class ServiceCollectionExtensions
     {
         return services
             .AddPeopleServices()
+            .AddScoped<ISearchSuggestionsIndexBuilder, SearchSuggestionsIndexBuilder>()
             .AddScoped<IHomepagePublisher, HomepagePublisher>()
             .AddScoped<ISubjectsPublisher, SubjectsPublisher>()
             .AddScoped<IPeoplePublisher, PeoplePublisher>()
             .AddScoped<IDiscoveryPublisher, DiscoveryPublisher>()
             .AddScoped<IDiscoveryInfoContentPublisher, DiscoveryInfoContentPublisher>()
             .AddScoped<ILanguagesPublisher, LanguagesPublisher>()
+            .AddScoped<ISearchSuggestionsPublisher, SearchSuggestionsPublisher>()
             .BindConfiguration<ContentOptions>("content")
             .AddCloudflareClients();
     }

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Models/SearchSuggestionEntry.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Models/SearchSuggestionEntry.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace RedditPodcastPoster.ContentPublisher.Models;
+
+public record SearchSuggestionEntry(
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("canonical")] string Canonical,
+    [property: JsonPropertyName("searchText")] string SearchText,
+    [property: JsonPropertyName("alias")] string? Alias = null);

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Models/SearchSuggestionsCorpus.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Models/SearchSuggestionsCorpus.cs
@@ -1,0 +1,7 @@
+using System.Text.Json.Serialization;
+
+namespace RedditPodcastPoster.ContentPublisher.Models;
+
+public record SearchSuggestionsCorpus(
+    [property: JsonPropertyName("generatedAtUtc")] DateTime GeneratedAtUtc,
+    [property: JsonPropertyName("entries")] SearchSuggestionEntry[] Entries);

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/ISearchSuggestionsPublisher.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/ISearchSuggestionsPublisher.cs
@@ -1,0 +1,6 @@
+namespace RedditPodcastPoster.ContentPublisher.Publishers;
+
+public interface ISearchSuggestionsPublisher
+{
+    Task<bool> PublishSearchSuggestions(CancellationToken cancellationToken = default);
+}

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/SearchSuggestionsPublisher.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/SearchSuggestionsPublisher.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RedditPodcastPoster.ContentPublisher.Builders;
+using RedditPodcastPoster.ContentPublisher.Configuration;
+
+namespace RedditPodcastPoster.ContentPublisher.Publishers;
+
+public class SearchSuggestionsPublisher(
+    IAmazonS3 client,
+    IOptions<ContentOptions> contentOptions,
+    ISearchSuggestionsIndexBuilder indexBuilder,
+    ILogger<SearchSuggestionsPublisher> logger) : ISearchSuggestionsPublisher
+{
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly ContentOptions _contentOptions = contentOptions.Value;
+
+    public async Task<bool> PublishSearchSuggestions(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var corpus = await indexBuilder.BuildAsync(cancellationToken);
+            var request = new PutObjectRequest
+            {
+                BucketName = _contentOptions.BucketName,
+                Key = _contentOptions.SearchSuggestionsKey,
+                ContentBody = JsonSerializer.Serialize(corpus, JsonSerializerOptions),
+                ContentType = "application/json",
+                DisablePayloadSigning = true
+            };
+
+            await client.PutObjectAsync(request, cancellationToken);
+            logger.LogInformation(
+                "Completed '{MethodName}'. Published {EntryCount} search-suggestion entries to '{Key}'.",
+                nameof(PublishSearchSuggestions),
+                corpus.Entries.Length,
+                _contentOptions.SearchSuggestionsKey);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "{MethodName} - Failed to publish search-suggestions to R2. BucketName: '{BucketName}', Key: '{Key}'.",
+                nameof(PublishSearchSuggestions),
+                _contentOptions.BucketName,
+                _contentOptions.SearchSuggestionsKey);
+            return false;
+        }
+    }
+}

--- a/Cloud/Indexer/Triggers/SearchSuggestionsPublishTrigger.cs
+++ b/Cloud/Indexer/Triggers/SearchSuggestionsPublishTrigger.cs
@@ -1,0 +1,38 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using RedditPodcastPoster.ContentPublisher.Publishers;
+
+namespace Indexer.Triggers;
+
+public class SearchSuggestionsPublishTrigger(
+    ISearchSuggestionsPublisher searchSuggestionsPublisher,
+    ILogger<SearchSuggestionsPublishTrigger> logger)
+{
+    /// <summary>
+    /// Weekly refresh of the public typeahead match index on R2 (Sunday 07:00 UTC).
+    /// </summary>
+    [Function("SearchSuggestionsPublish")]
+    public async Task Run(
+        [TimerTrigger("0 0 7 * * 0"
+#if DEBUG
+            , RunOnStartup = false
+#endif
+        )]
+        TimerInfo timerInfo,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "SearchSuggestionsPublish initiated. ScheduleStatus.Next: '{Next}'.",
+            timerInfo.ScheduleStatus?.Next);
+
+        var success = await searchSuggestionsPublisher.PublishSearchSuggestions(cancellationToken);
+        if (success)
+        {
+            logger.LogInformation("SearchSuggestionsPublish completed successfully.");
+        }
+        else
+        {
+            logger.LogError("SearchSuggestionsPublish failed.");
+        }
+    }
+}

--- a/Cloud/Indexer/Triggers/SearchSuggestionsPublishTrigger.cs
+++ b/Cloud/Indexer/Triggers/SearchSuggestionsPublishTrigger.cs
@@ -9,11 +9,11 @@ public class SearchSuggestionsPublishTrigger(
     ILogger<SearchSuggestionsPublishTrigger> logger)
 {
     /// <summary>
-    /// Weekly refresh of the public typeahead match index on R2 (Sunday 07:00 UTC).
+    /// Weekly refresh of the public typeahead match index on R2 (Sunday 07:07 UTC).
     /// </summary>
     [Function("SearchSuggestionsPublish")]
     public async Task Run(
-        [TimerTrigger("0 0 7 * * 0"
+        [TimerTrigger("0 7 7 * * 0"
 #if DEBUG
             , RunOnStartup = false
 #endif

--- a/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHostTestSupport.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/FunctionHostTestSupport.cs
@@ -63,6 +63,7 @@ internal static class FunctionHostTestSupport
             ["content:FlairsKey"] = "flairs.json",
             ["content:LanguagesKey"] = "languages.json",
             ["content:DiscoveryInfoKey"] = "discovery-info.json",
+            ["content:SearchSuggestionsKey"] = "search-suggestions.json",
             ["cloudflare:AccountId"] = "test-account-id",
             ["cloudflare:R2AccessKey"] = "test-r2-access-key",
             ["cloudflare:R2SecretKey"] = "test-r2-secret-key",

--- a/Console-Apps/Discover/appsettings.json
+++ b/Console-Apps/Discover/appsettings.json
@@ -66,6 +66,8 @@
     "SubjectsKey": "subjects",
     "FlairsKey": "flairs",
     "LanguagesKey": "languages",
-    "DiscoveryInfoKey": "discovery-info"
+    "DiscoveryInfoKey": "discovery-info",
+    "PeopleKey": "people",
+    "SearchSuggestionsKey": "search-suggestions"
   }
 }

--- a/Console-Apps/ExportSearchSuggestions/ExportSearchSuggestions.csproj
+++ b/Console-Apps/ExportSearchSuggestions/ExportSearchSuggestions.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Configuration\RedditPodcastPoster.Configuration.csproj" />
+    <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.ContentPublisher\RedditPodcastPoster.ContentPublisher.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Persistence\RedditPodcastPoster.Persistence.csproj" />
     <ProjectReference Include="..\..\Class-Libraries\RedditPodcastPoster.Subjects\RedditPodcastPoster.Subjects.csproj" />

--- a/Console-Apps/ExportSearchSuggestions/Program.cs
+++ b/Console-Apps/ExportSearchSuggestions/Program.cs
@@ -5,15 +5,12 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using RedditPodcastPoster.Configuration.Extensions;
+using RedditPodcastPoster.ContentPublisher.Builders;
 using RedditPodcastPoster.Persistence.Extensions;
 using RedditPodcastPoster.Subjects.Extensions;
-using RedditPodcastPoster.Persistence.Abstractions.Repositories;
 
-// Read-only, narrow-scope export for the flix search-typeahead prototype.
-// Pulls ONLY: Subject.Name + Subject.Aliases (AssociatedSubjects deliberately excluded)
-// and Podcast.Name. Emits a flat match index: { type, canonical, searchText, alias? }
-// with searchText already lowercase. Never writes to Cosmos. Not a full-catalog dump
-// (see CosmosDbDownloader for that).
+// Read-only file export of the flat search-suggestions index (same builder as R2 publish).
+// Prefer PublishR2 search-suggestions for production refresh.
 
 var builder = Host.CreateApplicationBuilder(args);
 
@@ -28,92 +25,17 @@ builder.Configuration
 builder.Services
     .AddLogging()
     .AddRepositories()
-    .AddSubjectServices();
+    .AddSubjectServices()
+    .AddScoped<ISearchSuggestionsIndexBuilder, SearchSuggestionsIndexBuilder>();
 
 using var host = builder.Build();
 
-var subjectRepository = host.Services.GetRequiredService<ISubjectRepository>();
-var podcastRepository = host.Services.GetRequiredService<IPodcastRepository>();
-
+var indexBuilder = host.Services.GetRequiredService<ISearchSuggestionsIndexBuilder>();
 var outputPath = args.FirstOrDefault(a => !a.StartsWith("--"))
                   ?? "search-suggestions.json";
 
-Console.WriteLine("Reading subjects (name + aliases only; associated-subjects excluded)...");
-var entries = new List<SuggestionEntry>();
-var seen = new HashSet<string>(StringComparer.Ordinal);
-
-void Add(string type, string canonical, string sourceText, string? alias = null)
-{
-    var trimmedCanonical = canonical.Trim();
-    var searchText = sourceText.Trim().ToLowerInvariant();
-    if (trimmedCanonical.Length == 0 || searchText.Length == 0)
-    {
-        return;
-    }
-
-    var key = $"{type}\0{trimmedCanonical}\0{searchText}";
-    if (!seen.Add(key))
-    {
-        return;
-    }
-
-    entries.Add(new SuggestionEntry(type, trimmedCanonical, searchText, alias));
-}
-
-var subjectCount = 0;
-await foreach (var subject in subjectRepository.GetAll())
-{
-    if (string.IsNullOrWhiteSpace(subject.Name))
-    {
-        continue;
-    }
-
-    subjectCount++;
-    var name = subject.Name.Trim();
-    Add("subject", name, name);
-
-    foreach (var rawAlias in subject.Aliases ?? Array.Empty<string>())
-    {
-        var alias = rawAlias.Trim();
-        if (alias.Length == 0)
-        {
-            continue;
-        }
-
-        Add("subject", name, alias, alias);
-    }
-}
-
-Console.WriteLine($"Read {subjectCount} subjects.");
-
-Console.WriteLine("Reading podcast names only...");
-var podcastCount = 0;
-await foreach (var podcast in podcastRepository.GetAll())
-{
-    if (string.IsNullOrWhiteSpace(podcast.Name))
-    {
-        continue;
-    }
-
-    if (podcast.Removed == true)
-    {
-        continue;
-    }
-
-    podcastCount++;
-    var name = podcast.Name.Trim();
-    Add("podcast", name, name);
-}
-
-Console.WriteLine($"Read {podcastCount} podcast names.");
-
-entries = entries
-    .OrderBy(e => e.SearchText, StringComparer.Ordinal)
-    .ThenBy(e => e.Type, StringComparer.Ordinal)
-    .ThenBy(e => e.Canonical, StringComparer.Ordinal)
-    .ToList();
-
-var corpus = new SuggestionsCorpus(DateTime.UtcNow, entries.ToArray());
+Console.WriteLine("Building search-suggestions index (subjects name+aliases; non-removed podcast names)...");
+var corpus = await indexBuilder.BuildAsync();
 
 var json = JsonSerializer.Serialize(corpus, new JsonSerializerOptions
 {
@@ -124,16 +46,6 @@ var json = JsonSerializer.Serialize(corpus, new JsonSerializerOptions
 
 await File.WriteAllTextAsync(outputPath, json);
 Console.WriteLine(
-    $"Wrote flat suggestions index ({entries.Count} entries) to '{Path.GetFullPath(outputPath)}'.");
+    $"Wrote flat suggestions index ({corpus.Entries.Length} entries) to '{Path.GetFullPath(outputPath)}'.");
 
 return 0;
-
-record SuggestionEntry(
-    [property: JsonPropertyName("type")] string Type,
-    [property: JsonPropertyName("canonical")] string Canonical,
-    [property: JsonPropertyName("searchText")] string SearchText,
-    [property: JsonPropertyName("alias")] string? Alias);
-
-record SuggestionsCorpus(
-    [property: JsonPropertyName("generatedAtUtc")] DateTime GeneratedAtUtc,
-    [property: JsonPropertyName("entries")] SuggestionEntry[] Entries);

--- a/Console-Apps/PublishR2/Program.cs
+++ b/Console-Apps/PublishR2/Program.cs
@@ -86,6 +86,7 @@ static R2PublishTarget ToR2Target(PublishMode mode) => mode switch
 {
     PublishMode.Languages => R2PublishTarget.Languages,
     PublishMode.People => R2PublishTarget.People,
+    PublishMode.SearchSuggestions => R2PublishTarget.SearchSuggestions,
     _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
 };
 
@@ -111,6 +112,7 @@ static PublishMode? ParseMode(string[] args)
     {
         "languages" or "--languages" or "-l" => PublishMode.Languages,
         "people" or "--people" or "-p" => PublishMode.People,
+        "search-suggestions" or "--search-suggestions" or "-s" or "suggestions" => PublishMode.SearchSuggestions,
         "flairs" or "--flairs" or "-f" or "flair" => PublishMode.Flairs,
         "all" or "--all" or "-a" => PublishMode.All,
         "r2" => PublishMode.Languages,
@@ -127,18 +129,20 @@ static void PrintUsage()
         PublishR2 — publish static content to Cloudflare R2 and Reddit flairs.
 
         Usage:
-          PublishR2 [languages|people|flairs|all]
-          PublishR2 [--languages|-l|--people|-p|--flairs|-f|--all|-a]
+          PublishR2 [languages|people|search-suggestions|flairs|all]
+          PublishR2 [--languages|-l|--people|-p|--search-suggestions|-s|--flairs|-f|--all|-a]
 
         Modes:
-          languages (default)  R2PublishProcessor — languages list to R2
-          people               R2PublishProcessor — People register to R2
-          flairs               FlairPublishProcessor — subject flairs to Reddit
-          all                  R2 (languages+people), then flairs
+          languages (default)     R2PublishProcessor — languages list to R2
+          people                  R2PublishProcessor — People register to R2
+          search-suggestions      R2PublishProcessor — typeahead match index to R2
+          flairs                  FlairPublishProcessor — subject flairs to Reddit
+          all                     R2 (languages+people+search-suggestions), then flairs
 
         Examples:
           PublishR2
           PublishR2 people
+          PublishR2 search-suggestions
           PublishR2 --flairs
           PublishR2 all
         """);
@@ -148,6 +152,7 @@ enum PublishMode
 {
     Languages,
     People,
+    SearchSuggestions,
     Flairs,
     All
 }

--- a/Console-Apps/PublishR2/R2PublishProcessor.cs
+++ b/Console-Apps/PublishR2/R2PublishProcessor.cs
@@ -4,7 +4,8 @@ namespace PublishR2;
 
 public class R2PublishProcessor(
     ILanguagesPublisher languagesPublisher,
-    IPeoplePublisher peoplePublisher)
+    IPeoplePublisher peoplePublisher,
+    ISearchSuggestionsPublisher searchSuggestionsPublisher)
 {
     public async Task<bool> Process(R2PublishRequest request)
     {
@@ -18,6 +19,11 @@ public class R2PublishProcessor(
         if (success && request.Target is R2PublishTarget.People or R2PublishTarget.All)
         {
             await peoplePublisher.PublishPeople();
+        }
+
+        if (success && request.Target is R2PublishTarget.SearchSuggestions or R2PublishTarget.All)
+        {
+            success = await searchSuggestionsPublisher.PublishSearchSuggestions();
         }
 
         return success;

--- a/Console-Apps/PublishR2/R2PublishRequest.cs
+++ b/Console-Apps/PublishR2/R2PublishRequest.cs
@@ -9,5 +9,6 @@ public enum R2PublishTarget
 {
     Languages,
     People,
+    SearchSuggestions,
     All
 }

--- a/Console-Apps/README.md
+++ b/Console-Apps/README.md
@@ -123,12 +123,14 @@ For `--help` on CommandLineParser apps, pass `-- --help` after `dotnet run` (or 
 |------|---------|--------|
 | `languages` (default) | `--languages`, `-l` | `R2PublishProcessor` — languages list to R2 |
 | `people` | `--people`, `-p` | `R2PublishProcessor` — People register to R2 |
+| `search-suggestions` | `--search-suggestions`, `-s`, `suggestions` | `R2PublishProcessor` — typeahead match index to R2 |
 | `flairs` | `--flairs`, `-f`, `flair` | `FlairPublishProcessor` — subject flairs to Reddit |
-| `all` | `--all`, `-a` | R2 languages+people, then flairs |
+| `all` | `--all`, `-a` | R2 languages+people+search-suggestions, then flairs |
 
 ```text
 PublishR2
 PublishR2 people
+PublishR2 search-suggestions
 PublishR2 --flairs
 PublishR2 all
 ```
@@ -399,7 +401,7 @@ RemoveEpisodes restore removed-episodes-log.txt
 
 ### ExportSearchSuggestions
 
-**Purpose:** Read-only, narrow export for the flix search-typeahead prototype. Reads only Subjects (`name` + `aliases`, `associatedSubjects` deliberately excluded) and Podcasts (`name` only, non-removed) via the existing repository `GetAll()` abstractions, and projects straight to a single small **flat match-index** JSON file (`entries[]` with `type`, `canonical`, lowercase `searchText`, optional `alias`) — never writes to disk per-document like `CosmosDbDownloader`, never writes to Cosmos.
+**Purpose:** Read-only file export of the flix search-typeahead flat match index (same `SearchSuggestionsIndexBuilder` as R2 publish). Subjects (`name` + `aliases`; `associatedSubjects` excluded) and non-removed podcast names. Prefer `PublishR2 search-suggestions` for production refresh.
 
 **Run:** `dotnet run --project Console-Apps/ExportSearchSuggestions -- [output-path]` · PATH: `ExportSearchSuggestions`
 
@@ -407,7 +409,7 @@ RemoveEpisodes restore removed-episodes-log.txt
 |-------|-------------|
 | `[output-path]` | Optional positional; JSON output path (default `search-suggestions.json`) |
 
-Consumed by the website repo (`cultpodcasts/docs/search-suggestions.md`) — copy the output into `src/assets/search-suggestions.json` on `design/visual-refresh-v1` and commit. If you still have a legacy nested `{ subjects, podcasts }` file, convert with `node scripts/flatten-search-suggestions.mjs` in `cultpodcasts/`.
+Production clients load the index from `GET /search-suggestions` (R2). See website `cultpodcasts/docs/search-suggestions.md`.
 
 ---
 

--- a/Infrastructure/functions.bicep
+++ b/Infrastructure/functions.bicep
@@ -209,6 +209,7 @@ var content= {
     content__PreProcessedHomepageKey: 'homepage-ssr'
     content__SubjectsKey: 'subjects'
     content__PeopleKey: 'people'
+    content__SearchSuggestionsKey: 'search-suggestions'
 }
 
 var cosmosdb= {

--- a/RedditPodcastPoster.slnx
+++ b/RedditPodcastPoster.slnx
@@ -87,6 +87,8 @@
 
     <Project Path="Class-Libraries/RedditPodcastPoster.People.Tests/RedditPodcastPoster.People.Tests.csproj" />
 
+    <Project Path="Class-Libraries/RedditPodcastPoster.ContentPublisher.Tests/RedditPodcastPoster.ContentPublisher.Tests.csproj" />
+
     <Project Path="Class-Libraries/RedditPodcastPoster.PodcastServices.Tests/RedditPodcastPoster.PodcastServices.Tests.csproj" />
 
     <Project Path="Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/RedditPodcastPoster.PodcastServices.Apple.Tests.csproj" />


### PR DESCRIPTION
## Summary
- Extract `SearchSuggestionsIndexBuilder` and publish the flat typeahead corpus to R2 key `search-suggestions`
- Add `PublishR2 search-suggestions` mode and a weekly Indexer timer (Sunday **07:07** UTC)
- Wire `content__SearchSuggestionsKey` in bicep + BusinessRules coverage for the builder

## Deploy (interim — GH Actions bicep not working)

`deploy-indexer.ps1` is **code-only**. New `content__SearchSuggestionsKey` will **not** land from bicep until provision works again. Apply it manually **before** (or with) the indexer code deploy — `ContentOptions.SearchSuggestionsKey` is required, so the weekly publisher will fail Options bind without it.

Bicep puts `content__*` on all three apps via `coreSettings`; set the new key on all three for parity:

```powershell
az login

# Required for SearchSuggestionsPublish timer + any ContentOptions bind
foreach ($app in @('indexer-infra', 'api-infra', 'discover-infra')) {
  az functionapp config appsettings set `
    --resource-group AutomatedInfra `
    --name $app `
    --settings content__SearchSuggestionsKey=search-suggestions `
    -o none
}

# Verify
az functionapp config appsettings list -g AutomatedInfra -n indexer-infra `
  --query "[?name=='content__SearchSuggestionsKey']" -o table

# Then code deploy (from merged main / this branch worktree)
.\scripts\deploy-indexer.ps1
```

R2 object is already seeded (`PublishR2 search-suggestions`, 8410 entries). Re-run publish only if you want a fresh corpus after merge.

## Deploy order (cross-repo)

1. This PR + manual app setting + `deploy-indexer.ps1`
2. Api worker [cultpodcasts/Api#127](https://github.com/cultpodcasts/Api/pull/127)
3. Website [cultpodcasts/website#451](https://github.com/cultpodcasts/website/pull/451)

## Test plan
- [x] `dotnet test` ContentPublisher.Tests (5 rules green)
- [x] `PublishR2 search-suggestions` seeded R2 (8410 entries)
- [ ] Manual `content__SearchSuggestionsKey` on indexer-infra (and api/discover for parity)
- [ ] `deploy-indexer.ps1`
- [ ] Confirm Api `GET /search-suggestions` after Api PR deploys