### PR TITLE
fix(content): fail SearchSuggestionsPublish loudly on R2 errors

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/ISearchSuggestionsPublisher.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/ISearchSuggestionsPublisher.cs
@@ -2,5 +2,9 @@ namespace RedditPodcastPoster.ContentPublisher.Publishers;
 
 public interface ISearchSuggestionsPublisher
 {
-    Task<bool> PublishSearchSuggestions(CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Builds and uploads the typeahead index. Throws on failure so callers
+    /// (timer / CLI) surface an unsuccessful result.
+    /// </summary>
+    Task PublishSearchSuggestions(CancellationToken cancellationToken = default);
 }

--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/SearchSuggestionsPublisher.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/SearchSuggestionsPublisher.cs
@@ -23,7 +23,7 @@ public class SearchSuggestionsPublisher(
 
     private readonly ContentOptions _contentOptions = contentOptions.Value;
 
-    public async Task<bool> PublishSearchSuggestions(CancellationToken cancellationToken = default)
+    public async Task PublishSearchSuggestions(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -43,7 +43,6 @@ public class SearchSuggestionsPublisher(
                 nameof(PublishSearchSuggestions),
                 corpus.Entries.Length,
                 _contentOptions.SearchSuggestionsKey);
-            return true;
         }
         catch (Exception ex)
         {
@@ -52,7 +51,7 @@ public class SearchSuggestionsPublisher(
                 nameof(PublishSearchSuggestions),
                 _contentOptions.BucketName,
                 _contentOptions.SearchSuggestionsKey);
-            return false;
+            throw;
         }
     }
 }

--- a/Cloud/Indexer/Triggers/SearchSuggestionsPublishTrigger.cs
+++ b/Cloud/Indexer/Triggers/SearchSuggestionsPublishTrigger.cs
@@ -10,6 +10,7 @@ public class SearchSuggestionsPublishTrigger(
 {
     /// <summary>
     /// Weekly refresh of the public typeahead match index on R2 (Sunday 07:07 UTC).
+    /// Failures throw so AppRequests records Success=false and exceptions appear in telemetry.
     /// </summary>
     [Function("SearchSuggestionsPublish")]
     public async Task Run(
@@ -25,14 +26,8 @@ public class SearchSuggestionsPublishTrigger(
             "SearchSuggestionsPublish initiated. ScheduleStatus.Next: '{Next}'.",
             timerInfo.ScheduleStatus?.Next);
 
-        var success = await searchSuggestionsPublisher.PublishSearchSuggestions(cancellationToken);
-        if (success)
-        {
-            logger.LogInformation("SearchSuggestionsPublish completed successfully.");
-        }
-        else
-        {
-            logger.LogError("SearchSuggestionsPublish failed.");
-        }
+        await searchSuggestionsPublisher.PublishSearchSuggestions(cancellationToken);
+
+        logger.LogInformation("SearchSuggestionsPublish completed successfully.");
     }
 }

--- a/Console-Apps/PublishR2/R2PublishProcessor.cs
+++ b/Console-Apps/PublishR2/R2PublishProcessor.cs
@@ -23,7 +23,15 @@ public class R2PublishProcessor(
 
         if (success && request.Target is R2PublishTarget.SearchSuggestions or R2PublishTarget.All)
         {
-            success = await searchSuggestionsPublisher.PublishSearchSuggestions();
+            try
+            {
+                await searchSuggestionsPublisher.PublishSearchSuggestions();
+            }
+            catch
+            {
+                // Publisher already logged the exception; map to CLI failure.
+                success = false;
+            }
         }
 
         return success;


### PR DESCRIPTION
## Summary
- `SearchSuggestionsPublisher` logs and **rethrows** on failure (no more `return false`)
- Timer lets the exception fail the function so `AppRequests` shows `Success=false`
- `PublishR2` maps the throw to a non-zero CLI exit

## Test plan
- [x] Build ContentPublisher, Indexer, PublishR2
- [ ] Deploy indexer; on a forced R2 failure, confirm `AppRequests` Success=false + `AppExceptions`


Made with [Cursor](https://cursor.com)