### PR TITLE
feat(indexer): enable YouTube resolving every 3 hours

### DIFF
--- a/Cloud/Indexer/Activities/IndexIdProvider.cs
+++ b/Cloud/Indexer/Activities/IndexIdProvider.cs
@@ -53,17 +53,10 @@ public class IndexIdProvider(
                 DateTime.UtcNow, youtubeDiscoveryIds.Length, string.Join(",", youtubeDiscoveryIds));
         }
 
-        var batchSizes = allIndexablePodcastIds.Length / req.IndexPasses;
-        var batches = new List<Guid[]>();
-        for (var i = 0; i < req.IndexPasses; i++)
+        var batches = IndexPassBatchSplitter.Split(allIndexablePodcastIds, req.IndexPasses);
+        for (var i = 0; i < batches.Length; i++)
         {
-            var batch = allIndexablePodcastIds.Skip(i * batchSizes);
-            if (i < req.IndexPasses - 1)
-            {
-                batch = batch.Take(batchSizes);
-            }
-
-            var batchArray = batch.ToArray();
+            var batchArray = batches[i];
             logger.LogInformation("Batch {i}: {batch}", i + 1, batchArray);
             if (i == 3)
             {
@@ -71,17 +64,9 @@ public class IndexIdProvider(
                     "IndexIdProvider batch-4-summary podcast-count='{PodcastCount}'",
                     batchArray.Length);
             }
-            batches.Add(batchArray);
-        }
-
-        var batchSum = batches.Sum(batch => batch.Length);
-        if (batchSum != allIndexablePodcastIds.Length)
-        {
-            throw new InvalidOperationException(
-                $"Batch sum {batchSum} does not equal all indexable podcast ids {allIndexablePodcastIds.Length}.");
         }
 
         logger.LogInformation($"{nameof(RunAsync)} Completed.");
-        return new IndexIdProviderResponse(batches.ToArray());
+        return new IndexIdProviderResponse(batches);
     }
 }

--- a/Cloud/Indexer/Orchestrations/HourlyIndexingPassSelector.cs
+++ b/Cloud/Indexer/Orchestrations/HourlyIndexingPassSelector.cs
@@ -4,8 +4,9 @@ using Indexer.Models;
 namespace Indexer.Orchestrations;
 
 /// <summary>
-/// Selects which indexer pass pair runs each hour so YouTube-enabled hours (every 6h) cover
-/// both lower (1-2) and upper (3-4) podcast batches without increasing API quota.
+/// Selects which indexer pass pair runs each hour so YouTube-enabled hours (every 3h) cover
+/// both lower (1-2) and upper (3-4) podcast batches. Even UTC hours run passes 1–2; odd hours
+/// run 3–4 — so YouTube hours 0/6/12/18 hit the lower half and 3/9/15/21 hit the upper half.
 /// </summary>
 public static class HourlyIndexingPassSelector
 {
@@ -27,20 +28,5 @@ public static class HourlyIndexingPassSelector
         return (firstPass, firstPass + passesPerHour - 1);
     }
 
-    internal static bool UseLowerBatches(int hour)
-    {
-        if (hour % 6 == 0)
-        {
-            return hour % 12 == 0;
-        }
-
-        if (hour % 2 == 1)
-        {
-            var segmentStartHour = hour / 6 * 6;
-            var youTubeHourUsedLowerBatches = segmentStartHour % 12 == 0;
-            return !youTubeHourUsedLowerBatches;
-        }
-
-        return true;
-    }
+    internal static bool UseLowerBatches(int hour) => hour % 2 == 0;
 }

--- a/Cloud/Indexer/Orchestrations/HourlyOrchestration.cs
+++ b/Cloud/Indexer/Orchestrations/HourlyOrchestration.cs
@@ -38,7 +38,7 @@ public class HourlyOrchestration : TaskOrchestrator<HourlyOrchestrationRunInput?
 
         var hourUtc = context.CurrentUtcDateTime.Hour;
         var (firstPass, lastPass) = HourlyIndexingPassSelector.SelectPasses(hourUtc, indexPasses);
