### PR TITLE
feat(discovery): YouTube synthetic media and guests on Discovery results

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Discovery.Tests/DiscoveryResultDeduplicatorTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Discovery.Tests/DiscoveryResultDeduplicatorTests.cs
@@ -307,6 +307,8 @@ public class DiscoveryResultDeduplicatorTests
             Subjects = source.Subjects.ToArray(),
             YouTubeViews = source.YouTubeViews,
             YouTubeChannelMembers = source.YouTubeChannelMembers,
+            ContainsSyntheticMedia = source.ContainsSyntheticMedia,
+            Guests = source.Guests.ToArray(),
             ImageUrl = source.ImageUrl,
             Sources = source.Sources.ToArray(),
             EnrichedTimeFromApple = source.EnrichedTimeFromApple,

--- a/Class-Libraries/RedditPodcastPoster.Discovery/Adapters/EnrichedEpisodeResultAdapter.cs
+++ b/Class-Libraries/RedditPodcastPoster.Discovery/Adapters/EnrichedEpisodeResultAdapter.cs
@@ -2,12 +2,14 @@ using Microsoft.Extensions.Logging;
 using RedditPodcastPoster.Discovery.Models;
 using RedditPodcastPoster.Models.Episodes;
 using RedditPodcastPoster.Models.Discovery;
+using RedditPodcastPoster.People.Enrichers;
 using RedditPodcastPoster.Subjects.Matching;
 
 namespace RedditPodcastPoster.Discovery.Adapters;
 
 public class EnrichedEpisodeResultAdapter(
     ISubjectMatcher subjectMatcher,
+    IEpisodeGuestEnricher guestEnricher,
 #pragma warning disable CS9113 // Parameter is unread.
     ILogger<EnrichedEpisodeResultAdapter> logger
 #pragma warning restore CS9113 // Parameter is unread.
@@ -20,8 +22,13 @@ public class EnrichedEpisodeResultAdapter(
             State = DiscoveryResultState.Unprocessed
         };
 
-        var subjects = await subjectMatcher.MatchSubjects(new Episode
-            { Title = episode.EpisodeResult.EpisodeName, Description = episode.EpisodeResult.Description });
+        var matchEpisode = new Episode
+        {
+            Title = episode.EpisodeResult.EpisodeName,
+            Description = episode.EpisodeResult.Description
+        };
+
+        var subjects = await subjectMatcher.MatchSubjects(matchEpisode);
 
         discoveryResult.Urls.Apple = episode.EpisodeResult.Urls.Apple;
         discoveryResult.Urls.Spotify = episode.EpisodeResult.Urls.Spotify;
@@ -59,7 +66,11 @@ public class EnrichedEpisodeResultAdapter(
             discoveryResult.YouTubeChannelMembers = episode.EpisodeResult.MemberCount;
         }
 
+        discoveryResult.ContainsSyntheticMedia = episode.EpisodeResult.ContainsSyntheticMedia;
         discoveryResult.ImageUrl = episode.EpisodeResult.ImageUrl;
+
+        await guestEnricher.EnrichGuests(matchEpisode);
+        discoveryResult.Guests = matchEpisode.Guests ?? [];
 
         discoveryResult.MatchingPodcastIds = episode.PodcastResults.Select(x => x.PodcastId).ToArray();
         return discoveryResult;

--- a/Class-Libraries/RedditPodcastPoster.Discovery/RedditPodcastPoster.Discovery.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Discovery/RedditPodcastPoster.Discovery.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.Taddy\RedditPodcastPoster.PodcastServices.Taddy.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.YouTube\RedditPodcastPoster.PodcastServices.YouTube.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Discovery.ML\RedditPodcastPoster.Discovery.ML.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.People\RedditPodcastPoster.People.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Subjects\RedditPodcastPoster.Subjects.csproj" />
   </ItemGroup>
 

--- a/Class-Libraries/RedditPodcastPoster.Discovery/Services/DiscoveryResultDeduplicator.cs
+++ b/Class-Libraries/RedditPodcastPoster.Discovery/Services/DiscoveryResultDeduplicator.cs
@@ -121,7 +121,15 @@ public class DiscoveryResultDeduplicator : IDiscoveryResultDeduplicator
             merged.Released = youTube.Released;
             merged.YouTubeViews = youTube.YouTubeViews;
             merged.YouTubeChannelMembers = youTube.YouTubeChannelMembers;
+            merged.ContainsSyntheticMedia = youTube.ContainsSyntheticMedia;
         }
