### PR TITLE
feat(matching): multi-criteria catalogue scoring with subject classification

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchScorerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchScorerRules.cs
@@ -1,0 +1,213 @@
+using FluentAssertions;
+using RedditPodcastPoster.Episodes.Matching;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+
+namespace RedditPodcastPoster.Episodes.Tests.BusinessRules.Matching;
+
+/// <summary>
+/// Multi-criteria catalogue match scoring for YouTube-discovered Spotify/Apple enrich.
+/// </summary>
+public class CatalogueMatchScorerRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "Duration within band plus same-calendar-day release alone scores below the match threshold, " +
+        "because Aug 2026 wrong-attach protection forbids duration+day-only accepts.")]
+    public void duration_and_same_day_alone_fails_threshold()
+    {
+        // Arrange
+        const string probeTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string catalogueTitle =
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
+        var length = _fixture.CreateDuration();
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = probeTitle;
+            e.Description = string.Empty;
+            e.Length = length;
+            e.Release = release;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = catalogueTitle;
+            e.Description = string.Empty;
+            e.Length = length;
+            e.Release = release;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+
+        // Assert
+        score.Should().Be(
+            CatalogueMatchScorer.DurationWithinBandPoints +
+            CatalogueMatchScorer.SameCalendarDayReleasePoints);
+        score.Should().BeLessThan(CatalogueMatchScorer.MatchThreshold);
+        CatalogueMatchScorer.MeetsMatchThreshold(probe, catalogue).Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "Duration, same-day release, and one shared classified subject meet the match threshold, " +
+        "so editorial renames that keep a proper noun can still match.")]
+    public void duration_same_day_and_one_shared_subject_meets_threshold()
+    {
+        // Arrange
+        var length = _fixture.CreateDuration();
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var sharedSubject = _fixture.CreateTitle(3);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = length;
+            e.Release = release;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [sharedSubject];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = length;
+            e.Release = release;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [sharedSubject];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+
+        // Assert
+        score.Should().Be(
+            CatalogueMatchScorer.DurationWithinBandPoints +
+            CatalogueMatchScorer.SameCalendarDayReleasePoints +
+            CatalogueMatchScorer.SingleSharedSubjectPoints);
+        CatalogueMatchScorer.MeetsMatchThreshold(probe, catalogue).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "Two shared classified subjects score higher than one shared subject on the subject vector.")]
+    public void two_shared_subjects_score_higher_than_one()
+    {
+        // Arrange
+        var length = _fixture.CreateDuration();
+        var release = DomainTestFixture.UtcDateDaysAgo(2);
+        var subjectA = _fixture.CreateTitle(3);
+        var subjectB = _fixture.CreateTitle(3);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = length;
+            e.Release = release;
+            e.Subjects = [subjectA, subjectB];
+        });
+        var oneShared = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = length;
+            e.Release = release;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [subjectA];
+        });
+        var twoShared = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = length;
+            e.Release = release;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [subjectA, subjectB];
+        });
+
+        // Act
+        var oneScore = CatalogueMatchScorer.Score(probe, oneShared);
+        var twoScore = CatalogueMatchScorer.Score(probe, twoShared);
+
+        // Assert
+        twoScore.Should().Be(oneScore - CatalogueMatchScorer.SingleSharedSubjectPoints +
+                             CatalogueMatchScorer.MultipleSharedSubjectPoints);
+        twoScore.Should().BeGreaterThan(oneScore);
+    }
+
+    [Fact(DisplayName =
+        "Podcast default subject alone does not contribute subject points when supplied as DefaultSubject filter.")]
+    public void default_subject_overlap_is_ignored()
+    {
+        // Arrange
+        var length = _fixture.CreateDuration();
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var defaultSubject = _fixture.CreateTitle(2);
+        var filters = new CatalogueSubjectScoreFilters(DefaultSubject: defaultSubject);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = length;
+            e.Release = release;
+            e.Subjects = [defaultSubject];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = length;
+            e.Release = release;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [defaultSubject];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue, filters);
+
+        // Assert
+        score.Should().Be(
+            CatalogueMatchScorer.DurationWithinBandPoints +
+            CatalogueMatchScorer.SameCalendarDayReleasePoints);
+        CatalogueMatchScorer.MeetsMatchThreshold(probe, catalogue, filters).Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "SelectBestMatch returns the highest-scoring candidate that meets the threshold and null when none do.")]
+    public void select_best_match_picks_highest_scoring_threshold_candidate()
+    {
+        // Arrange
+        var length = _fixture.CreateDuration();
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var sharedSubject = _fixture.CreateTitle(3);
+        var youTubeTitle = _fixture.CreateTitle(4);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = youTubeTitle;
+            e.Length = length;
+            e.Release = release;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [sharedSubject];
+        });
+        var weak = _fixture.CreateEpisode(e =>
+        {
+            e.Title = _fixture.CreateTitle();
+            e.Length = length;
+            e.Release = release;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [];
+        });
+        var strong = _fixture.CreateEpisode(e =>
+        {
+            e.Title = $"{youTubeTitle}: editorial rename";
+            e.Length = length;
+            e.Release = release;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [sharedSubject];
+        });
+
+        // Act
+        var best = CatalogueMatchScorer.SelectBestMatch(probe, [weak, strong]);
+        var none = CatalogueMatchScorer.SelectBestMatch(probe, [weak]);
+
+        // Assert
+        best.Should().BeSameAs(strong);
+        none.Should().BeNull();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -640,13 +640,12 @@ public class CatalogueMatchingRules
     }
 
     [Fact(DisplayName =
-        "When enriching a YouTube-discovered episode whose Spotify title is wholly different, " +
-        "FindCatalogueMatchByLength still matches the sole catalogue row with unique duration " +
-        "inside the expanded twelve-hour release window.")]
-    public void youtube_discovered_unique_duration_within_release_window_matches_without_title_confidence()
+        "Incident (Aug 2026): when enriching a YouTube-discovered episode whose Spotify title is wholly different, " +
+        "FindCatalogueMatchByLength must not match the sole catalogue row on unique duration alone — " +
+        "that path attached the wrong Spotify episode after delay-aligned release windows.")]
+    public void youtube_discovered_unique_duration_within_release_window_rejects_without_title_confidence()
     {
-        // Arrange — serialised-narrative shape: Apple/YouTube title vs editorial Spotify rename;
-        // same length, same day
+        // Arrange — wholly different titles; same length, same day (former no-title acceptance path)
         var storedTitle = _fixture.CreateTitle();
         var spotifyTitle = _fixture.CreateTitle();
         var sharedLength = TimeSpan.FromMinutes(58) + TimeSpan.FromSeconds(34);
@@ -677,14 +676,14 @@ public class CatalogueMatchingRules
             new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
 
         // Assert
-        result.Should().BeSameAs(catalogueItem);
+        result.Should().BeNull();
     }
 
     [Fact(DisplayName =
-        "Incident (Jul 2026): when enriching a YouTube-discovered episode, a date-only Spotify catalogue " +
-        "row from the same calendar day must match on unique duration even though its midnight release " +
-        "sits more than twelve hours from a late-in-the-day YouTube publish.")]
-    public void youtube_discovered_spotify_date_only_same_day_unique_duration_matches_outside_twelve_hours()
+        "Incident (Aug 2026): a date-only Spotify catalogue row from the same calendar day with unique " +
+        "duration but a wholly different title must not match a YouTube-discovered probe — title " +
+        "confidence is required even when midnight Spotify sits more than twelve hours from publish.")]
+    public void youtube_discovered_spotify_date_only_same_day_unique_duration_rejects_without_title_confidence()
     {
         // Arrange — Spotify carries no time-of-day, so its midnight release is 21 hours from the video
         var youTubePublish = DomainTestFixture.UtcAtTime(-3, new TimeSpan(21, 0, 0));
@@ -700,6 +699,89 @@ public class CatalogueMatchingRules
         var spotifyCatalogueItem = _fixture.CreateEpisode(e =>
         {
             e.Title = _fixture.CreateTitle();
+            e.Length = sharedLength;
+            e.Release = spotifyRelease;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+        });
+        var podcast = _fixture.CreatePodcast();
+
+        // Act
+        var result = _matcher.FindCatalogueMatchByLength(
+            probe,
+            [spotifyCatalogueItem],
+            podcast,
+            episodeMatchRegex: null,
+            new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "Incident (Aug 2026): when a negative YouTube publishing delay shifts an older YouTube probe " +
+        "onto a newer Spotify catalogue day, a sole similar-duration Spotify row with a disjoint title " +
+        "must not attach — that is how the wrong Spotify URL landed on a prior Hassan episode.")]
+    public void youtube_discovered_delay_aligned_wrong_episode_rejects_without_title_confidence()
+    {
+        // Arrange — older YouTube episode vs later Spotify with similar length and unrelated title;
+        // probe release is already delay-adjusted (as FindSpotifyEpisodeRequestFactory would set)
+        const string olderYouTubeTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string newerSpotifyTitle =
+            "The World Mission Society Church Of God With A Guest A Decade Inside An Arranged Marriage";
+        var olderYouTubeLength = TimeSpan.FromMinutes(64) + TimeSpan.FromSeconds(8);
+        var newerSpotifyLength = TimeSpan.FromMinutes(62) + TimeSpan.FromSeconds(48);
+        var delayAdjustedProbeRelease = DomainTestFixture.UtcDateDaysAgo(0);
+        var newerSpotifyRelease = DomainTestFixture.UtcDateDaysAgo(0);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = olderYouTubeTitle;
+            e.Length = olderYouTubeLength;
+            e.Release = delayAdjustedProbeRelease;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+        });
+        var wrongCatalogueItem = _fixture.CreateEpisode(e =>
+        {
+            e.Title = newerSpotifyTitle;
+            e.Length = newerSpotifyLength;
+            e.Release = newerSpotifyRelease;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+        });
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+
+        // Act
+        var result = _matcher.FindCatalogueMatchByLength(
+            probe,
+            [wrongCatalogueItem],
+            podcast,
+            episodeMatchRegex: null,
+            new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "When enriching a YouTube-discovered episode, a sole same-day Spotify catalogue row whose title " +
+        "shares containment confidence still matches on unique duration despite midnight date-only release.")]
+    public void youtube_discovered_spotify_date_only_same_day_matches_with_title_confidence()
+    {
+        // Arrange — Spotify title contains the YouTube title (containment confidence);
+        // Spotify midnight vs late YouTube publish
+        var youTubeTitle = _fixture.CreateTitle(4);
+        var youTubePublish = DomainTestFixture.UtcAtTime(-3, new TimeSpan(21, 0, 0));
+        var spotifyRelease = DomainTestFixture.SpotifyCatalogueReleaseDaysAfterYouTube(youTubePublish, 0);
+        var sharedLength = _fixture.CreateDuration();
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = youTubeTitle;
+            e.Length = sharedLength;
+            e.Release = youTubePublish;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+        });
+        var spotifyCatalogueItem = _fixture.CreateEpisode(e =>
+        {
+            e.Title = $"{youTubeTitle}: a decade inside and the exit that followed";
             e.Length = sharedLength;
             e.Release = spotifyRelease;
             e.SpotifyId = _fixture.CreateSpotifyId();

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -563,9 +563,10 @@ public class CatalogueMatchingRules
     }
 
     [Fact(DisplayName =
-        "When enriching a YouTube-discovered episode and duration does not match any catalogue row, " +
-        "FindCatalogueMatchByLength may still select the sole title-aligned row whose release is within twelve hours.")]
-    public void youtube_discovered_release_only_match_within_twelve_hour_window()
+        "When enriching a YouTube-discovered episode and duration is outside the five-minute band, " +
+        "FindCatalogueMatchByLength returns null even when a typo-aligned title sits within twelve hours of release, " +
+        "because multi-criteria scoring requires duration within band before title or release can contribute.")]
+    public void youtube_discovered_release_only_outside_duration_band_returns_null()
     {
         // Arrange
         var sharedTitle = _fixture.CreateShortTitle();
@@ -596,7 +597,7 @@ public class CatalogueMatchingRules
             new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
 
         // Assert
-        result.Should().BeSameAs(releaseAlignedCandidate);
+        result.Should().BeNull();
     }
 
     [Fact(DisplayName =
@@ -605,9 +606,10 @@ public class CatalogueMatchingRules
     public void youtube_discovered_enrichment_does_not_duration_snipe_disjoint_titles()
     {
         // Arrange — YouTube-authority enrichment: titles refer to different interviews; release is days apart
-        const string storedTitle = "My Buddhist Guru Convinced Me Her Ab*se Was Enlightenment";
+        const string storedTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
         const string catalogueTitle =
-            "Growing Up On SISTER WIVES: The Dark Side of Parenting No One Talks About (ft. Mykelti Brown)";
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
         var sharedLength = TimeSpan.FromMinutes(80);
         var probeRelease = DomainTestFixture.UtcAtTime(-30, TimeSpan.FromHours(7));
         var catalogueRelease = probeRelease.AddDays(-5);
@@ -640,14 +642,15 @@ public class CatalogueMatchingRules
     }
 
     [Fact(DisplayName =
-        "Incident (Aug 2026): when enriching a YouTube-discovered episode whose Spotify title is wholly different, " +
-        "FindCatalogueMatchByLength must not match the sole catalogue row on unique duration alone — " +
-        "that path attached the wrong Spotify episode after delay-aligned release windows.")]
-    public void youtube_discovered_unique_duration_within_release_window_rejects_without_title_confidence()
+        "Incident (Aug 2026): when enriching a YouTube-discovered episode, duration plus same-calendar-day release " +
+        "with disjoint titles and empty subjects scores below the multi-criteria threshold and must not match.")]
+    public void youtube_discovered_duration_and_day_with_disjoint_titles_and_empty_subjects_returns_null()
     {
-        // Arrange — wholly different titles; same length, same day (former no-title acceptance path)
-        var storedTitle = _fixture.CreateTitle();
-        var spotifyTitle = _fixture.CreateTitle();
+        // Arrange - duration+day alone is below MatchThreshold; explicit disjoint titles avoid fuzzy flukes
+        const string storedTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string spotifyTitle =
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
         var sharedLength = TimeSpan.FromMinutes(58) + TimeSpan.FromSeconds(34);
         var probeRelease = DomainTestFixture.UtcAtTime(-2, new TimeSpan(19, 0, 0));
         var spotifyRelease = DomainTestFixture.SameCalendarDateWithTime(probeRelease, new TimeSpan(12, 0, 0));
@@ -657,6 +660,7 @@ public class CatalogueMatchingRules
             e.Length = sharedLength;
             e.Release = probeRelease;
             e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
         });
         var catalogueItem = _fixture.CreateEpisode(e =>
         {
@@ -664,6 +668,7 @@ public class CatalogueMatchingRules
             e.Length = sharedLength;
             e.Release = spotifyRelease;
             e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [];
         });
         var podcast = _fixture.CreatePodcast();
 
