### PR TITLE
fix(apple): match catalogue when Apple omits duration

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchScorerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchScorerRules.cs
@@ -210,4 +210,80 @@ public class CatalogueMatchScorerRules
         best.Should().BeSameAs(strong);
         none.Should().BeNull();
     }
+
+    [Fact(DisplayName =
+        "When the catalogue row has no duration (Apple omitting durationInMilliseconds), " +
+        "same-calendar-day release and disjoint titles with empty subjects stay below the threshold, " +
+        "because missing duration must not revive release-only attaches.")]
+    public void missing_catalogue_duration_same_day_disjoint_titles_fails_threshold()
+    {
+        // Arrange
+        const string probeTitle =
+            "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+        const string catalogueTitle =
+            "A Decade Inside An Arranged Marriage And The Exit That Followed";
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = probeTitle;
+            e.Description = string.Empty;
+            e.Length = _fixture.CreateDuration();
+            e.Release = release;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = catalogueTitle;
+            e.Description = string.Empty;
+            e.Length = TimeSpan.Zero;
+            e.Release = release;
+            e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+
+        // Assert
+        score.Should().Be(CatalogueMatchScorer.SameCalendarDayReleasePoints);
+        CatalogueMatchScorer.MeetsMatchThreshold(probe, catalogue).Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "When the catalogue row has no duration, same-day release plus fuzzy title and one shared " +
+        "classified subject meet the match threshold, because title and subjects replace duration evidence.")]
+    public void missing_catalogue_duration_same_day_fuzzy_title_and_subject_meets_threshold()
+    {
+        // Arrange
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var sharedSubject = _fixture.CreateTitle(3);
+        var baseTitle = _fixture.CreateTitle(5);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = baseTitle;
+            e.Length = _fixture.CreateDuration();
+            e.Release = release;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [sharedSubject];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = DomainTestFixture.CreateTypoTitleVariant(baseTitle);
+            e.Length = TimeSpan.Zero;
+            e.Release = release;
+            e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [sharedSubject];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+
+        // Assert
+        score.Should().Be(
+            CatalogueMatchScorer.SameCalendarDayReleasePoints +
+            CatalogueMatchScorer.FuzzyTitlePoints +
+            CatalogueMatchScorer.SingleSharedSubjectPoints);
+        CatalogueMatchScorer.MeetsMatchThreshold(probe, catalogue).Should().BeTrue();
+    }
 }

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -563,9 +563,9 @@ public class CatalogueMatchingRules
     }
 
     [Fact(DisplayName =
-        "When enriching a YouTube-discovered episode and duration is outside the five-minute band, " +
+        "When enriching a YouTube-discovered episode and both sides have duration outside the five-minute band, " +
         "FindCatalogueMatchByLength returns null even when a typo-aligned title sits within twelve hours of release, " +
-        "because multi-criteria scoring requires duration within band before title or release can contribute.")]
+        "because multi-criteria scoring requires the duration band when both lengths are present.")]
     public void youtube_discovered_release_only_outside_duration_band_returns_null()
     {
         // Arrange
@@ -598,6 +598,46 @@ public class CatalogueMatchingRules
 
         // Assert
         result.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "When enriching a YouTube-discovered episode and Apple omits catalogue duration, " +
+        "FindCatalogueMatchByLength still returns the title-containment candidate, " +
+        "because missing duration must not empty the match when titles align.")]
+    public void youtube_discovered_missing_catalogue_duration_title_containment_matches()
+    {
+        // Arrange
+        var youTubeTitle = _fixture.CreateTitle();
+        var probeLength = _fixture.CreateDuration();
+        var probeRelease = DomainTestFixture.UtcAtTime(-2, _fixture.CreateNonMidnightTimeOfDay());
+        var appleId = _fixture.CreateAppleId();
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = youTubeTitle;
+            e.Length = probeLength;
+            e.Release = probeRelease;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+        });
+        var appleCandidate = _fixture.CreateEpisode(e =>
+        {
+            e.Title = $"{youTubeTitle}: editorial Apple rename";
+            e.Length = TimeSpan.Zero;
+            e.Release = probeRelease.AddHours(-1);
+            e.AppleId = appleId;
+        });
+        var podcast = _fixture.CreatePodcast();
+
+        // Act
+        var result = _matcher.FindCatalogueMatchByLength(
+            probe,
+            [appleCandidate],
+            podcast,
+            episodeMatchRegex: null,
+            new CatalogueMatchByLengthOptions(EnrichingYouTubeDiscoveredEpisode: true));
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.AppleId.Should().Be(appleId);
     }
 
     [Fact(DisplayName =

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchScorer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchScorer.cs
@@ -9,6 +9,9 @@ namespace RedditPodcastPoster.Episodes.Matching;
 /// Signals add; match when total ≥ <see cref="MatchThreshold"/>.
 /// Duration + in-window release alone stays below threshold (Aug 2026 wrong-attach protection).
 /// Title, description, or subject similarity supply the remaining confidence.
+/// When either side lacks duration (e.g. Apple omitting <c>durationInMilliseconds</c>),
+/// duration points are skipped and duration band is not a hard fail — release window plus
+/// title/description/subjects must still clear the threshold (release alone cannot).
 /// </summary>
 public static class CatalogueMatchScorer
 {
@@ -28,19 +31,28 @@ public static class CatalogueMatchScorer
     private const int DescriptionCompareMaxChars = 500;
 
     /// <summary>
-    /// Scores a probe against a catalogue candidate that is already within the duration band
-    /// and YouTube-discovered release window. Returns 0 when those preconditions are unmet.
+    /// Scores a probe against a catalogue candidate within the YouTube-discovered release window.
+    /// When both sides have duration, requires the ±5 minute band; otherwise scores without
+    /// duration points so Apple catalogue gaps can still match on title/subjects.
     /// </summary>
     public static int Score(
         Episode probe,
         Episode catalogueItem,
         CatalogueSubjectScoreFilters? subjectFilters = null)
     {
-        if (probe.Length <= TimeSpan.Zero ||
-            Math.Abs((catalogueItem.Length - probe.Length).Ticks) >=
-            TimeSpan.FromMinutes(5).Ticks)
+        var probeHasDuration = probe.Length > TimeSpan.Zero;
+        var catalogueHasDuration = catalogueItem.Length > TimeSpan.Zero;
+        var durationInBand = false;
+
+        if (probeHasDuration && catalogueHasDuration)
         {
-            return 0;
+            if (Math.Abs((catalogueItem.Length - probe.Length).Ticks) >=
+                TimeSpan.FromMinutes(5).Ticks)
+            {
+                return 0;
+            }
+
+            durationInBand = true;
         }
 
         if (probe.Release == DateTime.MinValue ||
@@ -49,7 +61,7 @@ public static class CatalogueMatchScorer
             return 0;
         }
 
-        var score = DurationWithinBandPoints;
+        var score = durationInBand ? DurationWithinBandPoints : 0;
         score += ScoreRelease(probe.Release, catalogueItem);
         score += ScoreTitle(probe.Title, catalogueItem.Title);
         score += ScoreDescription(probe.Description, catalogueItem.Description);

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodePlatformMatcher.Catalogue.cs
@@ -52,12 +52,12 @@ public sealed partial class EpisodePlatformMatcher
             ? candidates.Where(reducer).ToList()
             : candidates.ToList();
 
-        if (options.EnrichingYouTubeDiscoveredEpisode &&
-            probe.Length > TimeSpan.Zero)
+        if (options.EnrichingYouTubeDiscoveredEpisode)
         {
             // Multi-criteria score (duration, release, title, description, subjects).
             // Do not fall through to same-release / low fuzzy-score matching — that
             // reintroduces wrong-week Spotify attaches (Aug 2026 incident).
+            // Probe/catalogue may lack duration (Apple catalogue gaps); scorer handles that.
             return FindYouTubeDiscoveredCatalogueMatch(probe, sampleList, options);
         }
 

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple.Tests/AppleEpisodeResolverCatalogueWrapperRules.cs
@@ -73,6 +73,54 @@ public class AppleEpisodeResolverCatalogueWrapperRules
         result!.Id.Should().Be(matchingAppleId);
     }
 
+    [Fact(DisplayName =
+        "When Apple returns a YouTube-discovered catalogue row with zero duration and a title that " +
+        "contains the probe title, the resolver still returns that Apple episode, " +
+        "because Apple omitting durationInMilliseconds must not block title-confident enrich.")]
+    public async Task find_episode_matches_youtube_discovered_when_apple_omits_duration()
+    {
+        // Arrange
+        var youTubeTitle = _fixture.CreateTitle();
+        var probeLength = _fixture.CreateDuration();
+        var probeRelease = DomainTestFixture.UtcAtTime(-3, _fixture.CreateNonMidnightTimeOfDay());
+        var matchingAppleId = _fixture.CreateAppleId();
+        var appleEpisodes = new[]
+        {
+            new AppleEpisode(
+                matchingAppleId,
+                $"{youTubeTitle}: editorial Apple rename",
+                probeRelease.AddHours(-1),
+                TimeSpan.Zero,
+                new Uri($"https://podcasts.apple.com/us/podcast/episode/id{_fixture.CreateAppleId()}?i={matchingAppleId}"),
+                string.Empty,
+                false)
+        };
+        var request = new FindAppleEpisodeRequest(
+            _fixture.CreateAppleId(),
+            _fixture.CreateTitle(),
+            null,
+            youTubeTitle,
+            probeRelease,
+            null,
+            probeLength,
+            null,
+            EnrichingYouTubeDiscoveredEpisode: true);
+
+        var sut = new AppleEpisodeResolver(
+            new StubApplePodcastService(appleEpisodes),
+            EpisodeDomainTestServices.CreatePlatformMatcher(),
+            new StubSubjectMatcher(),
+            NullLogger<AppleEpisodeResolver>.Instance);
+
+        // Act
+        var result = await sut.FindEpisode(request, new IndexingContext());
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(matchingAppleId);
+        result.Duration.Should().Be(TimeSpan.Zero);
+    }
+
     private sealed class StubApplePodcastService(IEnumerable<AppleEpisode> episodes) : ICachedApplePodcastService
     {
         public Task<AppleEpisode?> SingleUseGetEpisode(

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Providers/ApplePodcastService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Providers/ApplePodcastService.cs
@@ -52,24 +52,25 @@ public class ApplePodcastService(
             var appleObject = JsonSerializer.Deserialize<PodcastResponse>(appleJson);
             if (appleObject != null && appleObject.Records.Any())
             {
-                var itemsWithDuration = appleObject.Records.Where(x => x.Attributes.Duration > TimeSpan.Zero);
-                if (!itemsWithDuration.Any())
+                // Apple occasionally omits durationInMilliseconds (catalogue bug). Keep the
+                // episode so title/release/subject matching can still attach; do not require Duration > 0.
+                if (appleObject.Records.Count > 1)
                 {
                     logger.LogError(
-                        "Failure calling apple-api with url '{requestUri}'. No item returned for podcast-episode-query for episode-id '{episodeId}' with duration > 0.",
+                        "Failure calling apple-api with url '{requestUri}'. Multiple items returned for podcast-episode-query for episode-id '{episodeId}'.",
                         requestUri, episodeId);
                     return null;
                 }
 
-                if (itemsWithDuration.Count() > 1)
+                var record = appleObject.Records.Single();
+                if (record.Attributes.Duration <= TimeSpan.Zero)
                 {
-                    logger.LogError(
-                        "Failure calling apple-api with url '{requestUri}'. Multiple items returned for podcast-episode-query for episode-id '{episodeId}' with duration > 0.",
-                        requestUri, episodeId);
-                    return null;
+                    logger.LogWarning(
+                        "Apple episode '{episodeId}' has no duration; keeping for title/release matching.",
+                        episodeId);
                 }
 
-                appleEpisode = itemsWithDuration.Single().ToAppleEpisode();
+                appleEpisode = record.ToAppleEpisode();
             }
         }
         else
@@ -157,27 +158,26 @@ public class ApplePodcastService(
                 requestUri, response.StatusCode, await response.Content.ReadAsStringAsync());
         }
 
-        var appleEpisodes = podcastRecords
-            .Where(x => x.Attributes.Duration > TimeSpan.Zero)
-            .Select(x => x.ToAppleEpisode()).ToArray();
-        if (podcastRecords.Any() && !appleEpisodes.Any())
+        // Keep episodes even when Apple omits durationInMilliseconds. Matching uses title /
+        // release / subjects when length is missing; filtering them out emptied catalogues
+        // (Aug 2026 Unpacking 1619) while Apple still returned the correct episode ids.
+        var appleEpisodes = podcastRecords.Select(x => x.ToAppleEpisode()).ToArray();
+        var withDurationCount = appleEpisodes.Count(x => x.Duration > TimeSpan.Zero);
+        if (podcastRecords.Count > 0 && withDurationCount == 0)
         {
-            logger.LogError(
-                "Missing duration-attribute on all apple-podcast episodes for podcast with apple-podcast-id '{podcastId}'. podcast-records count:'{podcastRecordsCount}',  apple-episodes count:'{appleEpisodesCount}'.",
-                podcastId.PodcastId, podcastRecords.Count, appleEpisodes.Count());
+            logger.LogWarning(
+                "Missing duration-attribute on all apple-podcast episodes for podcast with apple-podcast-id '{podcastId}'. podcast-records count:'{podcastRecordsCount}'. Keeping episodes for title/release matching.",
+                podcastId.PodcastId, podcastRecords.Count);
             foreach (var json in collectedAppleJson)
             {
-                logger.LogError(json);
+                logger.LogWarning(json);
             }
         }
-        else
+        else if (podcastRecords.Count > 0)
         {
-            if (podcastRecords.Count > 0)
-            {
-                logger.LogInformation(
-                    "Successfully found podcast-episodes with duration. Apple-podcast-id '{podcastId}', items-with-duration: '{appleEpisodesCount}/{podcastRecordsCount}'.",
-                    podcastId.PodcastId, appleEpisodes.Count(), podcastRecords.Count);
-            }
+            logger.LogInformation(
+                "Successfully found podcast-episodes. Apple-podcast-id '{podcastId}', items-with-duration: '{withDurationCount}/{podcastRecordsCount}'.",
+                podcastId.PodcastId, withDurationCount, podcastRecords.Count);
         }
 
         return appleEpisodes;


### PR DESCRIPTION
## Summary
- Keep Apple catalogue episodes when `durationInMilliseconds` is missing (Apple catalogue bug emptied shows like Unpacking 1619).
- `CatalogueMatchScorer` no longer hard-fails when either side lacks duration; duration points are skipped and title/release/subjects must still clear the threshold (release-only stays below 60).
- YouTube-discovered enrich still prefers the multi-criteria path; title containment continues to match zero-duration Apple rows.

## Test plan
- [x] `assert-unit-test-guardrails.ps1 -GitChanged`
- [x] `dotnet test` Episodes CatalogueMatch* (48 passed)
- [x] `dotnet test` AppleEpisodeResolverCatalogue* (2 passed)
- [ ] After deploy: re-index Unpacking 1619; confirm Apple `1000779812574` attaches to episode `81c3f0fd-…`
- [ ] Confirm Hassan-shaped duration+day / release-only rejects remain green in CI