+
+        merged.Guests = linkedItems
+            .Where(HasSameEpisodeIdentityWith(winner))
+            .SelectMany(x => x.Guests)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
         var apple = linkedItems.FirstOrDefault(x =>
             x.EnrichedTimeFromApple && HasSameEpisodeIdentity(x, winner));
@@ -363,6 +371,8 @@ public class DiscoveryResultDeduplicator : IDiscoveryResultDeduplicator
             Subjects = source.Subjects.ToArray(),
             YouTubeViews = source.YouTubeViews,
             YouTubeChannelMembers = source.YouTubeChannelMembers,
+            ContainsSyntheticMedia = source.ContainsSyntheticMedia,
+            Guests = source.Guests.ToArray(),
             ImageUrl = source.ImageUrl,
             Sources = source.Sources.ToArray(),
             EnrichedTimeFromApple = source.EnrichedTimeFromApple,

--- a/Class-Libraries/RedditPodcastPoster.Models/Discovery/DiscoveryResult.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Discovery/DiscoveryResult.cs
@@ -55,6 +55,14 @@ public class DiscoveryResult
     [JsonPropertyOrder(120)]
     public ulong? YouTubeChannelMembers { get; set; }
 
+    [JsonPropertyName("containsSyntheticMedia")]
+    [JsonPropertyOrder(125)]
+    public bool? ContainsSyntheticMedia { get; set; }
+
+    [JsonPropertyName("guests")]
+    [JsonPropertyOrder(128)]
+    public string[] Guests { get; set; } = [];
+
     [JsonPropertyName("imageUrl")]
     [JsonPropertyOrder(130)]
     public Uri? ImageUrl { get; set; }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Models/EpisodeResult.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Abstractions/Models/EpisodeResult.cs