@@ -681,27 +686,34 @@ public class CatalogueMatchingRules
 
     [Fact(DisplayName =
         "Incident (Aug 2026): a date-only Spotify catalogue row from the same calendar day with unique " +
-        "duration but a wholly different title must not match a YouTube-discovered probe — title " +
-        "confidence is required even when midnight Spotify sits more than twelve hours from publish.")]
-    public void youtube_discovered_spotify_date_only_same_day_unique_duration_rejects_without_title_confidence()
+        "duration but disjoint titles and empty subjects must not match a YouTube-discovered probe - " +
+        "duration+day alone stays below the multi-criteria threshold even when midnight Spotify sits " +
+        "more than twelve hours from publish.")]
+    public void youtube_discovered_spotify_date_only_same_day_duration_without_extra_signals_returns_null()
     {
-        // Arrange — Spotify carries no time-of-day, so its midnight release is 21 hours from the video
+        // Arrange - Spotify carries no time-of-day, so its midnight release is 21 hours from the video
+        const string youTubeTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string spotifyTitle =
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
         var youTubePublish = DomainTestFixture.UtcAtTime(-3, new TimeSpan(21, 0, 0));
         var spotifyRelease = DomainTestFixture.SpotifyCatalogueReleaseDaysAfterYouTube(youTubePublish, 0);
         var sharedLength = _fixture.CreateDuration();
         var probe = _fixture.CreateEpisode(e =>
         {
-            e.Title = _fixture.CreateTitle();
+            e.Title = youTubeTitle;
             e.Length = sharedLength;
             e.Release = youTubePublish;
             e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
         });
         var spotifyCatalogueItem = _fixture.CreateEpisode(e =>
         {
-            e.Title = _fixture.CreateTitle();
+            e.Title = spotifyTitle;
             e.Length = sharedLength;
             e.Release = spotifyRelease;
             e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [];
         });
         var podcast = _fixture.CreatePodcast();
 
@@ -720,10 +732,10 @@ public class CatalogueMatchingRules
     [Fact(DisplayName =
         "Incident (Aug 2026): when a negative YouTube publishing delay shifts an older YouTube probe " +
         "onto a newer Spotify catalogue day, a sole similar-duration Spotify row with a disjoint title " +
-        "must not attach — that is how the wrong Spotify URL landed on a prior Hassan episode.")]
-    public void youtube_discovered_delay_aligned_wrong_episode_rejects_without_title_confidence()
+        "and empty subjects must not attach - that is how the wrong Spotify URL landed on a prior episode.")]
+    public void youtube_discovered_delay_aligned_wrong_episode_rejects_without_multi_criteria_confidence()
     {
-        // Arrange — older YouTube episode vs later Spotify with similar length and unrelated title;
+        // Arrange - older YouTube episode vs later Spotify with similar length and unrelated title;
         // probe release is already delay-adjusted (as FindSpotifyEpisodeRequestFactory would set)
         const string olderYouTubeTitle =
             "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
@@ -739,6 +751,7 @@ public class CatalogueMatchingRules
             e.Length = olderYouTubeLength;
             e.Release = delayAdjustedProbeRelease;
             e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
         });
         var wrongCatalogueItem = _fixture.CreateEpisode(e =>
         {
@@ -746,6 +759,7 @@ public class CatalogueMatchingRules
             e.Length = newerSpotifyLength;
             e.Release = newerSpotifyRelease;
             e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [];
         });
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
 
@@ -759,6 +773,51 @@ public class CatalogueMatchingRules
 
         // Assert
         result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "When enriching a YouTube-discovered episode with duration plus same-calendar-day release and " +
+        "disjoint titles, a single shared classified subject on both Episode.Subjects lifts the score " +
+        "to the multi-criteria threshold and selects the catalogue row.")]
+    public void youtube_discovered_duration_day_and_shared_subject_matches()
+    {
+        // Arrange - duration+day alone is below threshold; one shared subject supplies the rest
+        const string youTubeTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string spotifyTitle =
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
+        var sharedSubject = _fixture.CreateTitle(3);
+        var sharedLength = TimeSpan.FromMinutes(58) + TimeSpan.FromSeconds(34);
+        var probeRelease = DomainTestFixture.UtcAtTime(-2, new TimeSpan(19, 0, 0));
+        var spotifyRelease = DomainTestFixture.SameCalendarDateWithTime(probeRelease, new TimeSpan(12, 0, 0));
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = youTubeTitle;
+            e.Length = sharedLength;
+            e.Release = probeRelease;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [sharedSubject];
+        });
+        var catalogueItem = _fixture.CreateEpisode(e =>
+        {
+            e.Title = spotifyTitle;
+            e.Length = sharedLength;
+            e.Release = spotifyRelease;
+            e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [sharedSubject];
+        });
+        var podcast = _fixture.CreatePodcast();
+
+        // Act
+        var result = _matcher.FindCatalogueMatchByLength(
+            probe,
+            [catalogueItem],
+            podcast,
+            episodeMatchRegex: null,
+            new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
+
+        // Assert
+        result.Should().BeSameAs(catalogueItem);
     }
 
     [Fact(DisplayName =
@@ -1272,10 +1331,11 @@ public class CatalogueMatchingRules
 
     [Fact(DisplayName =
         "When enriching a YouTube-discovered episode and multiple catalogue rows align on release " +
-        "within twelve hours but not on duration, FindCatalogueMatchByLength picks the closest release.")]
-    public void youtube_discovered_multiple_release_only_candidates_picks_closest_release()
+        "within twelve hours but all sit outside the duration band, FindCatalogueMatchByLength returns null " +
+        "because multi-criteria scoring requires duration within band.")]
+    public void youtube_discovered_multiple_release_only_candidates_outside_duration_band_returns_null()
     {
-        // Arrange
+        // Arrange - typo titles avoid early containment; durations outside five-minute band
         var sharedTitle = _fixture.CreateShortTitle();
         var probeLength = TimeSpan.FromMinutes(60);
         var probeRelease = DomainTestFixture.UtcAtTime(-4, _fixture.CreateNonMidnightTimeOfDay());
@@ -1286,6 +1346,7 @@ public class CatalogueMatchingRules
             e.Title = sharedTitle;
             e.Length = probeLength;
             e.Release = probeRelease;
+            e.Subjects = [];
         });
         var closerCandidate = _fixture.CreateEpisode(e =>
         {
@@ -1293,6 +1354,7 @@ public class CatalogueMatchingRules
             e.Length = TimeSpan.FromMinutes(30);
             e.Release = closerRelease;
             e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [];
         });
         var fartherCandidate = _fixture.CreateEpisode(e =>
         {
@@ -1300,6 +1362,7 @@ public class CatalogueMatchingRules
             e.Length = TimeSpan.FromMinutes(35);
             e.Release = fartherRelease;
             e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [];
         });
         var podcast = _fixture.CreatePodcast();
 
@@ -1312,7 +1375,7 @@ public class CatalogueMatchingRules
             new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
 
         // Assert