-        var youtubeEnabledHour = hourUtc % 6 == 0;
+        var youtubeEnabledHour = hourUtc % 3 == 0;
         logger.LogWarning(
             "HourlyOrchestration pass-selection hour-utc='{HourUtc}' first-pass='{FirstPass}' last-pass='{LastPass}' youtube-enabled-hour='{YouTubeEnabledHour}' orchestration-instance-id='{OrchestrationInstanceId}'",
             hourUtc, firstPass, lastPass, youtubeEnabledHour, context.InstanceId);

--- a/Cloud/Indexer/Services/IndexPassBatchSplitter.cs
+++ b/Cloud/Indexer/Services/IndexPassBatchSplitter.cs
@@ -1,0 +1,41 @@
+namespace Indexer.Services;
+
+/// <summary>
+/// Splits indexable podcast ids into contiguous hourly pass batches (same algorithm as
+/// <c>IndexIdProvider</c>). Every id lands in exactly one batch so schedule coverage of
+/// passes 1–4 is enough to cover the full catalogue.
+/// </summary>
+public static class IndexPassBatchSplitter
+{
+    public static Guid[][] Split(IReadOnlyList<Guid> podcastIds, int indexPasses)
+    {
+        if (indexPasses < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(indexPasses), "Index passes must be greater than 0.");
+        }
+
+        ArgumentNullException.ThrowIfNull(podcastIds);
+
+        var batchSize = podcastIds.Count / indexPasses;
+        var batches = new Guid[indexPasses][];
+        for (var i = 0; i < indexPasses; i++)
+        {
+            var batch = podcastIds.Skip(i * batchSize);
+            if (i < indexPasses - 1)
+            {
+                batch = batch.Take(batchSize);
+            }
+
+            batches[i] = batch.ToArray();
+        }
+
+        var batchSum = batches.Sum(batch => batch.Length);
+        if (batchSum != podcastIds.Count)
+        {
+            throw new InvalidOperationException(
+                $"Batch sum {batchSum} does not equal podcast id count {podcastIds.Count}.");
+        }
+
+        return batches;
+    }
+}

