### PR TITLE
fix(urlsubmission): exclude library appsettings from publish output

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/RedditPodcastPoster.UrlSubmission.csproj
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/RedditPodcastPoster.UrlSubmission.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Set `CopyToPublishDirectory=Never` on `RedditPodcastPoster.UrlSubmission`’s `appsettings.json` so it no longer collides with `SubmitUrl`’s own `appsettings.json` during `dotnet publish` (NETSDK1152).
- Unblocks `publish-console-apps.ps1` for SubmitUrl after the every-3h indexer deploy.

## Test plan
- [x] `pwsh ./scripts/publish-console-apps.ps1 -App SubmitUrl` succeeds
- [ ] Full `publish-console-apps.ps1` completes with no SubmitUrl failure