-        result.Should().BeSameAs(closerCandidate);
+        result.Should().BeNull();
     }
 
     [Fact(DisplayName =
@@ -1387,14 +1450,16 @@ public class CatalogueMatchingRules
         result.Should().BeSameAs(candidateWithoutRelease);
     }
 
+
     [Fact(DisplayName =
-        "Incident (Jul 2026): when enriching a YouTube-discovered episode whose Spotify row is title-confident " +
-        "(editorial prefix + case variation) and whose duration is within five minutes, the match succeeds even " +
-        "though the date-only Spotify release sits two calendar days before the offset-adjusted probe date.")]
-    public void youtube_discovered_title_confident_duration_match_succeeds_when_spotify_date_two_days_before_probe()
+        "Incident (Jul 2026 / Aug 2026): when enriching a YouTube-discovered episode, title containment " +
+        "(editorial prefix + case variation) and duration within five minutes still fail when the date-only " +
+        "Spotify release sits two calendar days before the probe - multi-criteria scoring requires the " +
+        "Spotify catalogue release window before title points can contribute.")]
+    public void youtube_discovered_title_confident_duration_outside_spotify_release_window_returns_null()
     {
-        // Arrange — probe body carries capitals; Spotify row is "<prefix> " + lowercased probe body,
-        // so the case-sensitive containment gate fails and matching must fall to title-confidence.
+        // Arrange - probe body carries capitals; Spotify row is "<prefix> " + lowercased probe body,
+        // so the case-sensitive early containment gate fails and matching falls to CatalogueMatchScorer.
         var probeTitle = "Nightshade: How The Victims Were Silenced";
         var spotifyTitle = "Special Report " + probeTitle.ToLowerInvariant();
         var probeLength = new TimeSpan(0, 25, 19);
@@ -1407,6 +1472,7 @@ public class CatalogueMatchingRules
             e.Length = probeLength;
             e.Release = probeRelease;
             e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
         });
         var spotifyCandidate = _fixture.CreateEpisode(e =>
         {
@@ -1414,6 +1480,7 @@ public class CatalogueMatchingRules
             e.Length = spotifyLength;
             e.Release = spotifyRelease;
             e.SpotifyId = _fixture.CreateSpotifyId();
+            e.Subjects = [];
         });
         var podcast = _fixture.CreatePodcast(p =>
             p.YouTubePublicationOffset = TimeSpan.FromHours(1).Ticks);
@@ -1427,6 +1494,6 @@ public class CatalogueMatchingRules
             new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
 
         // Assert
-        result.Should().BeSameAs(spotifyCandidate);
+        result.Should().BeNull();
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchByLengthOptions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchByLengthOptions.cs
@@ -8,4 +8,6 @@ namespace RedditPodcastPoster.Episodes.Matching;
 public sealed record CatalogueMatchByLengthOptions(
     Service? ReleaseAuthority = null,
     bool AcceptUniqueDurationWithoutTitleMatch = false,
-    bool EnrichingYouTubeDiscoveredEpisode = false);
+    bool EnrichingYouTubeDiscoveredEpisode = false,
+    string? DefaultSubject = null,
+    IReadOnlyList<string>? IgnoredSubjects = null);

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchScorer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchScorer.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Text.Matchers;
+
+namespace RedditPodcastPoster.Episodes.Matching;
+
+/// <summary>
+/// Multi-criteria score for YouTube-discovered Spotify/Apple catalogue enrichment.
+/// Signals add; match when total ≥ <see cref="MatchThreshold"/>.
+/// Duration + in-window release alone stays below threshold (Aug 2026 wrong-attach protection).
+/// Title, description, or subject similarity supply the remaining confidence.
+/// </summary>
+public static class CatalogueMatchScorer
+{
+    public const int MatchThreshold = 60;
+
+    public const int DurationWithinBandPoints = 30;
+    public const int SameCalendarDayReleasePoints = 25;
+    public const int WeakInWindowReleasePoints = 15;
+    public const int FuzzyTitlePoints = 25;
+    public const int SubstringTitlePoints = 20;
+    public const int FuzzyDescriptionPoints = FuzzyTitlePoints;
+    public const int SingleSharedSubjectPoints = 15;
+    public const int MultipleSharedSubjectPoints = 25;
+
+    private const int MinFuzzyTitleScore = 65;
+    private const int MinFuzzyDescriptionScore = 70;
+    private const int DescriptionCompareMaxChars = 500;
+
+    /// <summary>
+    /// Scores a probe against a catalogue candidate that is already within the duration band
+    /// and YouTube-discovered release window. Returns 0 when those preconditions are unmet.
+    /// </summary>
+    public static int Score(
+        Episode probe,
+        Episode catalogueItem,
+        CatalogueSubjectScoreFilters? subjectFilters = null)
+    {
+        if (probe.Length <= TimeSpan.Zero ||
+            Math.Abs((catalogueItem.Length - probe.Length).Ticks) >=
+            TimeSpan.FromMinutes(5).Ticks)
+        {
+            return 0;
+        }
+
+        if (probe.Release == DateTime.MinValue ||
+            !IsWithinReleaseWindow(probe.Release, catalogueItem))
+        {
+            return 0;
+        }
+
+        var score = DurationWithinBandPoints;
+        score += ScoreRelease(probe.Release, catalogueItem);
+        score += ScoreTitle(probe.Title, catalogueItem.Title);
+        score += ScoreDescription(probe.Description, catalogueItem.Description);
+        score += ScoreSubjects(probe.Subjects, catalogueItem.Subjects, subjectFilters);
+        return score;
+    }
+
+    public static bool MeetsMatchThreshold(
+        Episode probe,
+        Episode catalogueItem,
+        CatalogueSubjectScoreFilters? subjectFilters = null) =>
+        Score(probe, catalogueItem, subjectFilters) >= MatchThreshold;
+
+    public static int CountSharedSubjects(
+        IEnumerable<string>? left,
+        IEnumerable<string>? right,
+        CatalogueSubjectScoreFilters? filters = null)
+    {
+        var leftSet = FilterSubjectNames(left, filters);
+        if (leftSet.Count == 0)
+        {
+            return 0;
+        }
+
+        var rightSet = FilterSubjectNames(right, filters);
+        if (rightSet.Count == 0)
+        {
+            return 0;
+        }
+
+        return leftSet.Count(rightSet.Contains);
+    }
+
+    public static Episode? SelectBestMatch(
+        Episode probe,
+        IEnumerable<Episode> candidates,
+        CatalogueSubjectScoreFilters? subjectFilters = null)
+    {
+        Episode? best = null;
+        var bestScore = 0;
+        var bestSharedSubjects = -1;
+        var bestReleaseDelta = long.MaxValue;
+
+        foreach (var candidate in candidates)
+        {
+            var score = Score(probe, candidate, subjectFilters);
+            if (score < MatchThreshold)
+            {
+                continue;
+            }
+
+            var sharedSubjects = CountSharedSubjects(probe.Subjects, candidate.Subjects, subjectFilters);
+            var releaseDelta = probe.Release == DateTime.MinValue
+                ? long.MaxValue
+                : Math.Abs((candidate.Release - probe.Release).Ticks);
+
+            if (best == null ||
+                score > bestScore ||
+                (score == bestScore && sharedSubjects > bestSharedSubjects) ||
+                (score == bestScore &&
+                 sharedSubjects == bestSharedSubjects &&
+                 releaseDelta < bestReleaseDelta))
+            {
+                best = candidate;
+                bestScore = score;
+                bestSharedSubjects = sharedSubjects;
+                bestReleaseDelta = releaseDelta;
+            }
+        }
+
+        return best;
+    }
+
+    private static int ScoreRelease(DateTime probeRelease, Episode catalogueItem)
+    {
+        if (!string.IsNullOrWhiteSpace(catalogueItem.SpotifyId))
+        {
+            if (EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
+                    catalogueItem.Release,
+                    probeRelease))
+            {
+                var probeDate = DateOnly.FromDateTime(probeRelease);
+                var catalogueDate = DateOnly.FromDateTime(catalogueItem.Release);
+                return probeDate == catalogueDate
+                    ? SameCalendarDayReleasePoints
+                    : WeakInWindowReleasePoints;
+            }
+
+            return 0;
+        }
+
+        var delta = Math.Abs((catalogueItem.Release - probeRelease).Ticks);
+        if (delta < TimeSpan.FromHours(12).Ticks)
+        {
+            return EpisodeReleaseTolerance.AreCrossPlatformReleasesOnSameCalendarDay(
+                       catalogueItem.Release,
+                       probeRelease)
+                ? SameCalendarDayReleasePoints
+                : WeakInWindowReleasePoints;
+        }
+
+        return 0;
+    }
+
+    private static bool IsWithinReleaseWindow(DateTime probeRelease, Episode catalogueItem)
+    {
+        if (!string.IsNullOrWhiteSpace(catalogueItem.SpotifyId))
+        {
+            return EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
+                catalogueItem.Release,
+                probeRelease);
+        }
+
+        return Math.Abs((catalogueItem.Release - probeRelease).Ticks) <
+               TimeSpan.FromHours(12).Ticks;
+    }
+
+    private static int ScoreTitle(string probeTitle, string catalogueTitle)
+    {
+        var left = WebUtility.HtmlDecode(probeTitle.Trim());
+        var right = WebUtility.HtmlDecode(catalogueTitle.Trim());
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+        {
+            return 0;
+        }
+
+        if (left.Equals(right, StringComparison.OrdinalIgnoreCase) ||
+            left.Contains(right, StringComparison.OrdinalIgnoreCase) ||
+            right.Contains(left, StringComparison.OrdinalIgnoreCase))
+        {
+            return SubstringTitlePoints;
+        }
+
+        if (FuzzyMatcher.IsMatch(left, new Episode { Title = right }, e => e.Title, MinFuzzyTitleScore))
+        {
+            return FuzzyTitlePoints;
+        }
+
+        return 0;
+    }
+
+    private static int ScoreDescription(string? left, string? right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+        {
+            return 0;
+        }
+
+        var leftSample = TruncateForFuzzyCompare(left);
+        var rightSample = TruncateForFuzzyCompare(right);
+        return FuzzyMatcher.IsMatch(leftSample, rightSample, s => s, MinFuzzyDescriptionScore)
+            ? FuzzyDescriptionPoints
+            : 0;
+    }
+
+    private static int ScoreSubjects(
+        IEnumerable<string>? left,
+        IEnumerable<string>? right,
+        CatalogueSubjectScoreFilters? filters)
+    {
+        var shared = CountSharedSubjects(left, right, filters);
+        return shared switch
+        {
+            >= 2 => MultipleSharedSubjectPoints,
+            1 => SingleSharedSubjectPoints,
+            _ => 0
+        };
+    }
+
+    private static HashSet<string> FilterSubjectNames(
+        IEnumerable<string>? names,
+        CatalogueSubjectScoreFilters? filters)
+    {
+        var ignored = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(filters?.DefaultSubject))
+        {
+            ignored.Add(filters.DefaultSubject);
+        }
+
+        if (filters?.IgnoredSubjects != null)
+        {
+            foreach (var name in filters.IgnoredSubjects)
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    ignored.Add(name);
+                }
+            }
+        }
+
+        return (names ?? [])
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n.Trim())
+            .Where(n => !n.StartsWith('_'))
+            .Where(n => !ignored.Contains(n))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string TruncateForFuzzyCompare(string value)
+    {
+        var trimmed = value.Trim();
+        return trimmed.Length <= DescriptionCompareMaxChars
+            ? trimmed
+            : trimmed[..DescriptionCompareMaxChars];
+    }
+}
+
+/// <summary>
+/// Filters applied when scoring subject overlap for catalogue matching.
+/// </summary>
+public sealed record CatalogueSubjectScoreFilters(
+    string? DefaultSubject = null,
+    IReadOnlyList<string>? IgnoredSubjects = null);

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
@@ -15,7 +15,6 @@ public sealed partial class EpisodePlatformMatcher
     private static readonly long CatalogueBroaderTimeDifferenceThreshold = TimeSpan.FromSeconds(90).Ticks;
     private static readonly long CatalogueYouTubeDiscoveredDurationThreshold = TimeSpan.FromMinutes(5).Ticks;
     private static readonly TimeSpan CatalogueSameReleaseThreshold = TimeSpan.FromHours(3);