--- a/Cloud/Indexer/Services/IndexingStrategy.cs
+++ b/Cloud/Indexer/Services/IndexingStrategy.cs
@@ -7,8 +7,7 @@ public class IndexingStrategy(IDateTimeService dateTimeService) : IIndexingStrat
 {
     public bool ResolveYouTube()
     {
-        // was  % 2
-        return dateTimeService.GetHour() % 6 == 0;
+        return dateTimeService.GetHour() % 3 == 0;
     }
 
     public bool ExpensiveYouTubeQueries()

--- a/Cloud/Unit-Tests/Indexer.Tests/HourlyIndexingPassSelectorTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/HourlyIndexingPassSelectorTests.cs
@@ -1,80 +1,83 @@
 using FluentAssertions;
-using Indexer.Activities;
-using Indexer.Models;
 using Indexer.Orchestrations;
-using Indexer.Services;
 using Xunit;
 
 namespace Indexer.Tests;
 
 public class HourlyIndexingPassSelectorTests
 {
-    [Theory]
+    [Theory(DisplayName =
+        "Each UTC hour selects a fixed pass pair: even hours run batches 1–2 and odd hours run batches 3–4.")]
     [InlineData(0, 1, 2)]
     [InlineData(1, 3, 4)]
     [InlineData(2, 1, 2)]
     [InlineData(3, 3, 4)]
     [InlineData(4, 1, 2)]
     [InlineData(5, 3, 4)]
-    [InlineData(6, 3, 4)]
-    [InlineData(7, 1, 2)]
+    [InlineData(6, 1, 2)]
+    [InlineData(7, 3, 4)]
     [InlineData(8, 1, 2)]
-    [InlineData(9, 1, 2)]
+    [InlineData(9, 3, 4)]
     [InlineData(10, 1, 2)]
-    [InlineData(11, 1, 2)]
+    [InlineData(11, 3, 4)]
     [InlineData(12, 1, 2)]
     [InlineData(13, 3, 4)]
     [InlineData(14, 1, 2)]
     [InlineData(15, 3, 4)]
     [InlineData(16, 1, 2)]
     [InlineData(17, 3, 4)]
-    [InlineData(18, 3, 4)]
-    [InlineData(19, 1, 2)]
+    [InlineData(18, 1, 2)]
+    [InlineData(19, 3, 4)]
     [InlineData(20, 1, 2)]
-    [InlineData(21, 1, 2)]
+    [InlineData(21, 3, 4)]
     [InlineData(22, 1, 2)]
-    [InlineData(23, 1, 2)]
+    [InlineData(23, 3, 4)]
     public void SelectPasses_maps_hours_to_expected_batch_pairs(int hour, int expectedFirst, int expectedLast)
     {
+        // Arrange / Act
         var (firstPass, lastPass) = HourlyIndexingPassSelector.SelectPasses(hour);
 
+        // Assert
         firstPass.Should().Be(expectedFirst);
         lastPass.Should().Be(expectedLast);
     }
 
-    [Theory]
-    [InlineData(0)]
-    [InlineData(6)]
-    [InlineData(12)]
-    [InlineData(18)]
-    public void SelectPasses_on_youtube_hours_covers_both_batch_halves(int hour)
+    [Theory(DisplayName =
+        "YouTube-enabled hours alternate batch halves so lower batches run at 0/6/12/18 UTC and upper batches at 3/9/15/21 UTC.")]
+    [InlineData(0, 1)]
+    [InlineData(3, 3)]
+    [InlineData(6, 1)]
+    [InlineData(9, 3)]
+    [InlineData(12, 1)]
+    [InlineData(15, 3)]
+    [InlineData(18, 1)]
+    [InlineData(21, 3)]
+    public void SelectPasses_on_youtube_hours_covers_both_batch_halves(int hour, int expectedFirstPass)
     {
+        // Arrange / Act
         var (firstPass, _) = HourlyIndexingPassSelector.SelectPasses(hour);
 
-        if (hour % 12 == 0)
-        {
-            firstPass.Should().Be(1, "hours 0 and 12 should index lower batches with YouTube");
-        }
-        else
-        {
-            firstPass.Should().Be(3, "hours 6 and 18 should index upper batches with YouTube");
-        }
+        // Assert
+        firstPass.Should().Be(expectedFirstPass);
     }
 
-    [Fact]
-    public void SelectPasses_each_batch_pair_runs_on_two_youtube_hours_per_day()
+    [Fact(DisplayName =
+        "Each batch half is covered by four YouTube-enabled hours per UTC day under the every-three-hours cadence.")]
+    public void SelectPasses_each_batch_pair_runs_on_four_youtube_hours_per_day()
     {
-        var lowerBatchYouTubeHours = Enumerable.Range(0, 24)
-            .Where(h => h % 6 == 0)
+        // Arrange
+        var youTubeHours = Enumerable.Range(0, 24).Where(h => h % 3 == 0);
+
+        // Act
+        var lowerBatchYouTubeHours = youTubeHours
             .Where(h => HourlyIndexingPassSelector.SelectPasses(h).FirstPass == 1)
             .ToArray();
-
-        var upperBatchYouTubeHours = Enumerable.Range(0, 24)
-            .Where(h => h % 6 == 0)
+        var upperBatchYouTubeHours = youTubeHours
             .Where(h => HourlyIndexingPassSelector.SelectPasses(h).FirstPass == 3)
             .ToArray();
 
-        lowerBatchYouTubeHours.Should().Equal(0, 12);
-        upperBatchYouTubeHours.Should().Equal(6, 18);
+        // Assert
+        lowerBatchYouTubeHours.Should().Equal(0, 6, 12, 18);
+        upperBatchYouTubeHours.Should().Equal(3, 9, 15, 21);
     }
 }

--- a/Cloud/Unit-Tests/Indexer.Tests/IndexingStrategyTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/IndexingStrategyTests.cs
@@ -1,37 +1,86 @@
 using FluentAssertions;
-using Indexer.Activities;
-using Indexer.Models;
-using Indexer.Orchestrations;
 using Indexer.Services;
-using Xunit;
 using RedditPodcastPoster.Configuration.Services;
+using Xunit;
 
 namespace Indexer.Tests;
 
 public class IndexingStrategyTests
 {
-    [Theory]
+    [Theory(DisplayName =
+        "Expensive YouTube queries run only at midnight UTC because unbounded playlist walks must stay on one primary pass per day.")]
     [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(2, false)]
+    [InlineData(3, false)]
+    [InlineData(4, false)]
+    [InlineData(5, false)]
     [InlineData(6, false)]
+    [InlineData(7, false)]
+    [InlineData(8, false)]
+    [InlineData(9, false)]
+    [InlineData(10, false)]
+    [InlineData(11, false)]
     [InlineData(12, false)]
+    [InlineData(13, false)]
+    [InlineData(14, false)]
+    [InlineData(15, false)]
+    [InlineData(16, false)]
+    [InlineData(17, false)]
     [InlineData(18, false)]
+    [InlineData(19, false)]
+    [InlineData(20, false)]
+    [InlineData(21, false)]
+    [InlineData(22, false)]
+    [InlineData(23, false)]
     public void ExpensiveYouTubeQueries_only_runs_at_midnight_utc(int hour, bool expected)
     {
+        // Arrange
         var sut = new IndexingStrategy(new FixedHourDateTimeService(hour));
 
-        sut.ExpensiveYouTubeQueries().Should().Be(expected);
+        // Act
+        var result = sut.ExpensiveYouTubeQueries();
+
+        // Assert
+        result.Should().Be(expected);
     }
 
-    [Theory]
+    [Theory(DisplayName =
+        "YouTube URL resolving runs every three UTC hours so YouTube-authority podcasts are discovered four times per batch half per day.")]
     [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(2, false)]
+    [InlineData(3, true)]
+    [InlineData(4, false)]
+    [InlineData(5, false)]
     [InlineData(6, true)]
+    [InlineData(7, false)]
+    [InlineData(8, false)]
+    [InlineData(9, true)]
+    [InlineData(10, false)]
+    [InlineData(11, false)]
     [InlineData(12, true)]
+    [InlineData(13, false)]
+    [InlineData(14, false)]
+    [InlineData(15, true)]
+    [InlineData(16, false)]
+    [InlineData(17, false)]
     [InlineData(18, true)]
-    public void ResolveYouTube_runs_every_six_hours(int hour, bool expected)
+    [InlineData(19, false)]
+    [InlineData(20, false)]
+    [InlineData(21, true)]
+    [InlineData(22, false)]
+    [InlineData(23, false)]
+    public void ResolveYouTube_runs_every_three_hours(int hour, bool expected)
     {
+        // Arrange
         var sut = new IndexingStrategy(new FixedHourDateTimeService(hour));
 
-        sut.ResolveYouTube().Should().Be(expected);
+        // Act
+        var result = sut.ResolveYouTube();
+
+        // Assert
+        result.Should().Be(expected);
     }
 
     private sealed class FixedHourDateTimeService(int hour) : IDateTimeService

--- a/Cloud/Unit-Tests/Indexer.Tests/YouTubeIndexingDaySpreadRules.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/YouTubeIndexingDaySpreadRules.cs
@@ -1,0 +1,128 @@
+using FluentAssertions;
+using Indexer.Orchestrations;
+using Indexer.Services;
+using RedditPodcastPoster.Configuration.Services;
+using Xunit;
+
+namespace Indexer.Tests;
+
+public class YouTubeIndexingDaySpreadRules
+{
+    private const int IndexPasses = 4;
+
+    [Theory(DisplayName =
+        "A podcast in a given indexer pass receives YouTube resolving on exactly four UTC hours per day at the expected slots for its batch half.")]
+    [InlineData(1, new[] { 0, 6, 12, 18 })]
+    [InlineData(2, new[] { 0, 6, 12, 18 })]
+    [InlineData(3, new[] { 3, 9, 15, 21 })]
+    [InlineData(4, new[] { 3, 9, 15, 21 })]
+    public void youtube_enabled_hours_for_pass_match_expected_day_spread(int pass, int[] expectedHours)
+    {
+        // Arrange / Act
+        var youTubeHours = YouTubeEnabledHoursForPass(pass);
+
+        // Assert
+        youTubeHours.Should().Equal(expectedHours);
+    }
+
+    [Fact(DisplayName =
+        "Every indexer pass is covered by at least one YouTube-enabled hour so any podcast placed in any IndexIdProvider batch still gets YouTube discovery that day.")]
+    public void every_pass_has_youtube_enabled_hours()
+    {
+        // Arrange / Act
+        var passesWithoutYouTube = Enumerable.Range(1, IndexPasses)
+            .Where(pass => YouTubeEnabledHoursForPass(pass).Length == 0)
+            .ToArray();
+
+        // Assert
+        passesWithoutYouTube.Should().BeEmpty();
+    }
+
+    [Theory(DisplayName =
+        "Consecutive YouTube-enabled slots for a pass are at most six hours apart (including midnight wrap) so discovery latency stays bounded under the every-three-hours cadence.")]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void youtube_enabled_hour_gaps_for_pass_are_at_most_six_hours(int pass)
+    {
+        // Arrange
+        var hours = YouTubeEnabledHoursForPass(pass);
+
+        // Act
+        var gaps = Enumerable.Range(0, hours.Length)
+            .Select(i =>
+            {
+                var current = hours[i];
+                var next = hours[(i + 1) % hours.Length];
+                return next > current ? next - current : next + 24 - current;
+            })
+            .ToArray();
+
+        // Assert
+        hours.Should().NotBeEmpty();
+        gaps.Should().OnlyContain(gap => gap > 0 && gap <= 6);
+    }
+
+    [Fact(DisplayName =
+        "Index pass batching places every podcast id in exactly one pass batch, so schedule coverage of passes 1–4 covers the full indexable catalogue.")]
+    public void index_pass_batching_assigns_every_podcast_to_exactly_one_pass()
+    {
+        // Arrange — catalogue size need not divide evenly; remainder joins the last batch
+        var podcastIds = Enumerable.Range(0, 87).Select(_ => Guid.NewGuid()).ToArray();
+
+        // Act
+        var batches = IndexPassBatchSplitter.Split(podcastIds, IndexPasses);
+
+        // Assert
+        batches.Should().HaveCount(IndexPasses);
+        batches.SelectMany(batch => batch).Should().BeEquivalentTo(podcastIds);
+        batches.SelectMany(batch => batch).Should().OnlyHaveUniqueItems();
+        batches.Should().OnlyContain(batch => batch.Length > 0);
+    }
+
+    [Fact(DisplayName =
+        "For every podcast id after batching, the YouTube-enabled hours for its pass match the lower-half or upper-half day spread so no podcast is left without YouTube discovery windows.")]
+    public void every_batched_podcast_receives_expected_youtube_day_spread_for_its_pass()
+    {
+        // Arrange
+        var podcastIds = Enumerable.Range(0, 40).Select(_ => Guid.NewGuid()).ToArray();
+        var batches = IndexPassBatchSplitter.Split(podcastIds, IndexPasses);
+
+        // Act / Assert
+        for (var passIndex = 0; passIndex < batches.Length; passIndex++)
+        {
+            var pass = passIndex + 1;
+            var expectedHours = pass <= 2
+                ? new[] { 0, 6, 12, 18 }
+                : new[] { 3, 9, 15, 21 };
+
+            foreach (var _ in batches[passIndex])
+            {
+                YouTubeEnabledHoursForPass(pass).Should().Equal(expectedHours);
+            }
+        }
+    }
+
+    private static int[] YouTubeEnabledHoursForPass(int pass)
+    {
+        return Enumerable.Range(0, 24)
+            .Where(hour =>
+            {
+                var strategy = new IndexingStrategy(new FixedHourDateTimeService(hour));
+                if (!strategy.ResolveYouTube())
+                {
+                    return false;
+                }
+
+                var (firstPass, lastPass) = HourlyIndexingPassSelector.SelectPasses(hour, IndexPasses);
+                return pass >= firstPass && pass <= lastPass;
+            })
+            .ToArray();
+    }
+
+    private sealed class FixedHourDateTimeService(int hour) : IDateTimeService
+    {
+        public int GetHour() => hour;
+    }
+}

--- a/docs/indexer-youtube-go-live.md
+++ b/docs/indexer-youtube-go-live.md
@@ -5,7 +5,7 @@ Production checklist for deploying the **indexer** (`indexer-infra`) with the fl
 **Related docs:**
 
 - [youtube-keys.md](youtube-keys.md) — key vault naming, slot map, literal app settings
-- [indexing-app-insights-queries.md](indexing-app-insights-queries.md) — KQL validation at 06:00 / 18:00 UTC
+- [indexing-app-insights-queries.md](indexing-app-insights-queries.md) — KQL validation at YouTube-enabled hours
 - [interim-deployment.md](interim-deployment.md) — local deploy when GitHub Actions is offline
 
 ---
@@ -19,10 +19,10 @@ Pacific quota day
 Single flat indexer key ring (slots 1–4, 8–11, 13–16 — config order, deduped)
     │  persisted ring position; hour spread fallback when no state
     ▼
-YouTube enabled when hour % 6 == 0  →  00, 06, 12, 18 UTC
+YouTube enabled when hour % 3 == 0  →  00, 03, 06, 09, 12, 15, 18, 21 UTC
     │
-    ├─ Passes 1–2 at 00 / 12 UTC
-    └─ Passes 3–4 at 06 / 18 UTC
+    ├─ Passes 1–2 at even hours (00 / 06 / 12 / 18 UTC)
+    └─ Passes 3–4 at odd YouTube hours (03 / 09 / 15 / 21 UTC)
 ```
 
 - **Ring exhaustion:** if all keys are exhausted, later passes may run with `skip-youtube='True'`.
@@ -79,16 +79,16 @@ Deploy scripts do **not** change app settings.
 
 ---
 
-## 4. Verify — 06:00 or 18:00 UTC window
+## 4. Verify — YouTube-enabled hour window
 
 See [indexing-app-insights-queries.md](indexing-app-insights-queries.md) for full KQL.
 
 | Step | What to confirm |
 |------|-----------------|
-| Timer fired | `RunHourly initiated hour-utc='6'` or `'18'` |
-| Pass selection | `youtube-enabled-hour='True'` on YouTube hours |
+| Timer fired | `RunHourly initiated` on a YouTube hour (`hour % 3 == 0`) |
+| Pass selection | `youtube-enabled-hour='True'`; passes 1–2 on even hours, 3–4 on odd YouTube hours |
 | Key ring | No sustained `ring exhausted`; rotation only if quota hit |
-| Batch 4 | `skip-youtube='False'`, `success='True'` |
+| Batch 4 | At 03/09/15/21: `skip-youtube='False'`, `success='True'` |
 
 ---
 

--- a/docs/indexing-app-insights-queries.md
+++ b/docs/indexing-app-insights-queries.md
@@ -1,6 +1,6 @@
 # Indexing diagnostics — App Insights / Log Analytics KQL
 
-Operational query reference for diagnosing scheduled indexing failures on **`indexer-infra`**, especially **06:00 / 18:00 UTC** YouTube windows (batches 3–4) and the **Jakub Jahl** case study.
+Operational query reference for diagnosing scheduled indexing failures on **`indexer-infra`**, especially YouTube-enabled hours (`hour % 3 == 0`; batches 3–4 at **03 / 09 / 15 / 21 UTC**) and the **Jakub Jahl** case study.
 
 **Related:** [indexing-investigation-jun2026.md](../indexing-investigation-jun2026.md) — full decision tree, Cosmos checks, deploy notes.
 
@@ -140,9 +140,9 @@ Jakub Jahl is **usually not** YouTube-authority (Spotify/Apple discovery). For J
 
 ---
 
-## 1. Quick start — verify 06:00 / 18:00 run fired
+## 1. Quick start — verify YouTube-enabled upper-batch run fired
 
-YouTube-enabled scheduled indexing for **batch 4** runs only when **passes 3–4** execute at **06:00 or 18:00 UTC** (`hour % 6 == 0`).
+YouTube-enabled scheduled indexing for **batch 4** runs when **passes 3–4** execute at **03 / 09 / 15 / 21 UTC** (`hour % 3 == 0` and odd hour). Lower batches (1–2) get YouTube at **00 / 06 / 12 / 18 UTC**.
 
 ### A. Timer + orchestration scheduled (last 24h)
 
@@ -174,7 +174,7 @@ traces
 | order by timestamp desc
 ```
 
-### B. Pass selection at 06 / 18 (new Warning logs)
+### B. Pass selection at upper-batch YouTube hours (03 / 09 / 15 / 21)
 
 ```kusto
 AppTraces
@@ -185,12 +185,13 @@ AppTraces
 | extend firstPass = extract(@"first-pass='(\d+)'", 1, Message)
 | extend lastPass = extract(@"last-pass='(\d+)'", 1, Message)
 | extend youtubeEnabled = extract(@"youtube-enabled-hour='(True|False)'", 1, Message)
-| where hourUtc in (6, 18)
+| where hourUtc in (3, 9, 15, 21)
 | project TimeGenerated, hourUtc, firstPass, lastPass, youtubeEnabled, Message
 | order by TimeGenerated desc
 ```
 
-**Expect at 06/18:** `first-pass='3'`, `last-pass='4'`, `youtube-enabled-hour='True'`.
+**Expect at 03/09/15/21:** `first-pass='3'`, `last-pass='4'`, `youtube-enabled-hour='True'`.  
+**Expect at 00/06/12/18:** `first-pass='1'`, `last-pass='2'`, `youtube-enabled-hour='True'`.
 
 Legacy fallback (if Warning logs not yet deployed):
 
@@ -199,7 +200,7 @@ traces
 | where timestamp > ago(48h)
 | where cloud_RoleName == "indexer-infra"
 | where message has "Selected indexer passes 3-4"
-| where hourofday(timestamp) in (6, 18)
+| where hourofday(timestamp) in (3, 9, 15, 21)
 | project timestamp, message
 | order by timestamp desc
 ```
@@ -702,7 +703,7 @@ AppTraces
 | order by TimeGenerated asc
 ```
 
-- [ ] `first-pass='3'`, `last-pass='4'`, `youtube-enabled-hour='True'`
+- [ ] Under current cadence, upper-batch YouTube is at **03 / 09 / 15 / 21 UTC** (`first-pass='3'`, `last-pass='4'`, `youtube-enabled-hour='True'`). The Jun 20 06:00 window below is historical (pre every-3h change).
 - [ ] `batch-4-rollup` with `skip-youtube='False'`, `success='True'`, `youtube-error='False'`
 - [ ] Note `operation-id` from `batch-4-rollup` for deep-dive if failed
 
@@ -761,9 +762,9 @@ After 06:55 UTC, confirm prior day report saved (Section 6A) before concluding q
 
 ## 8. Key ring exhaustion — day-by-day comparison
 
-Indexer YouTube uses a **Cosmos-persisted key ring** (`YouTubeIndexerKeyState`) that **resumes within the same Pacific quota day**. Exhaustion at **12:00 UTC** (passes 1–2) leaves **18:00 UTC** (passes 3–4) with no keys. `Rotate indexer api-key` is **Information-level** and usually absent in production; use **`AppExceptions`** with `ring exhausted` and **`YouTubeAuthorityIndexingAudit`** instead.
+Indexer YouTube uses a **Cosmos-persisted key ring** (`YouTubeIndexerKeyState`) that **resumes within the same Pacific quota day**. Exhaustion mid-day leaves later YouTube hours with fewer keys. `Rotate indexer api-key` is **Information-level** and usually absent in production; use **`AppExceptions`** with `ring exhausted` and **`YouTubeAuthorityIndexingAudit`** instead.
 
-**YouTube windows:** hours **0 / 6 / 12 / 18 UTC** (`hour % 6 == 0`). Passes **1–2** at 0/12; passes **3–4** at 6/18.
+**YouTube windows:** hours **0 / 3 / 6 / 9 / 12 / 15 / 18 / 21 UTC** (`hour % 3 == 0`). Passes **1–2** at even YouTube hours (0/6/12/18); passes **3–4** at odd YouTube hours (3/9/15/21).
 
 ### A. Ring exhaustion heatmap (14d)
 


### PR DESCRIPTION
## Summary
- Enable YouTube URL resolving on `hour % 3 == 0` (8×/day) instead of every 6 hours, so YouTube-authority shows like Preacher Boys are discovered sooner.
- Simplify hourly pass selection to even→batches 1–2 / odd→batches 3–4, giving each half four YouTube windows per day (0/6/12/18 and 3/9/15/21 UTC).
- Update Indexer.Tests and ops docs for the new cadence. Quota headroom supports ~2× usage (~15% → ~30% on the working key).

## Test plan
- [x] `dotnet test Cloud/Unit-Tests/Indexer.Tests` — IndexingStrategy + HourlyIndexingPassSelector (passed)
- [x] `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged`
- [ ] Deploy indexer; confirm `HourlyOrchestration pass-selection` shows `youtube-enabled-hour='True'` at 00/03/06/…/21 UTC
- [ ] Confirm passes 1–2 on even YouTube hours and 3–4 on odd YouTube hours
- [ ] After a day or two, check `YouTubeQuotaReport` — expect ~2× units, no ring exhaustion