@@ -32,4 +32,9 @@ public class EpisodeResult(
     public PodcastServiceIds PodcastIds { get; set; } = new();
     public bool EnrichedTimeFromApple { get; set; }
     public bool EnrichedUrlFromSpotify { get; set; }
+
+    /// <summary>
+    /// YouTube altered/synthetic media disclosure (<c>status.containsSyntheticMedia</c>), when known.
+    /// </summary>
+    public bool? ContainsSyntheticMedia { get; set; }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeSearcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeSearcher.cs
@@ -115,7 +115,8 @@ public class YouTubeSearcher(
     {
         var videoIds = results.Select(x => x.SearchResult.Id.VideoId);
         var videos =
-            await youTubeVideoService.GetVideoContentDetails(youTubeService, videoIds, indexingContext, true, true);
+            await youTubeVideoService.GetVideoContentDetails(
+                youTubeService, videoIds, indexingContext, withSnippets: true, withStatistics: true, withStatus: true);
         foreach (var result in results)
         {
             var video = videos?.FirstOrDefault(x => x.Id == result.SearchResult.Id.VideoId);
@@ -179,6 +180,7 @@ public class YouTubeSearcher(
         );
         episodeResult.Urls.YouTube = episode.ToYouTubeUrl();
         episodeResult.PodcastIds.YouTube = channel?.Id;
+        episodeResult.ContainsSyntheticMedia = video?.Status?.ContainsSyntheticMedia;
         return episodeResult;
     }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Video/IYouTubeVideoService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Video/IYouTubeVideoService.cs
@@ -11,5 +11,6 @@ public interface IYouTubeVideoService
         IEnumerable<string> videoIds,
         IndexingContext options,
         bool withSnippets = false,
-        bool withStatistics = false);
+        bool withStatistics = false,
+        bool withStatus = false);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Video/YouTubeVideoService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Video/YouTubeVideoService.cs
@@ -23,7 +23,8 @@ public class YouTubeVideoService(
         IEnumerable<string> videoIds,
         IndexingContext? indexingContext,
         bool withSnippets = false,
-        bool withStatistics = false)
+        bool withStatistics = false,
+        bool withStatus = false)
     {
         if (indexingContext is {SkipYouTubeUrlResolving: true})
         {
@@ -51,6 +52,11 @@ public class YouTubeVideoService(
                 if (withStatistics)
                 {
                     contentDetails = "statistics," + contentDetails;
+                }
+
+                if (withStatus)
+                {
+                    contentDetails = "status," + contentDetails;
                 }
 
                 var request = youTubeService.YouTubeService.Videos.List(contentDetails);

--- a/Cloud/Api/Dtos/DiscoveryResponse.cs
+++ b/Cloud/Api/Dtos/DiscoveryResponse.cs
@@ -61,6 +61,14 @@ public class DiscoveryResponse
         [JsonPropertyOrder(100)]
         public ulong? YouTubeChannelMembers { get; set; }
 
+        [JsonPropertyName("containsSyntheticMedia")]
+        [JsonPropertyOrder(105)]
+        public bool? ContainsSyntheticMedia { get; set; }
+
+        [JsonPropertyName("guests")]
+        [JsonPropertyOrder(108)]
+        public string[] Guests { get; set; } = [];
+
         [JsonPropertyName("imageUrl")]
         [JsonPropertyOrder(110)]
         public Uri? ImageUrl { get; set; }

--- a/Cloud/Api/Dtos/Extensions/DiscoveryResultExtensions.cs
+++ b/Cloud/Api/Dtos/Extensions/DiscoveryResultExtensions.cs
@@ -56,6 +56,8 @@ public static class DiscoveryResultExtensions
         result.ShowName = item.ShowName;
         result.YouTubeChannelMembers = item.YouTubeChannelMembers;
         result.YouTubeViews = item.YouTubeViews;
+        result.ContainsSyntheticMedia = item.ContainsSyntheticMedia;
+        result.Guests = item.Guests;
         result.Subjects = item.Subjects;
         result.Sources = item.Sources
             .Select(x =>

--- a/Cloud/Discovery/Ioc.cs
+++ b/Cloud/Discovery/Ioc.cs
@@ -19,6 +19,7 @@ using RedditPodcastPoster.PodcastServices.Abstractions.Clients;
 using RedditPodcastPoster.PodcastServices.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Configuration;
 using RedditPodcastPoster.PushSubscriptions.Extensions;
+using RedditPodcastPoster.People.Extensions;
 using RedditPodcastPoster.Reddit.Extensions;
 using RedditPodcastPoster.Subjects.Extensions;
 
@@ -33,6 +34,7 @@ public static class Ioc
             .AddRepositories()
             .AddSubjectServices()
             .AddCachedSubjectProvider()
+            .AddPeopleServices()
             .AddDiscovery(ApplicationUsage.Discover)
             .AddScoped<Container>(s => s.GetRequiredService<ICosmosDbContainerFactory>().CreateActivitiesContainer())
             .AddScoped<IActivityMarshaller, ActivityMarshaller>()


### PR DESCRIPTION
## Summary
- Request YouTube `status` and map `containsSyntheticMedia` through EpisodeResult → DiscoveryResult → Discovery API DTO
- Enrich Discovery guests from People (`IEpisodeGuestEnricher`) in the Discovery function host
- Preserve synthetic flag and guests through DiscoveryResult dedupe Clone/Merge

## Test plan
- [ ] Discovery deduplicator tests pass
- [ ] Discovery YouTube path requests video status and maps `ContainsSyntheticMedia`
- [ ] GET discovery-curation response includes `containsSyntheticMedia` and `guests` when present
- [ ] Deploy Discovery + Api function apps before relying on website badges