-    private static readonly TimeSpan CatalogueYouTubeDiscoveredReleaseThreshold = TimeSpan.FromHours(12);
 
     /// <summary>
     /// Selects the best catalogue episode match by title and duration heuristics
@@ -56,10 +55,10 @@ public sealed partial class EpisodePlatformMatcher
         if (options.EnrichingYouTubeDiscoveredEpisode &&
             probe.Length > TimeSpan.Zero)
         {
-            // Title-confident YouTube-discovered path only. Do not fall through to
-            // same-release / low fuzzy-score matching - that reintroduces wrong-week
-            // Spotify attaches when titles are disjoint (Aug 2026 incident).
-            return FindYouTubeDiscoveredCatalogueMatch(probe, sampleList);
+            // Multi-criteria score (duration, release, title, description, subjects).
+            // Do not fall through to same-release / low fuzzy-score matching — that
+            // reintroduces wrong-week Spotify attaches (Aug 2026 incident).
+            return FindYouTubeDiscoveredCatalogueMatch(probe, sampleList, options);
         }
 
         if (probe.Length <= TimeSpan.Zero)
@@ -208,103 +207,13 @@ public sealed partial class EpisodePlatformMatcher
 
     private static Episode? FindYouTubeDiscoveredCatalogueMatch(
         Episode probe,
-        IList<Episode> sampleList)
-    {
-        var titleConfidentCandidates = sampleList
-            .Where(x => HasCatalogueTitleConfidence(probe.Title, x.Title))
-            .ToList();
-
-        if (titleConfidentCandidates.Count == 0)
-        {
-            // Incident (Aug 2026): unique-duration-within-release-window without title confidence
-            // attached a later Spotify episode to an older YouTube episode when negative YouTube
-            // publishing delay shifted the probe release onto the newer catalogue day. Require
-            // title confidence (exact/containment/fuzzy ≥ CatalogueMinFuzzyScore) for YouTube-
-            // discovered enrichment — editorial renames that share tokens still match.
-            return null;
-        }
-
-        return FindYouTubeDiscoveredCatalogueMatchByDuration(
-            titleConfidentCandidates,
-            probe.Length,
-            probe.Release);
-    }
-
-    /// <summary>
-    /// Spotify catalogue releases are date-only (midnight UTC), so a late-in-the-day YouTube publish
-    /// sits more than twelve hours from its own Spotify row. Compare Spotify rows with the shared
-    /// calendar-day tolerance instead. Apple/YouTube catalogue rows carry a publish time-of-day and
-    /// keep the twelve-hour tick window.
-    /// </summary>
-    private static bool IsWithinYouTubeDiscoveredReleaseWindow(DateTime probeRelease, Episode catalogueItem)
-    {
-        if (!string.IsNullOrWhiteSpace(catalogueItem.SpotifyId))
-        {
-            return EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
-                catalogueItem.Release,
-                probeRelease);
-        }
-
-        return Math.Abs((catalogueItem.Release - probeRelease).Ticks) <
-               CatalogueYouTubeDiscoveredReleaseThreshold.Ticks;
-    }
-
-    private static bool HasCatalogueTitleConfidence(string probeTitle, string candidateTitle)
-    {
-        var left = WebUtility.HtmlDecode(probeTitle.Trim());
-        var right = WebUtility.HtmlDecode(candidateTitle.Trim());
-
-        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
-        {
-            return false;
-        }
-
-        if (left.Equals(right, StringComparison.OrdinalIgnoreCase) ||
-            left.Contains(right, StringComparison.OrdinalIgnoreCase) ||
-            right.Contains(left, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return FuzzyMatcher.IsMatch(left, new Episode { Title = right }, e => e.Title, CatalogueMinFuzzyScore);
-    }
-
-    private static Episode? FindYouTubeDiscoveredCatalogueMatchByDuration(
         IList<Episode> sampleList,
-        TimeSpan episodeLength,
-        DateTime released)
+        CatalogueMatchByLengthOptions options)
     {
-        var sameLength = sampleList
-            .Where(x => Math.Abs((x.Length - episodeLength).Ticks) < CatalogueYouTubeDiscoveredDurationThreshold)
-            .ToList();
-
-        if (sameLength.Count == 1)
-        {
-            return sameLength[0];
-        }
-
-        if (sameLength.Count > 1 && released != DateTime.MinValue)
-        {
-            return sameLength.MinBy(x => Math.Abs((x.Release - released).Ticks));
-        }
-
-        if (released != DateTime.MinValue)
-        {
-            var releaseMatches = sampleList
-                .Where(x => IsWithinYouTubeDiscoveredReleaseWindow(released, x))
-                .ToList();
-            if (releaseMatches.Count == 1)
-            {
-                return releaseMatches[0];
-            }
-
-            if (releaseMatches.Count > 1)
-            {
-                return releaseMatches.MinBy(x => Math.Abs((x.Release - released).Ticks));
-            }
-        }
-
-        return null;
+        var subjectFilters = new CatalogueSubjectScoreFilters(
+            options.DefaultSubject,
+            options.IgnoredSubjects);
+        return CatalogueMatchScorer.SelectBestMatch(probe, sampleList, subjectFilters);
     }
 
     private static long GetCatalogueDurationThresholdTicks(CatalogueMatchByLengthOptions options) =>

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
@@ -56,11 +56,10 @@ public sealed partial class EpisodePlatformMatcher
         if (options.EnrichingYouTubeDiscoveredEpisode &&
             probe.Length > TimeSpan.Zero)
         {
-            var youTubeDiscoveredMatch = FindYouTubeDiscoveredCatalogueMatch(probe, sampleList);
-            if (youTubeDiscoveredMatch != null)
-            {
-                return youTubeDiscoveredMatch;
-            }
+            // Title-confident YouTube-discovered path only. Do not fall through to
+            // same-release / low fuzzy-score matching - that reintroduces wrong-week
+            // Spotify attaches when titles are disjoint (Aug 2026 incident).
+            return FindYouTubeDiscoveredCatalogueMatch(probe, sampleList);
         }
 
         if (probe.Length <= TimeSpan.Zero)
@@ -215,41 +214,20 @@ public sealed partial class EpisodePlatformMatcher
             .Where(x => HasCatalogueTitleConfidence(probe.Title, x.Title))
             .ToList();
 
-        if (titleConfidentCandidates.Count > 0)
+        if (titleConfidentCandidates.Count == 0)
         {
-            var titleConfidentMatch = FindYouTubeDiscoveredCatalogueMatchByDuration(
-                titleConfidentCandidates,
-                probe.Length,
-                probe.Release);
-            if (titleConfidentMatch != null)
-            {
-                return titleConfidentMatch;
-            }
-        }
-
-        // Titles can diverge across platforms (e.g. editorial Spotify rename) while release and
-        // duration still uniquely identify the episode. Accept only a sole duration match that
-        // also falls inside the expanded YouTube-discovered release window — never a bare
-        // unique-duration snipe across weeks.
-        return FindUniqueDurationWithinReleaseWindow(probe, sampleList);
-    }
-
-    private static Episode? FindUniqueDurationWithinReleaseWindow(
-        Episode probe,
-        IList<Episode> sampleList)
-    {
-        if (probe.Release == DateTime.MinValue || probe.Length <= TimeSpan.Zero)
-        {
+            // Incident (Aug 2026): unique-duration-within-release-window without title confidence
+            // attached a later Spotify episode to an older YouTube episode when negative YouTube
+            // publishing delay shifted the probe release onto the newer catalogue day. Require
+            // title confidence (exact/containment/fuzzy ≥ CatalogueMinFuzzyScore) for YouTube-
+            // discovered enrichment — editorial renames that share tokens still match.
             return null;
         }
 
-        var matches = sampleList
-            .Where(x =>
-                Math.Abs((x.Length - probe.Length).Ticks) < CatalogueYouTubeDiscoveredDurationThreshold &&
-                IsWithinYouTubeDiscoveredReleaseWindow(probe.Release, x))
-            .ToList();
-
-        return matches.Count == 1 ? matches[0] : null;
+        return FindYouTubeDiscoveredCatalogueMatchByDuration(
+            titleConfidentCandidates,
+            probe.Length,
+            probe.Release);
     }
 
     /// <summary>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverCatalogueWrapperRules.cs
@@ -7,6 +7,7 @@ using RedditPodcastPoster.PodcastServices.Apple.Models;
 using RedditPodcastPoster.PodcastServices.Apple.Providers;
 using RedditPodcastPoster.PodcastServices.Apple.Resolvers;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
+using RedditPodcastPoster.PodcastServices.Apple.Tests.Fakes;
 
 namespace RedditPodcastPoster.PodcastServices.Apple.Tests;
 
@@ -61,6 +62,7 @@ public class AppleEpisodeResolverCatalogueWrapperRules
         var sut = new AppleEpisodeResolver(
             new StubApplePodcastService(appleEpisodes),
             EpisodeDomainTestServices.CreatePlatformMatcher(),
+            new StubSubjectMatcher(),
             NullLogger<AppleEpisodeResolver>.Instance);
 
         // Act

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverCatalogueWrapperRules.cs
@@ -18,11 +18,12 @@ public class AppleEpisodeResolverCatalogueWrapperRules
     private readonly DomainTestFixture _fixture = new();
 
     [Fact(DisplayName =
-        "When the Apple resolver enriches a YouTube-discovered episode with a unique duration match, " +
-        "it returns the AppleEpisode mapped from the domain matcher result.")]
-    public async Task find_episode_delegates_youtube_discovered_unique_duration_to_domain_matcher()
+        "When the Apple resolver enriches a YouTube-discovered episode with title confidence and a unique " +
+        "duration match, it returns the AppleEpisode mapped from the domain matcher result.")]
+    public async Task find_episode_delegates_youtube_discovered_title_confident_match_to_domain_matcher()
     {
-        // Arrange
+        // Arrange — Apple title contains the YouTube episode title (containment confidence)
+        var youTubeTitle = _fixture.CreateTitle();
         var probeLength = _fixture.CreateDuration();
         var otherLength = probeLength + TimeSpan.FromMinutes(25);
         var probeRelease = DomainTestFixture.UtcAtTime(-3, _fixture.CreateNonMidnightTimeOfDay());
@@ -31,7 +32,7 @@ public class AppleEpisodeResolverCatalogueWrapperRules
         {
             new AppleEpisode(
                 matchingAppleId,
-                _fixture.CreateTitle(),
+                $"{youTubeTitle}: editorial Apple rename",
                 probeRelease.AddHours(-1),
                 probeLength + TimeSpan.FromSeconds(20),
                 new Uri($"https://podcasts.apple.com/us/podcast/episode/id{_fixture.CreateAppleId()}?i={matchingAppleId}"),
@@ -50,7 +51,7 @@ public class AppleEpisodeResolverCatalogueWrapperRules
             _fixture.CreateAppleId(),
             _fixture.CreateTitle(),
             null,
-            _fixture.CreateTitle(),
+            youTubeTitle,
             probeRelease,
             null,
             probeLength,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverTests.cs
@@ -17,36 +17,44 @@ namespace RedditPodcastPoster.PodcastServices.Apple.Tests;
 public class AppleEpisodeResolverTests
 {
     private readonly DomainTestFixture _fixture = new();
-    [Fact]
-    public async Task FindEpisode_WhenYouTubeDiscoveredTitleDiffersButDurationAndReleaseAlign_ReturnsMatch()
+    [Fact(DisplayName =
+        "Incident (Aug 2026): when Apple enriches a YouTube-discovered episode, a sole similar-duration " +
+        "catalogue row with a wholly different title must not match.")]
+    public async Task FindEpisode_WhenYouTubeDiscoveredTitleDiffersButDurationAndReleaseAlign_ReturnsNull()
     {
-        var lookupRelease = new DateTime(2026, 7, 2, 7, 0, 12, DateTimeKind.Utc);
+        // Arrange - explicit disjoint titles (CreateTitle pairs can still clear fuzzy confidence)
+        const string youTubeTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string appleTitle =
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
+        var lookupRelease = DomainTestFixture.UtcAtTime(-1, new TimeSpan(7, 0, 12));
         var episodeLength = TimeSpan.FromMinutes(54) + TimeSpan.FromSeconds(30);
+        var matchingAppleId = _fixture.CreateAppleId();
         var appleEpisodes = new[]
         {
             new AppleEpisode(
-                1000775078015,
-                "My Family Was America's Most Dangerous Cult",
-                new DateTime(2026, 7, 1, 23, 0, 0, DateTimeKind.Utc),
+                matchingAppleId,
+                appleTitle,
+                lookupRelease.AddHours(-8),
                 episodeLength + TimeSpan.FromMinutes(3),
-                new Uri("https://podcasts.apple.com/us/podcast/my-family-was-americas-most-dangerous-cult/id1860966643?i=1000775078015"),
+                new Uri($"https://podcasts.apple.com/us/podcast/episode/id{_fixture.CreateAppleId()}?i={matchingAppleId}"),
                 string.Empty,
                 false),
             new AppleEpisode(
-                1000757443994,
-                "Epstein's survivor: Jena-Lisa Jones Reveals all",
-                new DateTime(2026, 3, 26, 8, 0, 11, DateTimeKind.Utc),
+                _fixture.CreateAppleId(),
+                _fixture.CreateTitle(),
+                DomainTestFixture.UtcDateDaysAgo(90),
                 TimeSpan.FromMinutes(82),
-                new Uri("https://podcasts.apple.com/us/podcast/id1860966643?i=1000757443994"),
+                new Uri($"https://podcasts.apple.com/us/podcast/episode/id{_fixture.CreateAppleId()}?i={_fixture.CreateAppleId()}"),
                 string.Empty,
                 false)
         };
 
         var request = new FindAppleEpisodeRequest(
-            1860966643,
-            "The Shadow Sessions Podcast",
+            _fixture.CreateAppleId(),
+            _fixture.CreateTitle(),
             null,
-            "\"I Grew Up in a Murder Cult\" Cult Survivor Reveals What It's Like To Grow Up Inside It",
+            youTubeTitle,
             lookupRelease,
             null,
             episodeLength,
@@ -58,13 +66,14 @@ public class AppleEpisodeResolverTests
             EpisodeDomainTestServices.CreatePlatformMatcher(),
             NullLogger<AppleEpisodeResolver>.Instance);
 
+        // Act
         var result = await sut.FindEpisode(
             request,
             new IndexingContext(),
             y => Math.Abs((y.Release - lookupRelease).Ticks) < TimeSpan.FromDays(14).Ticks);
 
-        result.Should().NotBeNull();
-        result!.Id.Should().Be(1000775078015);
+        // Assert
+        result.Should().BeNull();
     }
 
     [Fact(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverTests.cs
@@ -11,6 +11,7 @@ using RedditPodcastPoster.PodcastServices.Apple.Providers;
 using RedditPodcastPoster.PodcastServices.Apple.Resolvers;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
 using RedditPodcastPoster.Episodes.Matching;
+using RedditPodcastPoster.PodcastServices.Apple.Tests.Fakes;
 
 namespace RedditPodcastPoster.PodcastServices.Apple.Tests;
 
@@ -64,6 +65,7 @@ public class AppleEpisodeResolverTests
         var sut = new AppleEpisodeResolver(
             new StubApplePodcastService(appleEpisodes),
             EpisodeDomainTestServices.CreatePlatformMatcher(),
+            new StubSubjectMatcher(),
             NullLogger<AppleEpisodeResolver>.Instance);
 
         // Act
@@ -91,7 +93,7 @@ public class AppleEpisodeResolverTests
             _fixture.CreateNonMidnightTimeOfDay());
         var storedLength = _fixture.CreateDuration();
         var storedTitle = _fixture.CreateShortTitle();
-        var appleTitle = DomainTestFixture.CreateFuzzyTitleVariant(storedTitle);
+        var appleTitle = $"{storedTitle}: editorial Apple rename";
         var spotifyId = _fixture.CreateSpotifyId();
         var youTubeId = _fixture.CreateYouTubeId();
         var appleEpisodeId = _fixture.CreateAppleId();
@@ -129,6 +131,7 @@ public class AppleEpisodeResolverTests
         var sut = new AppleEpisodeResolver(
             new StubApplePodcastService(appleEpisodes),
             matcher,
+            new StubSubjectMatcher(),
             NullLogger<AppleEpisodeResolver>.Instance);
 
         // Act

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/Fakes/StubSubjectMatcher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/Fakes/StubSubjectMatcher.cs
@@ -1,0 +1,35 @@
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Subjects;
+using RedditPodcastPoster.Subjects.Matching;
+using RedditPodcastPoster.Subjects.Models;
+
+namespace RedditPodcastPoster.PodcastServices.Apple.Tests.Fakes;
+
+/// <summary>
+/// Optional map from title substring to subject names; default returns no subjects.
+/// </summary>
+sealed class StubSubjectMatcher : ISubjectMatcher
+{
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<string>> _titleSubstringToSubjects;
+
+    public StubSubjectMatcher(IReadOnlyDictionary<string, IReadOnlyList<string>>? titleSubstringToSubjects = null)
+    {
+        _titleSubstringToSubjects = titleSubstringToSubjects ??
+                                    new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public Task<IList<SubjectMatch>> MatchSubjects(Episode episode, SubjectEnrichmentOptions? options = null)
+    {
+        var title = episode.Title ?? string.Empty;
+        var names = _titleSubstringToSubjects
+            .Where(kv => title.Contains(kv.Key, StringComparison.OrdinalIgnoreCase))
+            .SelectMany(kv => kv.Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        IList<SubjectMatch> matches = names
+            .Select(n => new SubjectMatch(new Subject(n), []))
+            .ToList();
+        return Task.FromResult(matches);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Factories/FindAppleEpisodeRequestFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Factories/FindAppleEpisodeRequestFactory.cs
@@ -24,8 +24,10 @@ public static class FindAppleEpisodeRequestFactory
             podcast.ReleaseAuthority,
             episode.Length,
             podcast.YouTubePublishingDelay(),
-            enrichingYouTubeDiscoveredEpisode
-        );
+            enrichingYouTubeDiscoveredEpisode,
+            episode.Description,
+            podcast.DefaultSubject,
+            podcast.IgnoredSubjects);
     }
 
     public static FindAppleEpisodeRequest Create(
@@ -52,7 +54,10 @@ public static class FindAppleEpisodeRequestFactory
             podcast?.ReleaseAuthority,
             criteria.Duration,
             podcast?.YouTubePublishingDelay() ?? null,
-            criteriaFromYouTube);
+            criteriaFromYouTube,
+            criteria.EpisodeDescription,
+            podcast?.DefaultSubject,
+            podcast?.IgnoredSubjects);
     }
 
     public static FindAppleEpisodeRequest Create(long podcastId, long episodeId)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Models/FindAppleEpisodeRequest.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Models/FindAppleEpisodeRequest.cs
@@ -11,4 +11,7 @@ public record FindAppleEpisodeRequest(
     Service? ReleaseAuthority,
     TimeSpan? EpisodeLength,
     TimeSpan? YouTubePublishingDelay,
-    bool EnrichingYouTubeDiscoveredEpisode = false);
+    bool EnrichingYouTubeDiscoveredEpisode = false,
+    string? EpisodeDescription = null,
+    string? DefaultSubject = null,
+    IReadOnlyList<string>? IgnoredSubjects = null);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/RedditPodcastPoster.PodcastServices.Apple.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/RedditPodcastPoster.PodcastServices.Apple.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.Abstractions\RedditPodcastPoster.PodcastServices.Abstractions.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.DependencyInjection\RedditPodcastPoster.DependencyInjection.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.DependencyInjection.Abstractions\RedditPodcastPoster.DependencyInjection.Abstractions.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.Subjects\RedditPodcastPoster.Subjects.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Text\RedditPodcastPoster.Text.csproj" />
   </ItemGroup>
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Resolvers/AppleEpisodeResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Resolvers/AppleEpisodeResolver.cs
@@ -7,12 +7,15 @@ using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.Apple.Models;
 using RedditPodcastPoster.PodcastServices.Apple.Providers;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
+using RedditPodcastPoster.Subjects.Matching;
+using RedditPodcastPoster.Subjects.Models;
 
 namespace RedditPodcastPoster.PodcastServices.Apple.Resolvers;
 
 public class AppleEpisodeResolver(
     ICachedApplePodcastService applePodcastService,
     IEpisodePlatformMatcher platformMatcher,
+    ISubjectMatcher subjectMatcher,
     ILogger<AppleEpisodeResolver> logger)
     : IAppleEpisodeResolver
 {
@@ -58,6 +61,15 @@ public class AppleEpisodeResolver(
                     return source != null && reducer(source);
                 };
 
+            if (request.EnrichingYouTubeDiscoveredEpisode)
+            {
+                await ClassifySubjectsAsync(
+                    probe,
+                    candidates,
+                    request.DefaultSubject,
+                    request.IgnoredSubjects);
+            }
+
             var match = platformMatcher.FindCatalogueMatchByLength(
                 probe,
                 candidates,
@@ -66,7 +78,9 @@ public class AppleEpisodeResolver(
                 new CatalogueMatchByLengthOptions(
                     request.ReleaseAuthority,
                     AcceptUniqueDurationWithoutTitleMatch: false,
-                    request.EnrichingYouTubeDiscoveredEpisode),
+                    request.EnrichingYouTubeDiscoveredEpisode,
+                    request.DefaultSubject,
+                    request.IgnoredSubjects),
                 episodeReducer);
 
             matchingEpisode = match == null
@@ -82,10 +96,42 @@ public class AppleEpisodeResolver(
         return matchingEpisode;
     }
 
+    private async Task ClassifySubjectsAsync(
+        Episode probe,
+        IList<Episode> candidates,
+        string? defaultSubject,
+        IReadOnlyList<string>? ignoredSubjects)
+    {
+        var options = new SubjectEnrichmentOptions(
+            IgnoredAssociatedSubjects: null,
+            IgnoredSubjects: ignoredSubjects?.ToArray(),
+            DefaultSubject: defaultSubject,
+            DescriptionRegex: string.Empty);
+
+        probe.Subjects = await MatchSubjectNamesAsync(probe, options);
+        foreach (var candidate in candidates)
+        {
+            candidate.Subjects = await MatchSubjectNamesAsync(candidate, options);
+        }
+    }
+
+    private async Task<List<string>> MatchSubjectNamesAsync(
+        Episode episode,
+        SubjectEnrichmentOptions options)
+    {
+        var matches = await subjectMatcher.MatchSubjects(episode, options);
+        return matches
+            .Select(x => x.Subject.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     private static Episode CreateProbeEpisode(FindAppleEpisodeRequest request) =>
         new()
         {
             Title = WebUtility.HtmlDecode(request.EpisodeTitle.Trim()),
+            Description = request.EpisodeDescription?.Trim() ?? string.Empty,
             Length = request.EpisodeLength ?? TimeSpan.Zero,
             Release = request.Released ?? DateTime.MinValue
         };
@@ -94,6 +140,7 @@ public class AppleEpisodeResolver(
         new()
         {
             Title = WebUtility.HtmlDecode(episode.Title.Trim()),
+            Description = episode.Description ?? string.Empty,
             Length = episode.Duration,
             Release = episode.Release,
             AppleId = episode.Id

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SearchResultFinderCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SearchResultFinderCatalogueWrapperRules.cs
@@ -1,8 +1,11 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using RedditPodcastPoster.Episodes.TestSupport;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Spotify.Finders;
+using RedditPodcastPoster.PodcastServices.Spotify.Tests.Fakes;
+using RedditPodcastPoster.Text.Sanitisers;
 using SpotifyAPI.Web;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Finders;
@@ -13,7 +16,10 @@ namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Finder
 public class SearchResultFinderCatalogueWrapperRules
 {
     private readonly DomainTestFixture _fixture = new();
-    private readonly SpotifySearchResultFinder _sut = new(EpisodeDomainTestServices.CreatePlatformMatcher());
+    private readonly SpotifySearchResultFinder _sut = new(
+        EpisodeDomainTestServices.CreatePlatformMatcher(),
+        new StubSubjectMatcher(),
+        new HtmlSanitiser(NullLogger<HtmlSanitiser>.Instance));
 
     [Fact(DisplayName =
         "When the Spotify finder resolves by release date, " +
@@ -46,7 +52,7 @@ public class SearchResultFinderCatalogueWrapperRules
     [Fact(DisplayName =
         "When the Spotify finder applies a reducer callback, " +
         "excluded SimpleEpisodes are not returned even when they would otherwise match.")]
-    public void find_by_length_passes_reducer_through_to_domain_matcher()
+    public async Task find_by_length_passes_reducer_through_to_domain_matcher()
     {
         // Arrange
         var sharedTitle = _fixture.CreateTitle();
@@ -73,7 +79,7 @@ public class SearchResultFinderCatalogueWrapperRules
         var assignedIds = new HashSet<string> { assignedId };
 
         // Act
-        var result = _sut.FindMatchingEpisodeByLength(
+        var result = await _sut.FindMatchingEpisodeByLength(
             sharedTitle,
             sharedLength,
             episodes,
@@ -88,9 +94,9 @@ public class SearchResultFinderCatalogueWrapperRules
         "When enriching a YouTube-discovered episode via the Spotify finder, a sole catalogue row " +
         "within five minutes of duration but outside the expanded release window and with a " +
         "disjoint title must not be selected.")]
-    public void find_by_length_youtube_enrichment_does_not_duration_snipe_disjoint_title()
+    public async Task find_by_length_youtube_enrichment_does_not_duration_snipe_disjoint_title()
     {
-        // Arrange — wrong-week YouTube must not claim a later Spotify row on duration alone
+        // Arrange - wrong-week YouTube must not claim a later Spotify row on duration alone
         const string youTubeTitle =
             "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
         const string spotifyTitle =
@@ -112,7 +118,7 @@ public class SearchResultFinderCatalogueWrapperRules
         };
 
         // Act
-        var result = _sut.FindMatchingEpisodeByLength(
+        var result = await _sut.FindMatchingEpisodeByLength(
             youTubeTitle,
             youTubeLength,
             episodes,
@@ -126,10 +132,11 @@ public class SearchResultFinderCatalogueWrapperRules
 
     [Fact(DisplayName =
         "Incident (Aug 2026): when enriching a YouTube-discovered episode via the Spotify finder, a sole " +
-        "catalogue row with unique duration on the same calendar day must not be selected when titles diverge.")]
-    public void find_by_length_youtube_enrichment_rejects_unique_duration_without_title_confidence()
+        "catalogue row with unique duration on the same calendar day must not be selected when titles diverge " +
+        "and no shared classified subjects lift the multi-criteria score to the threshold.")]
+    public async Task find_by_length_youtube_enrichment_rejects_unique_duration_without_title_confidence()
     {
-        // Arrange — YouTube title vs wholly different Spotify rename; same length, same calendar day
+        // Arrange - YouTube title vs wholly different Spotify rename; same length, same calendar day
         const string youTubeTitle =
             "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
         const string spotifyTitle =
@@ -150,7 +157,7 @@ public class SearchResultFinderCatalogueWrapperRules
         };
 
         // Act
-        var result = _sut.FindMatchingEpisodeByLength(
+        var result = await _sut.FindMatchingEpisodeByLength(
             youTubeTitle,
             length,
             episodes,
@@ -166,7 +173,7 @@ public class SearchResultFinderCatalogueWrapperRules
         "Incident (Aug 2026): when enriching a YouTube-discovered episode via the Spotify finder, a sole " +
         "catalogue row with unique duration on the same calendar day must not match without title confidence " +
         "even when the YouTube publish is more than twelve hours after Spotify midnight.")]
-    public void find_by_length_youtube_enrichment_rejects_same_day_spotify_outside_twelve_hours_without_title()
+    public async Task find_by_length_youtube_enrichment_rejects_same_day_spotify_outside_twelve_hours_without_title()
     {
         // Arrange - explicit disjoint titles (random long titles can still clear fuzzy confidence)
         const string youTubeTitle =
@@ -190,7 +197,7 @@ public class SearchResultFinderCatalogueWrapperRules
         (probeRelease - probeRelease.Date).Should().BeGreaterThan(TimeSpan.FromHours(12));
 
         // Act
-        var result = _sut.FindMatchingEpisodeByLength(
+        var result = await _sut.FindMatchingEpisodeByLength(
             youTubeTitle,
             length,
             episodes,
@@ -205,9 +212,9 @@ public class SearchResultFinderCatalogueWrapperRules
     [Fact(DisplayName =
         "When enriching a YouTube-discovered episode via the Spotify finder, a sole same-day catalogue " +
         "row still matches when the Spotify title contains the YouTube title phrase.")]
-    public void find_by_length_youtube_enrichment_accepts_same_day_spotify_with_title_confidence()
+    public async Task find_by_length_youtube_enrichment_accepts_same_day_spotify_with_title_confidence()
     {
-        // Arrange — Spotify title contains the YouTube title (containment confidence)
+        // Arrange - Spotify title contains the YouTube title (containment confidence)
         var youTubeTitle = _fixture.CreateTitle();
         var length = _fixture.CreateDuration();
         var matchingId = _fixture.CreateSpotifyId();
@@ -225,7 +232,7 @@ public class SearchResultFinderCatalogueWrapperRules
         };
 
         // Act
-        var result = _sut.FindMatchingEpisodeByLength(
+        var result = await _sut.FindMatchingEpisodeByLength(
             youTubeTitle,
             length,
             episodes,
@@ -241,9 +248,9 @@ public class SearchResultFinderCatalogueWrapperRules
     [Fact(DisplayName =
         "The Spotify finder never enables AcceptUniqueDurationWithoutTitleMatch: a sole catalogue row " +
         "with matching duration but a title below catalogue fuzzy thresholds is rejected.")]
-    public void find_by_length_never_accepts_unique_duration_without_title_match()
+    public async Task find_by_length_never_accepts_unique_duration_without_title_match()
     {
-        // Arrange — titles chosen so FuzzySharp stays below CatalogueSameLengthMinFuzzyScore (35)
+        // Arrange - titles chosen so FuzzySharp stays below CatalogueSameLengthMinFuzzyScore (35)
         const string probeTitle = "aaaaaaaa";
         const string catalogueTitle = "zzzzzzzz";
         var episodeLength = TimeSpan.FromMinutes(45);
@@ -260,7 +267,7 @@ public class SearchResultFinderCatalogueWrapperRules
         };
 
         // Act
-        var result = _sut.FindMatchingEpisodeByLength(
+        var result = await _sut.FindMatchingEpisodeByLength(
             probeTitle,
             episodeLength,
             episodes,
@@ -273,7 +280,7 @@ public class SearchResultFinderCatalogueWrapperRules
     [Fact(DisplayName =
         "When enriching a YouTube-discovered episode via the Spotify finder, a catalogue row with " +
         "title confidence and duration within five minutes is still selected.")]
-    public void find_by_length_youtube_enrichment_accepts_title_confident_duration_match()
+    public async Task find_by_length_youtube_enrichment_accepts_title_confident_duration_match()
     {
         // Arrange
         var title = _fixture.CreateLongTitle();
@@ -293,7 +300,7 @@ public class SearchResultFinderCatalogueWrapperRules
         };
 
         // Act
-        var result = _sut.FindMatchingEpisodeByLength(
+        var result = await _sut.FindMatchingEpisodeByLength(
             title,
             length,
             episodes,

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SearchResultFinderCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SearchResultFinderCatalogueWrapperRules.cs
@@ -91,8 +91,10 @@ public class SearchResultFinderCatalogueWrapperRules
     public void find_by_length_youtube_enrichment_does_not_duration_snipe_disjoint_title()
     {
         // Arrange — wrong-week YouTube must not claim a later Spotify row on duration alone
-        var youTubeTitle = _fixture.CreateLongTitle();
-        var spotifyTitle = _fixture.CreateLongTitle();
+        const string youTubeTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string spotifyTitle =
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
         var youTubeLength = _fixture.CreateDuration();
         var spotifyLength = youTubeLength + TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(59);
         var matchingId = _fixture.CreateSpotifyId();
@@ -123,13 +125,15 @@ public class SearchResultFinderCatalogueWrapperRules
     }
 
     [Fact(DisplayName =
-        "When enriching a YouTube-discovered episode via the Spotify finder, a sole catalogue row " +
-        "with unique duration on the same calendar day is selected even when titles diverge.")]
-    public void find_by_length_youtube_enrichment_accepts_unique_duration_within_release_window()
+        "Incident (Aug 2026): when enriching a YouTube-discovered episode via the Spotify finder, a sole " +
+        "catalogue row with unique duration on the same calendar day must not be selected when titles diverge.")]
+    public void find_by_length_youtube_enrichment_rejects_unique_duration_without_title_confidence()
     {
         // Arrange — YouTube title vs wholly different Spotify rename; same length, same calendar day
-        var youTubeTitle = _fixture.CreateLongTitle();
-        var spotifyTitle = _fixture.CreateLongTitle();
+        const string youTubeTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string spotifyTitle =
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
         var length = _fixture.CreateDuration();
         var matchingId = _fixture.CreateSpotifyId();
         var spotifyReleaseDate = DomainTestFixture.UtcDateDaysAgo(2);
@@ -145,7 +149,7 @@ public class SearchResultFinderCatalogueWrapperRules
             }
         };
 
-        // Act — probe release within 12h of Spotify midnight UTC
+        // Act
         var result = _sut.FindMatchingEpisodeByLength(
             youTubeTitle,
             length,
@@ -155,19 +159,20 @@ public class SearchResultFinderCatalogueWrapperRules
             enrichingYouTubeDiscoveredEpisode: true);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Id.Should().Be(matchingId);
+        result.Should().BeNull();
     }
 
     [Fact(DisplayName =
-        "When enriching a YouTube-discovered episode via the Spotify finder, a sole catalogue row with " +
-        "unique duration on the same calendar day is selected even when the YouTube publish is more than " +
-        "twelve hours after Spotify midnight, because Spotify catalogue releases are date-only.")]
-    public void find_by_length_youtube_enrichment_accepts_same_day_spotify_outside_twelve_hours()
+        "Incident (Aug 2026): when enriching a YouTube-discovered episode via the Spotify finder, a sole " +
+        "catalogue row with unique duration on the same calendar day must not match without title confidence " +
+        "even when the YouTube publish is more than twelve hours after Spotify midnight.")]
+    public void find_by_length_youtube_enrichment_rejects_same_day_spotify_outside_twelve_hours_without_title()
     {
-        // Arrange
-        var youTubeTitle = _fixture.CreateLongTitle();
-        var spotifyTitle = _fixture.CreateLongTitle();
+        // Arrange - explicit disjoint titles (random long titles can still clear fuzzy confidence)
+        const string youTubeTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string spotifyTitle =
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
         var length = _fixture.CreateDuration();
         var matchingId = _fixture.CreateSpotifyId();
         var afternoonPublish = TimeSpan.FromHours(17) + TimeSpan.FromMinutes(28);
@@ -183,6 +188,41 @@ public class SearchResultFinderCatalogueWrapperRules
             }
         };
         (probeRelease - probeRelease.Date).Should().BeGreaterThan(TimeSpan.FromHours(12));
+
+        // Act
+        var result = _sut.FindMatchingEpisodeByLength(
+            youTubeTitle,
+            length,
+            episodes,
+            releaseAuthority: Service.Spotify,
+            released: probeRelease,
+            enrichingYouTubeDiscoveredEpisode: true);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "When enriching a YouTube-discovered episode via the Spotify finder, a sole same-day catalogue " +
+        "row still matches when the Spotify title contains the YouTube title phrase.")]
+    public void find_by_length_youtube_enrichment_accepts_same_day_spotify_with_title_confidence()
+    {
+        // Arrange — Spotify title contains the YouTube title (containment confidence)
+        var youTubeTitle = _fixture.CreateTitle();
+        var length = _fixture.CreateDuration();
+        var matchingId = _fixture.CreateSpotifyId();
+        var afternoonPublish = TimeSpan.FromHours(17) + TimeSpan.FromMinutes(28);
+        var probeRelease = DomainTestFixture.UtcAtTime(-2, afternoonPublish);
+        var episodes = new List<SimpleEpisode>
+        {
+            new()
+            {
+                Id = matchingId,
+                Name = $"{youTubeTitle}: editorial rename and the exit that followed",
+                DurationMs = (int)length.TotalMilliseconds,
+                ReleaseDate = probeRelease.ToString("yyyy-MM-dd")
+            }
+        };
 
         // Act
         var result = _sut.FindMatchingEpisodeByLength(

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SpotifySearchResultFinderPodcastMatchRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Finders/SpotifySearchResultFinderPodcastMatchRules.cs
@@ -2,6 +2,9 @@ using FluentAssertions;
 using RedditPodcastPoster.Episodes.TestSupport;
 using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
 using RedditPodcastPoster.PodcastServices.Spotify.Finders;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedditPodcastPoster.PodcastServices.Spotify.Tests.Fakes;
+using RedditPodcastPoster.Text.Sanitisers;
 using SpotifyAPI.Web;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Finders;
@@ -12,7 +15,10 @@ namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.BusinessRules.Finder
 public class SpotifySearchResultFinderPodcastMatchRules
 {
     private readonly DomainTestFixture _fixture = new();
-    private readonly SpotifySearchResultFinder _sut = new(EpisodeDomainTestServices.CreatePlatformMatcher());
+    private readonly SpotifySearchResultFinder _sut = new(
+        EpisodeDomainTestServices.CreatePlatformMatcher(),
+        new StubSubjectMatcher(),
+        new HtmlSanitiser(NullLogger<HtmlSanitiser>.Instance));
 
     [Fact(DisplayName =
         "When the podcasts list is null, FindMatchingPodcasts returns an empty sequence " +

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Resolvers/SpotifyEpisodeResolverRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/BusinessRules/Resolvers/SpotifyEpisodeResolverRules.cs
@@ -159,7 +159,11 @@ public class SpotifyEpisodeResolverRules
                 It.IsAny<Func<SimpleEpisode, bool>?>(),
                 It.IsAny<Service?>(),
                 It.IsAny<DateTime?>(),
-                It.IsAny<bool>()),
+                It.IsAny<bool>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
         wrapper.Verify(
             x => x.GetFullEpisode(
@@ -281,8 +285,12 @@ public class SpotifyEpisodeResolverRules
                 reducer,
                 Service.YouTube,
                 released,
-                false))
-            .Returns(catalogueEpisode);
+                false,
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(catalogueEpisode);
         var sut = CreateSut(provider.Object, wrapper.Object, finder.Object);
         var request = new FindSpotifyEpisodeRequest(
             PodcastSpotifyId: _fixture.CreateSpotifyId(),
@@ -307,7 +315,11 @@ public class SpotifyEpisodeResolverRules
                 reducer,
                 Service.YouTube,
                 released,
-                false),
+                false,
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<CancellationToken>()),
             Times.Once);
         finder.Verify(
             x => x.FindMatchingEpisodeByDate(
@@ -360,8 +372,12 @@ public class SpotifyEpisodeResolverRules
                 null,
                 Service.Spotify,
                 released,
-                true))
-            .Returns(catalogueEpisode);
+                true,
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(catalogueEpisode);
         var sut = CreateSut(provider.Object, wrapper.Object, finder.Object);
         var request = new FindSpotifyEpisodeRequest(
             PodcastSpotifyId: _fixture.CreateSpotifyId(),
@@ -388,7 +404,11 @@ public class SpotifyEpisodeResolverRules
                 null,
                 Service.Spotify,
                 released,
-                true),
+                true,
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<CancellationToken>()),
             Times.Once);
         finder.Verify(
             x => x.FindMatchingEpisodeByDate(

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Fakes/CatalogueMatchingTestDoubles.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify.Tests/Fakes/CatalogueMatchingTestDoubles.cs
@@ -1,0 +1,40 @@
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Subjects;
+using RedditPodcastPoster.Subjects.Matching;
+using RedditPodcastPoster.Subjects.Models;
+
+namespace RedditPodcastPoster.PodcastServices.Spotify.Tests.Fakes;
+
+/// <summary>
+/// Optional map from title substring to subject names; default returns no subjects.
+/// </summary>
+sealed class StubSubjectMatcher : ISubjectMatcher
+{
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<string>> _titleSubstringToSubjects;
+
+    public StubSubjectMatcher(IReadOnlyDictionary<string, IReadOnlyList<string>>? titleSubstringToSubjects = null)
+    {
+        _titleSubstringToSubjects = titleSubstringToSubjects ??
+                                    new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public Task<IList<SubjectMatch>> MatchSubjects(Episode episode, SubjectEnrichmentOptions? options = null)
+    {
+        var title = episode.Title ?? string.Empty;
+        var names = _titleSubstringToSubjects
+            .Where(kv => title.Contains(kv.Key, StringComparison.OrdinalIgnoreCase))
+            .SelectMany(kv => kv.Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        IList<SubjectMatch> matches = names
+            .Select(n => new SubjectMatch(new Subject(n), []))
+            .ToList();
+        return Task.FromResult(matches);
+    }
+}
+
+sealed class PassThroughHtmlSanitiser : RedditPodcastPoster.Text.Sanitisers.IHtmlSanitiser
+{
+    public string Sanitise(string htmlDescription) => htmlDescription ?? string.Empty;
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Factories/FindSpotifyEpisodeRequestFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Factories/FindSpotifyEpisodeRequestFactory.cs
@@ -32,7 +32,10 @@ public static class FindSpotifyEpisodeRequestFactory
             podcast?.YouTubePublishingDelay() ?? TimeSpan.Zero,
             podcast?.ReleaseAuthority,
             criteria.Duration,
-            EnrichingYouTubeDiscoveredEpisode: criteriaFromYouTube);
+            EnrichingYouTubeDiscoveredEpisode: criteriaFromYouTube,
+            EpisodeDescription: criteria.EpisodeDescription,
+            DefaultSubject: podcast?.DefaultSubject,
+            IgnoredSubjects: podcast?.IgnoredSubjects);
     }
 
     public static FindSpotifyEpisodeRequest Create(Podcast podcast, Episode episode)
@@ -51,7 +54,10 @@ public static class FindSpotifyEpisodeRequestFactory
             podcast.ReleaseAuthority,
             episode.Length,
             podcast.SpotifyMarket,
-            enrichingYouTubeDiscoveredEpisode);
+            enrichingYouTubeDiscoveredEpisode,
+            episode.Description,
+            podcast.DefaultSubject,
+            podcast.IgnoredSubjects);
     }
 
     public static FindSpotifyEpisodeRequest Create(string episodeSpotifyId)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/ISpotifySearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/ISpotifySearchResultFinder.cs
@@ -14,12 +14,16 @@ public interface ISpotifySearchResultFinder
         string podcastName,
         List<SimpleShow>? podcasts);
 
-    SimpleEpisode? FindMatchingEpisodeByLength(
+    Task<SimpleEpisode?> FindMatchingEpisodeByLength(
         string episodeTitle,
         TimeSpan episodeLength,
         IEnumerable<SimpleEpisode> episodeLists,
         Func<SimpleEpisode, bool>? reducer = null,
         Service? releaseAuthority = null,
         DateTime? released = null,
-        bool enrichingYouTubeDiscoveredEpisode = false);
+        bool enrichingYouTubeDiscoveredEpisode = false,
+        string? episodeDescription = null,
+        string? defaultSubject = null,
+        IReadOnlyList<string>? ignoredSubjects = null,
+        CancellationToken cancellationToken = default);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/SpotifySearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Finders/SpotifySearchResultFinder.cs
@@ -3,11 +3,17 @@ using RedditPodcastPoster.Episodes.Matching;
 using RedditPodcastPoster.Models.Episodes;
 using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Spotify.Extensions;
+using RedditPodcastPoster.Subjects.Matching;
+using RedditPodcastPoster.Subjects.Models;
+using RedditPodcastPoster.Text.Sanitisers;
 using SpotifyAPI.Web;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Finders;
 
-public class SpotifySearchResultFinder(IEpisodePlatformMatcher platformMatcher) : ISpotifySearchResultFinder
+public class SpotifySearchResultFinder(
+    IEpisodePlatformMatcher platformMatcher,
+    ISubjectMatcher subjectMatcher,
+    IHtmlSanitiser htmlSanitiser) : ISpotifySearchResultFinder
 {
     public IEnumerable<SimpleShow> FindMatchingPodcasts(string podcastName, List<SimpleShow>? podcasts)
     {
@@ -19,17 +25,21 @@ public class SpotifySearchResultFinder(IEpisodePlatformMatcher platformMatcher) 
         return podcasts.Where(x => x.Name.ToLower().Trim() == podcastName.ToLower());
     }
 
-    public SimpleEpisode? FindMatchingEpisodeByLength(
+    public async Task<SimpleEpisode?> FindMatchingEpisodeByLength(
         string episodeTitle,
         TimeSpan episodeLength,
         IEnumerable<SimpleEpisode> episodes,
         Func<SimpleEpisode, bool>? reducer = null,
         Service? releaseAuthority = null,
         DateTime? released = null,
-        bool enrichingYouTubeDiscoveredEpisode = false)
+        bool enrichingYouTubeDiscoveredEpisode = false,
+        string? episodeDescription = null,
+        string? defaultSubject = null,
+        IReadOnlyList<string>? ignoredSubjects = null,
+        CancellationToken cancellationToken = default)
     {
-        var probe = CreateProbeEpisode(episodeTitle, episodeLength, released);
-        var candidates = episodes.Select(ToCatalogueEpisode).ToList();
+        var probe = CreateProbeEpisode(episodeTitle, episodeLength, released, episodeDescription);
+        var candidates = episodes.Select(e => ToCatalogueEpisode(e, htmlSanitiser)).ToList();
         Func<Episode, bool>? episodeReducer = reducer == null
             ? null
             : e =>
@@ -38,8 +48,11 @@ public class SpotifySearchResultFinder(IEpisodePlatformMatcher platformMatcher) 
                 return source != null && reducer(source);
             };
 
-        // Match AppleEpisodeResolver: YouTube-discovered enrichment must not accept a sole
-        // duration match without title confidence (prevents wrong-week Spotify sniping).
+        if (enrichingYouTubeDiscoveredEpisode)
+        {
+            await ClassifySubjectsAsync(probe, candidates, defaultSubject, ignoredSubjects, cancellationToken);
+        }
+
         var match = platformMatcher.FindCatalogueMatchByLength(
             probe,
             candidates,
@@ -48,7 +61,9 @@ public class SpotifySearchResultFinder(IEpisodePlatformMatcher platformMatcher) 
             new CatalogueMatchByLengthOptions(
                 ReleaseAuthority: releaseAuthority,
                 AcceptUniqueDurationWithoutTitleMatch: false,
-                EnrichingYouTubeDiscoveredEpisode: enrichingYouTubeDiscoveredEpisode),
+                EnrichingYouTubeDiscoveredEpisode: enrichingYouTubeDiscoveredEpisode,
+                DefaultSubject: defaultSubject,
+                IgnoredSubjects: ignoredSubjects),
             episodeReducer);
 
         return match == null ? null : FindSourceEpisode(episodes, match);
@@ -59,8 +74,8 @@ public class SpotifySearchResultFinder(IEpisodePlatformMatcher platformMatcher) 
         DateTime? episodeRelease,
         IEnumerable<SimpleEpisode> episodes)
     {
-        var probe = CreateProbeEpisode(episodeTitle, TimeSpan.Zero, episodeRelease);
-        var candidates = episodes.Select(ToCatalogueEpisode).ToList();
+        var probe = CreateProbeEpisode(episodeTitle, TimeSpan.Zero, episodeRelease, description: null);
+        var candidates = episodes.Select(e => ToCatalogueEpisode(e, htmlSanitiser)).ToList();
 
         var match = platformMatcher.FindCatalogueMatchByDate(
             probe,
@@ -71,18 +86,59 @@ public class SpotifySearchResultFinder(IEpisodePlatformMatcher platformMatcher) 
         return match == null ? null : FindSourceEpisode(episodes, match);
     }
 
-    private static Episode CreateProbeEpisode(string title, TimeSpan length, DateTime? released) =>
+    private async Task ClassifySubjectsAsync(
+        Episode probe,
+        IList<Episode> candidates,
+        string? defaultSubject,
+        IReadOnlyList<string>? ignoredSubjects,
+        CancellationToken cancellationToken)
+    {
+        var options = new SubjectEnrichmentOptions(
+            IgnoredAssociatedSubjects: null,
+            IgnoredSubjects: ignoredSubjects?.ToArray(),
+            DefaultSubject: defaultSubject,
+            DescriptionRegex: string.Empty);
+
+        probe.Subjects = await MatchSubjectNamesAsync(probe, options, cancellationToken);
+        foreach (var candidate in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            candidate.Subjects = await MatchSubjectNamesAsync(candidate, options, cancellationToken);
+        }
+    }
+
+    private async Task<List<string>> MatchSubjectNamesAsync(
+        Episode episode,
+        SubjectEnrichmentOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var matches = await subjectMatcher.MatchSubjects(episode, options);
+        return matches
+            .Select(x => x.Subject.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static Episode CreateProbeEpisode(
+        string title,
+        TimeSpan length,
+        DateTime? released,
+        string? description) =>
         new()
         {
             Title = WebUtility.HtmlDecode(title.Trim()),
+            Description = description?.Trim() ?? string.Empty,
             Length = length,
             Release = released ?? DateTime.MinValue
         };
 
-    private static Episode ToCatalogueEpisode(SimpleEpisode episode) =>
+    private static Episode ToCatalogueEpisode(SimpleEpisode episode, IHtmlSanitiser htmlSanitiser) =>
         new()
         {
             Title = WebUtility.HtmlDecode(episode.Name.Trim()),
+            Description = htmlSanitiser.Sanitise(episode.HtmlDescription ?? string.Empty),
             Length = episode.GetDuration(),
             Release = episode.GetReleaseDate(),
             SpotifyId = episode.Id

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/FindSpotifyEpisodeRequest.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Models/FindSpotifyEpisodeRequest.cs
@@ -9,8 +9,11 @@ public record FindSpotifyEpisodeRequest(
     string EpisodeTitle,
     DateTime? Released,
     bool HasExpensiveSpotifyEpisodesQuery,
-    TimeSpan? YouTubePublishingDelay= null,
+    TimeSpan? YouTubePublishingDelay = null,
     Service? ReleaseAuthority = null,
     TimeSpan? Length = null,
     string? Market = null,
-    bool EnrichingYouTubeDiscoveredEpisode = false);
+    bool EnrichingYouTubeDiscoveredEpisode = false,
+    string? EpisodeDescription = null,
+    string? DefaultSubject = null,
+    IReadOnlyList<string>? IgnoredSubjects = null);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/RedditPodcastPoster.PodcastServices.Spotify.csproj
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/RedditPodcastPoster.PodcastServices.Spotify.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\RedditPodcastPoster.Episodes\RedditPodcastPoster.Episodes.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.PodcastServices.Abstractions\RedditPodcastPoster.PodcastServices.Abstractions.csproj" />
+    <ProjectReference Include="..\RedditPodcastPoster.Subjects\RedditPodcastPoster.Subjects.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Text\RedditPodcastPoster.Text.csproj" />
   </ItemGroup>
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Resolvers/SpotifyEpisodeResolver.cs
@@ -51,14 +51,17 @@ public class SpotifyEpisodeResolver(
         if (request.Length is { } episodeLength && episodeLength > TimeSpan.Zero &&
             (request.ReleaseAuthority == Service.YouTube || request.EnrichingYouTubeDiscoveredEpisode))
         {
-            matchingEpisode = searchResultFinder.FindMatchingEpisodeByLength(
+            matchingEpisode = await searchResultFinder.FindMatchingEpisodeByLength(
                 request.EpisodeTitle,
                 episodeLength,
                 podcastEpisodes.Episodes,
                 reducer,
                 request.ReleaseAuthority,
                 request.Released,
-                request.EnrichingYouTubeDiscoveredEpisode);
+                request.EnrichingYouTubeDiscoveredEpisode,
+                request.EpisodeDescription,
+                request.DefaultSubject,
+                request.IgnoredSubjects);
         }
         else
         {


### PR DESCRIPTION
## Summary
- Replaces YouTube-discovered Spotify/Apple unique-duration / title-only sniping with multi-criteria `CatalogueMatchScorer` (duration, release, title, description, shared subjects; match threshold 60).
- Duration + same-calendar-day alone stays below threshold; title containment or a shared classified subject can lift a same-day duration pair over the line.
- Spotify/Apple finders classify subjects via `ISubjectMatcher` (plus HTML sanitisation for Spotify descriptions) before catalogue matching; request DTOs carry description / default / ignored subjects.
- Fixes Aug 2026 wrong-attach class (delay-aligned disjoint titles) without accepting duration+day-only matches.

## Test plan
- [x] `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged`
- [x] `dotnet test` Episodes.Tests --filter CatalogueMatch (45 passed)
- [x] `dotnet test` Spotify.Tests --filter SearchResultFinder|SpotifyEpisodeResolver (21 passed)
- [x] `dotnet test` Apple.Tests --filter AppleEpisodeResolver (3 passed)