### PR TITLE
fix(matching): Apple-authority release adopt, subject DI, and enrich scoring

### DIFF
--- a/.cursor/rules/deploy-functions-and-clis.mdc
+++ b/.cursor/rules/deploy-functions-and-clis.mdc
@@ -1,0 +1,50 @@
+---
+description: When user says "deploy functions & clis" — non-interactive Function deploys then publish console apps
+alwaysApply: true
+---
+
+# Deploy functions & CLIs (phrase → actions)
+
+When the user says **deploy functions & clis** (or clearly equivalent: "deploy functions and CLIs", "deploy funcs & clis"), run this sequence from the **RedditPodcastPoster** repo root. Do **not** ask for confirmation beyond the phrase itself — that phrase is explicit deploy approval.
+
+## 1. Function apps (order is mandatory)
+
+Non-interactive: pass all four Azure target args so `Resolve-DeploySettings` skips `Read-Host`, and use `-Confirm:$false` for `ShouldProcess`.
+
+Load targets from the matching gitignored JSON under `scripts/` (`deploy-indexer.json`, `deploy-discover.json`, `deploy-api.json`) — or hardcode the known prod values below if JSON is missing.
+
+| Order | Script | App | Container |
+|------:|--------|-----|-----------|
+| 1 | `.\scripts\deploy-indexer.ps1` | `indexer-infra` | `indexer-deployment` |
+| 2 | `.\scripts\deploy-discover.ps1` | `discover-infra` | `discovery-deployment` |
+| 3 | `.\scripts\deploy-api.ps1` | `api-infra` | `api-deployment` |
+
+Shared: `-ResourceGroup AutomatedInfra` `-StorageAccount cultpodcastsstg` `-Confirm:$false`
+
+Example (Indexer; repeat pattern for Discover then Api):
+
+```powershell
+.\scripts\deploy-indexer.ps1 `
+  -ResourceGroup AutomatedInfra `
+  -AppName indexer-infra `
+  -StorageAccount cultpodcastsstg `
+  -DeploymentContainer indexer-deployment `
+  -Confirm:$false
+```
+
+Stop the sequence if a deploy exits non-zero; do not continue to the next app or to CLIs.
+
+## 2. Console apps
+
+```powershell
+.\scripts\publish-console-apps.ps1 -Confirm:$false
+```
+
+Publishes to `artifacts\tools\` (all console apps except `ThrowawayConsole`).
+
+## Do not
+
+- Prompt "Use these details? (Y/n)" — always pass explicit `-ResourceGroup` / `-AppName` / `-StorageAccount` / `-DeploymentContainer`
+- Reorder Function deploys (Indexer → Discover → Api only)
+- Use GitHub Actions / Kudu as the deploy path for this phrase
+- Skip console publish unless the user said only "deploy functions"

--- a/.cursor/rules/deployment.mdc
+++ b/.cursor/rules/deployment.mdc
@@ -23,7 +23,7 @@ Wrappers resolve Azure targets (JSON + interactive prompts via `Resolve-DeploySe
 1. **NEVER delete or rename `scripts/deploy-*.ps1`** without explicit user approval.
 2. **NEVER change the deploy mechanism** — OneDeploy modes (`FlexBlob` / `FunctionAppDeploy`), blob upload flow, app settings, Kudu/SAS paths — without explicit user approval.
 3. **Local deploy must stay 1:1 with CI** — compare changes to [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml) and [`Infrastructure/function.bicep`](../../Infrastructure/function.bicep) / [`functions.bicep`](../../Infrastructure/functions.bicep) first. Justify as "CI equivalent on Windows", not a new Azure integration.
-4. **Do not run production deploy** (`az login` + deploy scripts, `az functionapp restart`, blob upload to `cultpodcastsstg`) unless the user explicitly asks.
+4. **Do not run production deploy** (`az login` + deploy scripts, `az functionapp restart`, blob upload to `cultpodcastsstg`) unless the user explicitly asks — **except** when they say **deploy functions & clis** (see [deploy-functions-and-clis.mdc](deploy-functions-and-clis.mdc)).
 5. **Never modify app settings** during code deploy — settings come from bicep only.
 6. **Document** behaviour changes in `docs/deployment.md`.
 

--- a/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.TestSupport/Fixtures/DomainTestFixture.cs
@@ -455,6 +455,25 @@ public sealed class DomainTestFixture
       p.ReleaseAuthority = Service.Spotify;
     });
 
+  /// <summary>Podcast with Apple release authority (<see cref="Podcast.ReleaseAuthority"/> = <see cref="Service.Apple"/>).</summary>
+  public Podcast CreateAppleReleaseAuthorityPodcast(
+    long applePodcastId,
+    string? spotifyShowId = null,
+    long? youTubePublicationOffsetTicks = null,
+    Guid? id = null) =>
+    CreatePodcast(p =>
+    {
+      if (id.HasValue)
+        p.Id = id.Value;
+      p.Name = "Apple release authority podcast";
+      p.ReleaseAuthority = Service.Apple;
+      p.AppleId = applePodcastId;
+      p.SpotifyId = spotifyShowId ?? CreateSpotifyId();
+      p.YouTubeChannelId = CreateYouTubeChannelId();
+      if (youTubePublicationOffsetTicks.HasValue)
+        p.YouTubePublicationOffset = youTubePublicationOffsetTicks.Value;
+    });
+
   /// <summary>Podcast with YouTube release authority (<see cref="Podcast.ReleaseAuthority"/> = <see cref="Service.YouTube"/>).</summary>
   public Podcast CreateYouTubeReleaseAuthorityPodcast(
     string channelId,
@@ -654,8 +673,10 @@ public sealed class DomainTestFixture
     var delay = podcast.YouTubePublishingDelay();
     var youTubeRelease = UtcAtTime(-40, TimeSpan.FromHours(15));
     var expectedAudioRelease = youTubeRelease - delay;
-    // Three calendar days off expected audio — inside ±5 catalogue day tolerance, outside 1-day delay align.
-    var incomingRelease = expectedAudioRelease.Date.AddDays(3);
+    // Five calendar days off expected audio — outside ±3d near-delay proximity and ±1d full
+    // align, still inside ±5 catalogue-day tolerance for release strategies. Scoring must not
+    // reach the cross-platform match threshold (#869 false-positive shape).
+    var incomingRelease = expectedAudioRelease.Date.AddDays(5);
     var storedLength = CreateDuration();
     var incomingLength = storedLength - TimeSpan.FromSeconds(5);
 

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/AppleAuthorityAudioReleaseLookupRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/AppleAuthorityAudioReleaseLookupRules.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using RedditPodcastPoster.Episodes.Matching;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+
+namespace RedditPodcastPoster.Episodes.Tests.BusinessRules.Matching;
+
+public class AppleAuthorityAudioReleaseLookupRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "GetAudioReleaseForPlatformLookup does not subtract YouTubePublicationOffset when Apple is " +
+        "release authority and the episode already has Apple identity (release is audio-shaped).")]
+    public void apple_authority_with_apple_and_youtube_does_not_subtract_delay()
+    {
+        // Arrange
+        var delay = TimeSpan.FromDays(2) + TimeSpan.FromHours(7);
+        var podcast = _fixture.CreateAppleReleaseAuthorityPodcast(
+            _fixture.CreateAppleId(),
+            youTubePublicationOffsetTicks: delay.Ticks);
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-4, TimeSpan.FromHours(12));
+        var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast, release: youTubeRelease);
+        var appleId = _fixture.CreateAppleId();
+        episode.AppleId = appleId;
+        episode.Urls.Apple = _fixture.DefaultAppleUrl(appleId);
+
+        // Act
+        var lookup = EpisodeReleaseTolerance.GetAudioReleaseForPlatformLookup(podcast, episode);
+
+        // Assert
+        lookup.Should().Be(youTubeRelease);
+    }
+
+    [Fact(DisplayName =
+        "GetAudioReleaseForPlatformLookup still subtracts YouTubePublicationOffset when Apple is " +
+        "release authority but the episode has YouTube only (release is still YouTube-shaped).")]
+    public void apple_authority_youtube_only_subtracts_delay()
+    {
+        // Arrange
+        var delay = TimeSpan.FromDays(2) + TimeSpan.FromHours(7);
+        var podcast = _fixture.CreateAppleReleaseAuthorityPodcast(
+            _fixture.CreateAppleId(),
+            youTubePublicationOffsetTicks: delay.Ticks);
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-4, TimeSpan.FromHours(12));
+        var episode = _fixture.CreateStoredEpisodeWithYouTubeOnly(podcast, release: youTubeRelease);
+
+        // Act
+        var lookup = EpisodeReleaseTolerance.GetAudioReleaseForPlatformLookup(podcast, episode);
+
+        // Assert
+        lookup.Should().Be(youTubeRelease - delay);
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchScorerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CrossPlatformMatchScorerRules.cs
@@ -17,11 +17,14 @@ public class CrossPlatformMatchScorerRules
         "Delay-aligned release plus duration scores 70 and meets the match threshold without title confidence.")]
     public void Delay_aligned_release_and_duration_meets_threshold_without_title()
     {
+        // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var (youTube, audio) = CreateDelayAlignedDivergentPair(podcast);
 
+        // Act
         var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
 
+        // Assert
         score.Should().Be(
             CrossPlatformMatchScorer.DurationWithinBandPoints +
             CrossPlatformMatchScorer.DelayAlignedReleasePoints);
@@ -32,6 +35,7 @@ public class CrossPlatformMatchScorerRules
         "Same-calendar-day release plus duration scores exactly 60 and meets the match threshold without title.")]
     public void Same_calendar_day_release_and_duration_meets_threshold_at_boundary()
     {
+        // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var youTubeRelease = DomainTestFixture.UtcAtTime(-10, TimeSpan.FromHours(15));
         var audioRelease = youTubeRelease.Date.Add(TimeSpan.FromHours(8));
@@ -50,8 +54,10 @@ public class CrossPlatformMatchScorerRules
         EpisodeReleaseTolerance.AreCrossPlatformReleasesOnSameCalendarDay(audioRelease, youTubeRelease)
             .Should().BeTrue();
 
+        // Act
         var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
 
+        // Assert
         score.Should().Be(CrossPlatformMatchScorer.MatchThreshold);
         CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeTrue();
     }
@@ -60,14 +66,18 @@ public class CrossPlatformMatchScorerRules
         "Weak catalogue-day release plus duration scores 45 and stays below the match threshold without title.")]
     public void Weak_catalogue_release_and_duration_stays_below_threshold()
     {
+        // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var (youTube, audio) = _fixture.CreateNegativeDelayNonMatchingPair(podcast);
 
+        // Act
         var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
 
+        // Assert
         score.Should().Be(
             CrossPlatformMatchScorer.DurationWithinBandPoints +
             CrossPlatformMatchScorer.WeakCatalogueReleasePoints);
+        // Assert
         score.Should().BeLessThan(CrossPlatformMatchScorer.MatchThreshold);
         CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeFalse();
     }
@@ -77,12 +87,15 @@ public class CrossPlatformMatchScorerRules
         "meets the threshold even when marketing titles are wholly disjoint.")]
     public void Early_within_delay_with_matching_descriptions_meets_threshold()
     {
+        // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var (youTube, audio, _) =
             _fixture.CreateYouTubeAuthorityNegativeOffsetEarlyAudioPair(podcast, matchingTitles: false);
 
+        // Act
         var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
 
+        // Assert
         score.Should().Be(
             CrossPlatformMatchScorer.DurationWithinBandPoints +
             CrossPlatformMatchScorer.WeakCatalogueReleasePoints +
@@ -94,10 +107,11 @@ public class CrossPlatformMatchScorerRules
         "Weak catalogue-day release plus duration plus fuzzy title reaches 70 and meets the match threshold.")]
     public void Weak_catalogue_release_with_fuzzy_title_meets_threshold()
     {
+        // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var delay = podcast.YouTubePublishingDelay();
         var youTubeRelease = DomainTestFixture.UtcAtTime(-40, TimeSpan.FromHours(15));
-        var audioRelease = (youTubeRelease - delay).Date.AddDays(3);
+        var audioRelease = (youTubeRelease - delay).Date.AddDays(5);
         var length = TimeSpan.FromMinutes(55);
         const string baseTitle = "Holy Disobedience Inside the Seventh-day Adventist Church";
         var (youTube, audio) = CreateYouTubeAudioPair(
@@ -108,8 +122,10 @@ public class CrossPlatformMatchScorerRules
             baseTitle,
             baseTitle + " with Melissa Duge Spiers");
 
+        // Act
         var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
 
+        // Assert
         score.Should().Be(
             CrossPlatformMatchScorer.DurationWithinBandPoints +
             CrossPlatformMatchScorer.WeakCatalogueReleasePoints +
@@ -122,10 +138,11 @@ public class CrossPlatformMatchScorerRules
         "65 and meets the match threshold (title points push past the 45 weak-release floor).")]
     public void Weak_catalogue_release_with_substring_title_meets_threshold()
     {
+        // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var delay = podcast.YouTubePublishingDelay();
         var youTubeRelease = DomainTestFixture.UtcAtTime(-40, TimeSpan.FromHours(15));
-        var audioRelease = (youTubeRelease - delay).Date.AddDays(3);
+        var audioRelease = (youTubeRelease - delay).Date.AddDays(5);
         var length = TimeSpan.FromMinutes(55);
         // Short core contained in a longer title: substring relationship; may also fuzzy-match.
         const string core = "zkq-match-core-token";
@@ -137,25 +154,30 @@ public class CrossPlatformMatchScorerRules
             core,
             "Broadcast archive " + core + " extended cut");
 
+        // Act
         var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
         var weakFloor =
             CrossPlatformMatchScorer.DurationWithinBandPoints +
             CrossPlatformMatchScorer.WeakCatalogueReleasePoints;
 
+        // Assert
         score.Should().BeOneOf(
             weakFloor + CrossPlatformMatchScorer.SubstringTitlePoints,
             weakFloor + CrossPlatformMatchScorer.FuzzyTitlePoints);
+        // Assert
         score.Should().BeGreaterThanOrEqualTo(CrossPlatformMatchScorer.MatchThreshold);
         CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeTrue();
     }
 
     [Fact(DisplayName =
-        "Delay-aligned release takes precedence over same-calendar-day: release tiers are mutually exclusive.")]
+        "Delay-aligned release takes precedence over same-calendar-day via max of delay-proximity and " +
+        "calendar-day points — tiers do not stack.")]
     public void Delay_aligned_release_tier_does_not_stack_same_calendar_day_points()
     {
+        // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         podcast.YouTubePublicationOffset = TimeSpan.FromHours(-8).Ticks;
-        var audioRelease = new DateTime(2026, 7, 13, 8, 0, 0, DateTimeKind.Utc);
+        var audioRelease = DomainTestFixture.UtcAtTime(-20, TimeSpan.FromHours(8));
         var youTubeRelease = audioRelease.Add(podcast.YouTubePublishingDelay());
         youTubeRelease.Date.Should().Be(audioRelease.Date, "same calendar day while delay-aligned");
         var length = TimeSpan.FromMinutes(62);
@@ -167,8 +189,10 @@ public class CrossPlatformMatchScorerRules
             "Alpha market briefing on early catalogue drift signals",
             "Omega wellness interview about unrelated guest journeys");
 
+        // Act
         var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
 
+        // Assert
         score.Should().Be(
             CrossPlatformMatchScorer.DurationWithinBandPoints +
             CrossPlatformMatchScorer.DelayAlignedReleasePoints);
@@ -179,9 +203,46 @@ public class CrossPlatformMatchScorerRules
     }
 
     [Fact(DisplayName =
+        "YouTube publish within three days of audioRelease + YouTubePublishingDelay earns near-delay " +
+        "proximity points (25) so delay difference is scored without requiring full ±1-day alignment.")]
+    public void Near_delay_aligned_release_earns_partial_proximity_points()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var delay = podcast.YouTubePublishingDelay();
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-40, TimeSpan.FromHours(15));
+        var expectedAudio = youTubeRelease - delay;
+        // Two days off expected audio — outside ±1d full align, inside ±3d near-align; not same calendar day.
+        var audioRelease = expectedAudio.Date.AddDays(2).Add(TimeSpan.FromHours(10));
+        EpisodeReleaseTolerance.IsYouTubePublishDelayAligned(audioRelease, youTubeRelease, delay)
+            .Should().BeFalse();
+        EpisodeReleaseTolerance.AreCrossPlatformReleasesOnSameCalendarDay(audioRelease, youTubeRelease)
+            .Should().BeFalse();
+        var length = TimeSpan.FromMinutes(55);
+        var (youTube, audio) = CreateYouTubeAudioPair(
+            podcast,
+            youTubeRelease,
+            audioRelease,
+            length,
+            "Alpha market briefing on early catalogue drift signals",
+            "Omega wellness interview about unrelated guest journeys");
+
+        // Act
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        // Assert
+        score.Should().Be(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.NearDelayAlignedReleasePoints);
+        score.Should().BeLessThan(CrossPlatformMatchScorer.MatchThreshold);
+    }
+
+    [Fact(DisplayName =
         "Fifty-nine is below threshold and sixty meets it — MeetsMatchThreshold uses inclusive comparison.")]
     public void Match_threshold_is_inclusive_at_sixty()
     {
+        // Arrange
+        // Assert
         CrossPlatformMatchScorer.MatchThreshold.Should().Be(60);
         (CrossPlatformMatchScorer.DurationWithinBandPoints +
          CrossPlatformMatchScorer.SameCalendarDayReleasePoints)
@@ -199,11 +260,82 @@ public class CrossPlatformMatchScorerRules
         "Score is symmetric for YouTube-stored/audio-incoming and audio-stored/YouTube-incoming argument order.")]
     public void Score_is_symmetric_for_youtube_and_audio_argument_order()
     {
+        // Arrange
         var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
         var (youTube, audio) = CreateDelayAlignedDivergentPair(podcast);
 
+        // Act
+        // Assert
         CrossPlatformMatchScorer.Score(youTube, audio, podcast)
             .Should().Be(CrossPlatformMatchScorer.Score(audio, youTube, podcast));
+    }
+
+    [Fact(DisplayName =
+        "Weak catalogue-day release plus duration plus one shared classified subject scores 60 and " +
+        "meets the match threshold without title confidence.")]
+    public void Weak_catalogue_release_with_one_shared_subject_meets_threshold()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var sharedSubject = _fixture.CreateTitle(3);
+        var (youTube, audio) = _fixture.CreateNegativeDelayNonMatchingPair(podcast);
+        youTube.Subjects = [sharedSubject];
+        audio.Subjects = [sharedSubject];
+
+        // Act
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        // Assert
+        score.Should().Be(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.WeakCatalogueReleasePoints +
+            CrossPlatformMatchScorer.SingleSharedSubjectPoints);
+        CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "Podcast default subject alone does not contribute subject points on cross-platform scoring.")]
+    public void Default_subject_overlap_does_not_contribute_points()
+    {
+        // Arrange
+        var defaultSubject = _fixture.CreateTitle(2);
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        podcast.DefaultSubject = defaultSubject;
+        var (youTube, audio) = _fixture.CreateNegativeDelayNonMatchingPair(podcast);
+        youTube.Subjects = [defaultSubject];
+        audio.Subjects = [defaultSubject];
+
+        // Act
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        // Assert
+        score.Should().Be(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.WeakCatalogueReleasePoints);
+        CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "Ignored subjects and underscore-prefixed subjects do not contribute cross-platform subject points.")]
+    public void Ignored_and_underscore_subjects_do_not_contribute_points()
+    {
+        // Arrange
+        var ignoredSubject = _fixture.CreateTitle(2);
+        var underscoreSubject = "_" + _fixture.CreateTitle(2);
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        podcast.IgnoredSubjects = [ignoredSubject];
+        var (youTube, audio) = _fixture.CreateNegativeDelayNonMatchingPair(podcast);
+        youTube.Subjects = [ignoredSubject, underscoreSubject];
+        audio.Subjects = [ignoredSubject, underscoreSubject];
+
+        // Act
+        var score = CrossPlatformMatchScorer.Score(youTube, audio, podcast);
+
+        // Assert
+        score.Should().Be(
+            CrossPlatformMatchScorer.DurationWithinBandPoints +
+            CrossPlatformMatchScorer.WeakCatalogueReleasePoints);
+        CrossPlatformMatchScorer.MeetsMatchThreshold(youTube, audio, podcast).Should().BeFalse();
     }
 
     private (Episode YouTube, Episode Audio) CreateDelayAlignedDivergentPair(Podcast podcast)

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Merging/ReleaseDateMergingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Merging/ReleaseDateMergingRules.cs
@@ -166,4 +166,63 @@ public class ReleaseDateMergingRules
         result.MergedEpisodes.Should().ContainSingle();
         stored.ShouldMatchExpectation(expected);
     }
+
+    [Fact(DisplayName =
+        "For Apple-authority podcasts, attaching Apple onto a YouTube-first episode with a timed release " +
+        "on a different calendar day adopts Apple's publish datetime as the episode release.")]
+    public void Apple_authority_adopts_Apple_release_over_timed_YouTube_release_on_different_day()
+    {
+        // Arrange
+        var delay = TimeSpan.FromDays(2) + TimeSpan.FromHours(7);
+        var podcast = _fixture.CreateAppleReleaseAuthorityPodcast(
+            _fixture.CreateAppleId(),
+            youTubePublicationOffsetTicks: delay.Ticks);
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-4, TimeSpan.FromHours(12));
+        var appleRelease = youTubeRelease + delay;
+        var sharedTitle = _fixture.CreateTitle();
+        var sharedLength = _fixture.CreateDuration();
+        var stored = _fixture.CreateStoredEpisodeWithYouTubeOnly(
+            podcast, youTubeRelease, sharedLength, sharedTitle);
+        var appleInput = _fixture.CreateAppleCatalogueInput(b => b
+            .WithTitle(sharedTitle)
+            .WithRelease(appleRelease)
+            .WithDuration(sharedLength));
+        var discovered = _fixture.CreateAppleCatalogueEpisode(b => b
+            .WithAppleId(appleInput.AppleId)
+            .WithTitle(sharedTitle)
+            .WithRelease(appleRelease)
+            .WithDuration(sharedLength));
+        var expected = EpisodeExpectation.From(stored)
+            .WithRelease(appleRelease)
+            .WithApple(appleInput.AppleId, appleInput.AppleUrl);
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.MergedEpisodes.Should().ContainSingle();
+        stored.ShouldMatchExpectation(expected);
+    }
+
+    [Fact(DisplayName =
+        "For YouTube-authority podcasts with YouTube identity, Apple merge must not replace the " +
+        "YouTube publish datetime even when Apple is on a different calendar day.")]
+    public void YouTube_authority_preserves_YouTube_release_when_Apple_arrives_on_different_day()
+    {
+        // Arrange
+        var podcast = _fixture.CreateYouTubeReleaseAuthorityPodcastWithNegativeDelay();
+        var (stored, discovered, appleId) =
+            _fixture.CreateCrossPlatformYouTubeReleaseAuthorityApplePair(podcast);
+        var youTubeRelease = stored.Release;
+        var expected = EpisodeExpectation.From(stored)
+            .WithApple(appleId, discovered.Urls.Apple!);
+
+        // Act
+        var result = _merger.MergeEpisodes(podcast, [stored], [discovered]);
+
+        // Assert
+        result.MergedEpisodes.Should().ContainSingle();
+        stored.Release.Should().Be(youTubeRelease);
+        stored.ShouldMatchExpectation(expected);
+    }
 }

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Extensions/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<IReleaseMatchStrategy, YouTubePublishDelayMatchStrategy>();
 
             services.AddSingleton<IReleaseMergePolicy, YouTubeAuthoritativePreserveMergePolicy>();
+            services.AddSingleton<IReleaseMergePolicy, AppleAuthoritativeAdoptReleaseMergePolicy>();
             services.AddSingleton<IReleaseMergePolicy, YouTubeTimeBackfillMergePolicy>();
             services.AddSingleton<IReleaseMergePolicy, SpotifyNoTimeBackfillMergePolicy>();
             services.AddSingleton<IReleaseMergePolicy, AppleTimeBackfillMergePolicy>();

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CrossPlatformMatchScorer.cs
@@ -8,21 +8,33 @@ namespace RedditPodcastPoster.Episodes.Matching;
 /// <summary>
 /// Composite confidence score for YouTube↔audio cross-platform merges.
 /// Signals add; match when total ≥ <see cref="MatchThreshold"/>.
+/// Release scoring prefers proximity of the YouTube publish to
+/// <c>audioRelease + YouTubePublishingDelay</c> (delay is a score signal, not a hard gate).
 /// Delay-aligned release + duration reaches threshold without title confidence.
-/// Weak catalogue-day (or early-within-negative-delay) release + duration alone does not
-/// (#869 protection). Matching episode descriptions supply the same confidence as a fuzzy title.
+/// Weak catalogue-day release + duration alone does not (#869 protection).
+/// Matching episode descriptions or shared subjects supply supporting confidence.
 /// </summary>
 public static class CrossPlatformMatchScorer
 {
     public const int MatchThreshold = 60;
 
     public const int DelayAlignedReleasePoints = 40;
+    public const int NearDelayAlignedReleasePoints = 25;
     public const int SameCalendarDayReleasePoints = 30;
     public const int WeakCatalogueReleasePoints = 15;
     public const int DurationWithinBandPoints = 30;
     public const int FuzzyTitlePoints = 25;
     public const int SubstringTitlePoints = 20;
     public const int FuzzyDescriptionPoints = FuzzyTitlePoints;
+    public const int SingleSharedSubjectPoints = CatalogueMatchScorer.SingleSharedSubjectPoints;
+    public const int MultipleSharedSubjectPoints = CatalogueMatchScorer.MultipleSharedSubjectPoints;
+
+    /// <summary>Full delay-alignment credit when YouTube is within this of expected publish.</summary>
+    public static readonly TimeSpan DelayAlignedWindow =
+        EpisodeReleaseTolerance.YouTubePublishDelayMatchThreshold;
+
+    /// <summary>Partial delay-proximity credit outside the full window but still near expected.</summary>
+    public static readonly TimeSpan NearDelayAlignedWindow = TimeSpan.FromDays(3);
 
     private const int MinFuzzyTitleScore = 70;
     private const int MinFuzzyDescriptionScore = 70;
@@ -30,7 +42,8 @@ public static class CrossPlatformMatchScorer
 
     /// <summary>
     /// Scores a YouTube↔audio pair that already passed a release-strategy match and
-    /// duration-within-band checks. Title is supporting evidence, not a hard veto.
+    /// duration-within-band checks. Title, description, shared subjects, and how close
+    /// YouTube’s publish is to <c>audio + YouTubePublishingDelay</c> are supporting evidence.
     /// </summary>
     public static int Score(
         Episode existingEpisode,
@@ -40,6 +53,7 @@ public static class CrossPlatformMatchScorer
         var score = DurationWithinBandPoints;
         score += ScoreReleaseStrength(existingEpisode, incomingEpisode, podcast);
         score += ScoreTitle(existingEpisode, incomingEpisode);
+        score += ScoreSubjects(existingEpisode, incomingEpisode, podcast);
         return score;
     }
 
@@ -59,24 +73,47 @@ public static class CrossPlatformMatchScorer
             return WeakCatalogueReleasePoints;
         }
 
-        var delay = podcast.YouTubePublishingDelay();
-        if (delay != TimeSpan.Zero &&
-            EpisodeReleaseTolerance.IsYouTubePublishDelayAligned(
+        var delayProximityPoints = ScoreDelayProximity(
+            audioSide.Release,
+            youTubeSide.Release,
+            podcast.YouTubePublishingDelay());
+        var calendarDayPoints = EpisodeReleaseTolerance.AreCrossPlatformReleasesOnSameCalendarDay(
                 audioSide.Release,
-                youTubeSide.Release,
-                delay))
+                youTubeSide.Release)
+            ? SameCalendarDayReleasePoints
+            : 0;
+
+        var best = Math.Max(delayProximityPoints, calendarDayPoints);
+        return best > 0 ? best : WeakCatalogueReleasePoints;
+    }
+
+    /// <summary>
+    /// Points from |youTubeRelease − (audioRelease + delay)|. Zero delay configured → 0
+    /// (calendar-day / weak tiers apply instead).
+    /// </summary>
+    private static int ScoreDelayProximity(
+        DateTime audioRelease,
+        DateTime youTubeRelease,
+        TimeSpan publishingDelay)
+    {
+        if (publishingDelay == TimeSpan.Zero)
+        {
+            return 0;
+        }
+
+        var expectedPublish = audioRelease.Add(publishingDelay);
+        var delta = TimeSpan.FromTicks(Math.Abs((youTubeRelease - expectedPublish).Ticks));
+        if (delta < DelayAlignedWindow)
         {
             return DelayAlignedReleasePoints;
         }
 
-        if (EpisodeReleaseTolerance.AreCrossPlatformReleasesOnSameCalendarDay(
-                audioSide.Release,
-                youTubeSide.Release))
+        if (delta < NearDelayAlignedWindow)
         {
-            return SameCalendarDayReleasePoints;
+            return NearDelayAlignedReleasePoints;
         }
 
-        return WeakCatalogueReleasePoints;
+        return 0;
     }
 
     private static int ScoreTitle(Episode existingEpisode, Episode incomingEpisode)
@@ -103,6 +140,26 @@ public static class CrossPlatformMatchScorer
         }
 
         return 0;
+    }
+
+    private static int ScoreSubjects(
+        Episode existingEpisode,
+        Episode incomingEpisode,
+        Podcast podcast)
+    {
+        var filters = new CatalogueSubjectScoreFilters(
+            podcast.DefaultSubject,
+            podcast.IgnoredSubjects);
+        var shared = CatalogueMatchScorer.CountSharedSubjects(
+            existingEpisode.Subjects,
+            incomingEpisode.Subjects,
+            filters);
+        return shared switch
+        {
+            >= 2 => MultipleSharedSubjectPoints,
+            1 => SingleSharedSubjectPoints,
+            _ => 0
+        };
     }
 
     private static bool DescriptionsFuzzyMatch(string left, string right)

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodeReleaseTolerance.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/EpisodeReleaseTolerance.cs
@@ -200,8 +200,29 @@ public static class EpisodeReleaseTolerance
         Podcast? podcast) =>
         SpotifyCatalogueReleaseMatches(catalogueRelease, expectedRelease, toleranceTicks, podcast);
 
-    public static DateTime GetAudioReleaseForPlatformLookup(Podcast podcast, Episode episode) =>
-        GetAudioReleaseForPlatformLookup(podcast, episode.Release, HasYouTubeIdentity(episode));
+    public static DateTime GetAudioReleaseForPlatformLookup(Podcast podcast, Episode episode)
+    {
+        var delay = podcast.YouTubePublishingDelay();
+        if (delay == TimeSpan.Zero)
+        {
+            return episode.Release;
+        }
+
+        if (podcast.ReleaseAuthority == Service.YouTube)
+        {
+            return episode.Release - delay;
+        }
+
+        // Release is still YouTube-shaped only while the release-authority audio id is missing.
+        if (HasYouTubeIdentity(episode) &&
+            IsReleaseAuthorityAudioIdentityMissing(podcast, episode) &&
+            HasAudioPlatformConfigured(podcast))
+        {
+            return episode.Release - delay;
+        }
+
+        return episode.Release;
+    }
 
     public static DateTime GetAudioReleaseForPlatformLookup(
         Podcast podcast,
@@ -259,6 +280,14 @@ public static class EpisodeReleaseTolerance
         var needsApple = podcast.AppleId is > 0 && episode.AppleId is null or 0;
         return needsSpotify || needsApple;
     }
+
+    private static bool IsReleaseAuthorityAudioIdentityMissing(Podcast podcast, Episode episode) =>
+        podcast.ReleaseAuthority switch
+        {
+            Service.Apple => episode.AppleId is null or 0,
+            Service.Spotify => string.IsNullOrWhiteSpace(episode.SpotifyId) && episode.Urls.Spotify == null,
+            _ => EpisodeMissingConfiguredPlatformIds(episode, podcast)
+        };
 
     private static bool HasYouTubeIdentity(Episode episode) =>
         !string.IsNullOrWhiteSpace(episode.YouTubeId) || episode.Urls.YouTube != null;

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Merging/Policies/AppleAuthoritativeAdoptReleaseMergePolicy.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Merging/Policies/AppleAuthoritativeAdoptReleaseMergePolicy.cs
@@ -1,0 +1,32 @@
+using RedditPodcastPoster.Episodes.Merging;
+using RedditPodcastPoster.Models.Podcasts;
+
+namespace RedditPodcastPoster.Episodes.Merging.Policies;
+
+/// <summary>
+/// When Apple is release authority, adopt the incoming Apple publish datetime even if the
+/// existing episode already has a timed YouTube release on another calendar day
+/// (midnight same-day backfill alone is not enough).
+/// </summary>
+public sealed class AppleAuthoritativeAdoptReleaseMergePolicy : IReleaseMergePolicy
+{
+    public ReleaseMergeOpinion Evaluate(ReleaseMergeContext context)
+    {
+        if (context.Podcast.ReleaseAuthority != Service.Apple)
+        {
+            return ReleaseMergeOpinion.NoOpinion;
+        }
+
+        if (context.IncomingEpisode.AppleId is null or 0)
+        {
+            return ReleaseMergeOpinion.NoOpinion;
+        }
+
+        if (context.IncomingEpisode.Release == context.ExistingEpisode.Release)
+        {
+            return ReleaseMergeOpinion.NoOpinion;
+        }
+
+        return ReleaseMergeOpinion.Backfill;
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Apple/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using RedditPodcastPoster.PodcastServices.Apple.Handlers;
 using RedditPodcastPoster.PodcastServices.Apple.Providers;
 using RedditPodcastPoster.PodcastServices.Apple.Resolvers;
 using RedditPodcastPoster.PodcastServices.Abstractions.Handlers;
+using RedditPodcastPoster.Subjects.Extensions;
 
 namespace RedditPodcastPoster.PodcastServices.Apple.Extensions;
 
@@ -15,6 +16,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAppleServices(this IServiceCollection services)
     {
         return services
+            .AddSubjectServices()
             .AddScoped<IAppleEpisodeEnricher, AppleEpisodeEnricher>()
             .AddScoped<IApplePodcastResolver, ApplePodcastResolver>()
             .AddScoped<IEnrichedApplePodcastResolver, EnrichedApplePodcastResolver>()

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.Spotify/Extensions/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ using RedditPodcastPoster.PodcastServices.Spotify.Search;
 using SpotifyAPI.Web;
 using RedditPodcastPoster.PodcastServices.Abstractions.Enriching;
 using RedditPodcastPoster.PodcastServices.Abstractions.Handlers;
+using RedditPodcastPoster.Subjects.Extensions;
 
 namespace RedditPodcastPoster.PodcastServices.Spotify.Extensions;
 
@@ -35,6 +36,7 @@ public static class ServiceCollectionExtensions
         public IServiceCollection AddSpotifyServices()
         {
             return services
+                .AddSubjectServices()
                 .AddSpotifyClient()
                 .AddScoped<ISpotifyEpisodeProvider, SpotifyEpisodeProvider>()
                 .AddScoped<ISpotifyEpisodeEnricher, SpotifyEpisodeEnricher>()

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Enrichment/YouTubeEpisodeEnricherCatalogueRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Enrichment/YouTubeEpisodeEnricherCatalogueRules.cs
@@ -553,9 +553,9 @@ public class YouTubeEpisodeEnricherCatalogueRules
     }
 
     [Fact(DisplayName =
-        "When the episode is still inside the delayed YouTube publishing window, YouTube enrichment " +
-        "is bypassed and does not query the catalogue.")]
-    public async Task enrich_is_bypassed_inside_delayed_youtube_publishing_window()
+        "Enrichment always queries FindEpisode even while YouTubePublicationOffset is active; " +
+        "with no catalogue match, no YouTube URL is attached.")]
+    public async Task enrich_inside_delay_without_match_queries_but_does_not_attach()
     {
         // Arrange
         var publishingDelay = TimeSpan.FromDays(1);
@@ -575,6 +575,9 @@ public class YouTubeEpisodeEnricherCatalogueRules
             })
             .Create();
         var resolver = new Mock<IYouTubeItemResolver>();
+        resolver
+            .Setup(x => x.FindEpisode(It.IsAny<EnrichmentRequest>(), It.IsAny<IndexingContext>()))
+            .ReturnsAsync((FindEpisodeResponse?)null);
         var sut = CreateEnricher(youTubeItemResolver: resolver.Object);
         var enrichmentContext = new EnrichmentContext();
 
@@ -587,8 +590,61 @@ public class YouTubeEpisodeEnricherCatalogueRules
         // Assert
         resolver.Verify(
             x => x.FindEpisode(It.IsAny<EnrichmentRequest>(), It.IsAny<IndexingContext>()),
-            Times.Never);
+            Times.Once);
+        episode.YouTubeId.Should().BeNullOrWhiteSpace();
         enrichmentContext.YouTubeUrlUpdated.Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "A scored catalogue match attaches YouTube identity even while YouTubePublicationOffset is active — " +
+        "offset does not gate enrichment; delay proximity is scored in the finder.")]
+    public async Task enrich_inside_delay_with_strong_match_attaches_youtube()
+    {
+        // Arrange
+        var publishingDelay = TimeSpan.FromDays(1);
+        var podcast = _fixture.CreateSpotifyPrimaryPodcast(_fixture.CreateSpotifyId());
+        podcast.YouTubeChannelId = _fixture.CreateYouTubeChannelId();
+        podcast.YouTubePublicationOffset = publishingDelay.Ticks;
+        var inWindowRelease = DomainTestFixture.SpotifyCatalogueReleaseStillInsideDelayedPublishingWindow(
+            publishingDelay);
+        var sharedTitle = _fixture.CreateTitle();
+        var length = _fixture.CreateDuration();
+        var youTubeId = _fixture.CreateYouTubeId();
+        var image = _fixture.Create<Uri>();
+        var episode = _fixture.BuildEpisode()
+            .WithPodcast(podcast)
+            .WithRelease(inWindowRelease)
+            .WithLength(length)
+            .Customize(e =>
+            {
+                e.Title = sharedTitle;
+                e.YouTubeId = string.Empty;
+                e.Urls = new ServiceUrls();
+                e.Description = _fixture.CreateTitle();
+                e.Images = new EpisodeImages { YouTube = image };
+            })
+            .Create();
+        var resolver = new Mock<IYouTubeItemResolver>();
+        resolver
+            .Setup(x => x.FindEpisode(It.IsAny<EnrichmentRequest>(), It.IsAny<IndexingContext>()))
+            .ReturnsAsync(CreateSearchResultResponse(youTubeId, sharedTitle, inWindowRelease));
+        var sut = CreateEnricher(youTubeItemResolver: resolver.Object);
+        var enrichmentContext = new EnrichmentContext();
+        var expected = EpisodeExpectation.From(episode)
+            .WithYouTube(youTubeId, SearchResultExtensions.ToYouTubeUrl(youTubeId), image);
+
+        // Act
+        await sut.Enrich(
+            new EnrichmentRequest(podcast, [episode], episode),
+            new IndexingContext(),
+            enrichmentContext);
+
+        // Assert
+        resolver.Verify(
+            x => x.FindEpisode(It.IsAny<EnrichmentRequest>(), It.IsAny<IndexingContext>()),
+            Times.Once);
+        enrichmentContext.YouTubeUrlUpdated.Should().BeTrue();
+        episode.ShouldMatchExpectation(expected);
     }
 
     private YouTubeEpisodeEnricher CreateEnricher(

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Finders/PlaylistItemFinderCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Finders/PlaylistItemFinderCatalogueWrapperRules.cs
@@ -39,11 +39,13 @@ public class PlaylistItemFinderCatalogueWrapperRules
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync((
                 IYouTubeServiceWrapper _,
                 IEnumerable<string> videoIds,
                 IndexingContext _,
+                bool _,
                 bool _,
                 bool _) =>
                 videoIds.Select(id => CreateCompletedVideo(id, TimeSpan.FromHours(1))).ToList());
@@ -317,33 +319,30 @@ public class PlaylistItemFinderCatalogueWrapperRules
     // Episode-number and duration-only local heuristics (after exact-title path fails).
     // --------------------------------------------------------------------------------------------
 
-    [Theory(DisplayName =
-        "When exact title matching fails, each fuzzy title variant on a short title may still resolve " +
-        "via shared episode number and acceptable video duration.")]
-    [MemberData(nameof(AllFuzzyVariantStrategies))]
-    public async Task find_by_episode_number_for_each_fuzzy_variant_on_short_title(
-        FuzzyTitleVariantStrategy strategy)
+    [Fact(DisplayName =
+        "When exact title matching fails, a shared episode number with acceptable video duration " +
+        "still resolves the playlist item.")]
+    public async Task find_by_episode_number_with_divergent_titles_resolves()
     {
         // Arrange
-        const int episodeNumber = 42;
-        var episodeTitle = $"Series discussion part {episodeNumber} opening themes";
-        var catalogueTitle = DomainTestFixture.CreateFuzzyTitleVariant(
-            $"Series recap part {episodeNumber} closing thoughts",
-            strategy);
-
+        const int episodeNumber = 1042;
+        var episodeTitle = $"Series discussion Episode{episodeNumber} opening themes";
+        var catalogueTitle = $"Series recap Episode{episodeNumber} closing thoughts";
         var episodeLength = TimeSpan.FromHours(1);
         var catalogueVideoLength = episodeLength - TimeSpan.FromSeconds(30);
         var matchingVideoId = _fixture.CreateYouTubeId();
+        var release = DomainTestFixture.UtcAtTime(-2, TimeSpan.FromHours(12));
         var episode = _fixture.BuildEpisode()
             .Customize(e =>
             {
                 e.Title = episodeTitle;
                 e.Length = episodeLength;
+                e.Release = release;
             })
             .Create();
         var playlistItems = new List<PlaylistItem>
         {
-            CreatePlaylistItem(matchingVideoId, catalogueTitle, DomainTestFixture.UtcDaysAgo(1))
+            CreatePlaylistItem(matchingVideoId, catalogueTitle, release)
         };
         ConfigureVideoDuration(matchingVideoId, catalogueVideoLength);
 
@@ -396,28 +395,32 @@ public class PlaylistItemFinderCatalogueWrapperRules
     }
 
     [Theory(DisplayName =
-        "When exact title, episode number, and publish-delay paths fail, " +
-        "duration-only matching may still resolve a video within the two-minute tolerance.")]
+        "When exact title, episode number, and publish-delay paths fail and the closest-duration " +
+        "candidate has a wholly divergent title, the finder rejects it because the cross-platform " +
+        "score stays below threshold.")]
     [InlineData(0)]
     [InlineData(90)]
-    public async Task find_by_duration_only_within_two_minute_tolerance(long offsetSeconds)
+    public async Task find_by_duration_only_rejects_when_cross_platform_score_below_threshold(long offsetSeconds)
     {
         // Arrange
         var episodeLength = TimeSpan.FromHours(1);
         var catalogueVideoLength = episodeLength - TimeSpan.FromSeconds(offsetSeconds);
         var matchingVideoId = _fixture.CreateYouTubeId();
         var distractorVideoId = _fixture.CreateYouTubeId();
+        var release = DomainTestFixture.UtcAtTime(-10, TimeSpan.FromHours(12));
         var episode = _fixture.BuildEpisode()
             .Customize(e =>
             {
                 e.Title = "Quantum computing fundamentals overview";
                 e.Length = episodeLength;
+                e.Release = release;
+                e.Description = "Alpha-only notes about quantum fundamentals.";
             })
             .Create();
         var playlistItems = new List<PlaylistItem>
         {
-            CreatePlaylistItem(matchingVideoId, "Ancient pottery restoration techniques", DomainTestFixture.UtcDaysAgo(1)),
-            CreatePlaylistItem(distractorVideoId, "Modern urban gardening tips", DomainTestFixture.UtcDaysAgo(2))
+            CreatePlaylistItem(matchingVideoId, "Ancient pottery restoration techniques", release.AddDays(3)),
+            CreatePlaylistItem(distractorVideoId, "Modern urban gardening tips", release.AddDays(4))
         };
         ConfigureVideoDurations(
             (matchingVideoId, catalogueVideoLength),
@@ -431,8 +434,7 @@ public class PlaylistItemFinderCatalogueWrapperRules
             new IndexingContext());
 
         // Assert
-        result.Should().NotBeNull();
-        result!.PlaylistItem!.GetVideoId().Should().Be(matchingVideoId);
+        result.Should().BeNull();
     }
 
     [Fact(DisplayName =
@@ -501,13 +503,15 @@ public class PlaylistItemFinderCatalogueWrapperRules
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync((
                 IYouTubeServiceWrapper _,
                 IEnumerable<string> videoIds,
                 IndexingContext _,
                 bool _,
-                bool withSnippets) =>
+                bool _,
+                bool _) =>
             {
                 return videoIds.Select(id => id == liveVideoId
                     ? CreateVideo(id, episodeLength, liveBroadcastContent: "live")
@@ -581,11 +585,13 @@ public class PlaylistItemFinderCatalogueWrapperRules
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync((
                 IYouTubeServiceWrapper _,
                 IEnumerable<string> videoIds,
                 IndexingContext _,
+                bool _,
                 bool _,
                 bool _) =>
                 videoIds.Select(id => CreateVideo(id, episode.Length, liveBroadcastContent: "live")).ToList());
@@ -899,6 +905,7 @@ public class PlaylistItemFinderCatalogueWrapperRules
                 It.Is<IEnumerable<string>>(ids => ids.Single() == videoId),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync([]);
 
@@ -939,13 +946,15 @@ public class PlaylistItemFinderCatalogueWrapperRules
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync((
                 IYouTubeServiceWrapper _,
                 IEnumerable<string> videoIds,
                 IndexingContext _,
+                bool withSnippets,
                 bool _,
-                bool withSnippets) =>
+                bool _) =>
             {
                 if (withSnippets)
                 {
@@ -978,11 +987,13 @@ public class PlaylistItemFinderCatalogueWrapperRules
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync((
                 IYouTubeServiceWrapper _,
                 IEnumerable<string> videoIds,
                 IndexingContext _,
+                bool _,
                 bool _,
                 bool _) =>
                 videoIds.Select(id =>
@@ -1052,11 +1063,13 @@ public class PlaylistItemFinderCatalogueWrapperRules
                 It.Is<IEnumerable<string>>(ids => ids.Contains(videoId)),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync((
                 IYouTubeServiceWrapper _,
                 IEnumerable<string> videoIds,
                 IndexingContext _,
+                bool _,
                 bool _,
                 bool _) =>
                 videoIds.Select(id => CreateCompletedVideo(id, id == videoId ? duration : TimeSpan.FromMinutes(20)))

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Finders/SearchResultFinderCatalogueWrapperRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Finders/SearchResultFinderCatalogueWrapperRules.cs
@@ -38,11 +38,13 @@ public class SearchResultFinderCatalogueWrapperRules
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync((
                 IYouTubeServiceWrapper _,
                 IEnumerable<string> videoIds,
                 IndexingContext _,
+                bool _,
                 bool _,
                 bool _) =>
                 videoIds.Select(id => CreateCompletedVideo(id, TimeSpan.FromHours(1))).ToList());
@@ -259,6 +261,51 @@ public class SearchResultFinderCatalogueWrapperRules
         result!.SearchResult!.Id.VideoId.Should().Be(matchingVideoId);
     }
 
+    [Fact(DisplayName =
+        "When the closest-duration search result has a wholly divergent title and only weak release " +
+        "alignment, the finder rejects it because the cross-platform score stays below threshold.")]
+    public async Task duration_closest_match_rejects_when_cross_platform_score_below_threshold()
+    {
+        // Arrange
+        var episodeLength = TimeSpan.FromHours(1);
+        var matchingVideoId = _fixture.CreateYouTubeId();
+        var otherVideoId = _fixture.CreateYouTubeId();
+        var release = DomainTestFixture.UtcAtTime(-10, TimeSpan.FromHours(12));
+        var episode = _fixture.BuildEpisode()
+            .Customize(e =>
+            {
+                e.Title = "Alpha market briefing on early catalogue drift signals";
+                e.Length = episodeLength;
+                e.Release = release;
+                e.Description = "Alpha-only show notes about market briefing mechanics.";
+            })
+            .Create();
+        var searchResults = new List<SearchResult>
+        {
+            CreateSearchResult(
+                matchingVideoId,
+                "Omega wellness interview about unrelated guest journeys",
+                release.AddDays(3)),
+            CreateSearchResult(
+                otherVideoId,
+                "Zeta travel diary from a distant continent tour",
+                release.AddDays(4))
+        };
+        ConfigureVideoDurations(
+            (matchingVideoId, episodeLength - TimeSpan.FromSeconds(30)),
+            (otherVideoId, TimeSpan.FromMinutes(20)));
+
+        // Act
+        var result = await Sut.FindMatchingYouTubeVideo(
+            episode,
+            searchResults,
+            youTubePublishDelay: null,
+            new IndexingContext());
+
+        // Assert
+        result.Should().BeNull();
+    }
+
     private (
         EpisodeModel Episode,
         string MatchingVideoId,
@@ -317,11 +364,13 @@ public class SearchResultFinderCatalogueWrapperRules
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync((
                 IYouTubeServiceWrapper _,
                 IEnumerable<string> videoIds,
                 IndexingContext _,
+                bool _,
                 bool _,
                 bool _) =>
                 videoIds.Select(id =>
@@ -340,11 +389,13 @@ public class SearchResultFinderCatalogueWrapperRules
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .ReturnsAsync((
                 IYouTubeServiceWrapper _,
                 IEnumerable<string> videoIds,
                 IndexingContext _,
+                bool _,
                 bool _,
                 bool _) =>
                 videoIds.Select(id =>

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Services/SearchResultFinderTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Services/SearchResultFinderTests.cs
@@ -31,8 +31,10 @@ public class SearchResultFinderTests
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IndexingContext>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
-            .ReturnsAsync((IYouTubeServiceWrapper _, IEnumerable<string> videoIds, IndexingContext _, bool _, bool _) =>
+            .ReturnsAsync((IYouTubeServiceWrapper _, IEnumerable<string> videoIds, IndexingContext _, bool _, bool _,
+                bool _) =>
                 videoIds.Select(CreateVideoWithMatchingDuration).ToList());
     }
 
@@ -44,14 +46,14 @@ public class SearchResultFinderTests
             Snippet = new VideoSnippet { LiveBroadcastContent = "none" }
         };
 
-    [Theory]
+    [Theory(DisplayName = "When release time is inaccurate, exact title prefers the title-matched video over a midnight-closer distractor.")]
     [InlineData(0)]
     [InlineData(6)]
     [InlineData(12)]
     public async Task FindMatchingYouTubeVideo_WithInAccurateReleaseTimeAndUnmatchedVideoCloserToMidnight_IsCorrect(
         long youTubePublishDelayTicks)
     {
-        // arrange
+        // Arrange
         var expectedTitle = "Matching Episode";
         var today = DateTime.UtcNow.Date;
         var episode = _fixture
@@ -77,24 +79,24 @@ public class SearchResultFinderTests
                 .With(x => x.PublishedAtDateTimeOffset, today)
                 .Create())
             .Create();
-        // act
+        // Act
         var result = await Sut.FindMatchingYouTubeVideo(
             episode,
             new List<SearchResult> {expected, incorrectResult},
             TimeSpan.FromTicks(youTubePublishDelayTicks),
             new IndexingContext());
-        // assert
+        // Assert
         result?.SearchResult.Should().Be(expected);
     }
 
-    [Theory]
+    [Theory(DisplayName = "When release time is accurate, exact title prefers the title-matched video over a midnight-closer distractor.")]
     [InlineData(0)]
     [InlineData(6)]
     [InlineData(12)]
     public async Task FindMatchingYouTubeVideo_WithAccurateReleaseTimeAndUnmatchedVideoCloserToMidnight_IsCorrect(
         long youTubePublishDelayTicks)
     {
-        // arrange
+        // Arrange
         var expectedTitle = "Matching Episode";
         var today = DateTime.UtcNow.Date;
         var release = DateTime.UtcNow.Date.AddHours(17);
@@ -120,17 +122,17 @@ public class SearchResultFinderTests
                 .With(x => x.PublishedAtDateTimeOffset, today)
                 .Create())
             .Create();
-        // act
+        // Act
         var result = await Sut.FindMatchingYouTubeVideo(
             episode,
             new List<SearchResult> {expected, incorrectResult},
             TimeSpan.FromTicks(youTubePublishDelayTicks),
             new IndexingContext());
-        // assert
+        // Assert
         result?.SearchResult.Should().Be(expected);
     }
 
-    [Theory]
+    [Theory(DisplayName = "When YouTube published slightly before audio, exact title still prefers the title-matched video.")]
     [InlineData(0)]
     [InlineData(6)]
     [InlineData(12)]
@@ -138,7 +140,7 @@ public class SearchResultFinderTests
         FindMatchingYouTubeVideo_WithAccurateReleaseTimeAndMatchingVideoReleasedOnYouTubeBeforeAudioAndUnmatchedVideoCloserToMidnight_IsCorrect(
             long youTubePublishDelayTicks)
     {
-        // arrange
+        // Arrange
         var expectedTitle = "Matching Episode";
         var today = DateTime.UtcNow.Date;
         var release = DateTime.UtcNow.Date.AddHours(17);
@@ -164,23 +166,23 @@ public class SearchResultFinderTests
                 .With(x => x.PublishedAtDateTimeOffset, today)
                 .Create())
             .Create();
-        // act
+        // Act
         var result = await Sut.FindMatchingYouTubeVideo(
             episode,
             new List<SearchResult> {expected, incorrectResult},
             TimeSpan.FromTicks(youTubePublishDelayTicks),
             new IndexingContext());
-        // assert
+        // Assert
         result?.SearchResult.Should().Be(expected);
     }
 
-    [Theory]
+    [Theory(DisplayName = "When titles diverge but share an episode number, the finder resolves by episode number and duration.")]
     [InlineData(0)]
     [InlineData(6)]
     [InlineData(12)]
     public async Task FindMatchingYouTubeVideo_WithMatchingEpisodeNumber_IsCorrect(long youTubePublishDelayTicks)
     {
-        // arrange
+        // Arrange
         var episodeNumber = _fixture.Create<int>();
         var today = DateTime.UtcNow.Date;
         var release = DateTime.UtcNow.Date.AddHours(17);
@@ -205,13 +207,13 @@ public class SearchResultFinderTests
                 .With(x => x.PublishedAtDateTimeOffset, today)
                 .Create())
             .Create();
-        // act
+        // Act
         var result = await Sut.FindMatchingYouTubeVideo(
             episode,
             new List<SearchResult> {expected, incorrectResult},
             TimeSpan.FromTicks(youTubePublishDelayTicks),
             new IndexingContext());
-        // assert
+        // Assert
         result?.SearchResult.Should().Be(expected);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Enrichment/YouTubeEpisodeEnricher.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Enrichment/YouTubeEpisodeEnricher.cs
@@ -36,11 +36,6 @@ public class YouTubeEpisodeEnricher(
         IndexingContext indexingContext,
         EnrichmentContext enrichmentContext)
     {
-        if (IsBypassedByDelayedYouTubePublishing(request, "YouTube", logger))
-        {
-            return;
-        }
-
         if (!string.IsNullOrWhiteSpace(request.Episode.YouTubeId) && request.Episode.Urls.YouTube == null)
         {
             ApplyYouTubeLink(
@@ -77,8 +72,11 @@ public class YouTubeEpisodeEnricher(
                     youTubeItem.SearchResult.Snippet.Title,
                     youTubeItem.SearchResult.ToYouTubeUrl());
             }
+
+            return;
         }
-        else if (youTubeItem?.PlaylistItem != null)
+
+        if (youTubeItem?.PlaylistItem != null)
         {
             if (!string.IsNullOrWhiteSpace(youTubeItem.PlaylistItem.Snippet.ResourceId.VideoId) &&
                 request.Episodes.All(x => x.YouTubeId != youTubeItem.PlaylistItem.Snippet.ResourceId.VideoId))

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Resolvers/YouTubeUrlResolver.cs
@@ -79,7 +79,8 @@ public class YouTubeItemResolver(
                 request.Episode,
                 latestPlaylistItems.Result,
                 youTubePublishingDelay,
-                indexingContext);
+                indexingContext,
+                request.Podcast);
             return matchedYouTubeVideo;
         }
 
@@ -117,7 +118,8 @@ public class YouTubeItemResolver(
                 request.Episode,
                 searchListResponse,
                 youTubePublishingDelay,
-                indexingContext);
+                indexingContext,
+                request.Podcast);
         }
         catch (YouTubeChannelSearchForbiddenException ex)
         {
@@ -149,7 +151,8 @@ public class YouTubeItemResolver(
             request.Episode,
             playlistItems,
             youTubePublishingDelay,
-            indexingContext);
+            indexingContext,
+            request.Podcast);
     }
 
     private void LogRetrievedCount(string method, int count, IndexingContext indexingContext)

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/IPlaylistItemFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/IPlaylistItemFinder.cs
@@ -1,4 +1,5 @@
 ﻿using Google.Apis.YouTube.v3.Data;
+using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
@@ -8,9 +9,10 @@ namespace RedditPodcastPoster.PodcastServices.YouTube.Services;
 
 public interface IPlaylistItemFinder
 {
-    public Task<FindEpisodeResponse?> FindMatchingYouTubeVideo(
-    EpisodeModel episode,
-    IList<PlaylistItem> searchResults,
-    TimeSpan? youTubePublishDelay,
-    IndexingContext indexingContext);
+    Task<FindEpisodeResponse?> FindMatchingYouTubeVideo(
+        EpisodeModel episode,
+        IList<PlaylistItem> searchResults,
+        TimeSpan? youTubePublishDelay,
+        IndexingContext indexingContext,
+        Podcast? podcast = null);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/IYouTubeSearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/IYouTubeSearchResultFinder.cs
@@ -1,4 +1,5 @@
 ﻿using Google.Apis.YouTube.v3.Data;
+using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
@@ -8,8 +9,10 @@ namespace RedditPodcastPoster.PodcastServices.YouTube.Services;
 
 public interface IYouTubeSearchResultFinder
 {
-    Task<FindEpisodeResponse?> FindMatchingYouTubeVideo(EpisodeModel episode,
+    Task<FindEpisodeResponse?> FindMatchingYouTubeVideo(
+        EpisodeModel episode,
         IList<SearchResult> searchResults,
         TimeSpan? youTubePublishDelay,
-        IndexingContext indexingContext);
+        IndexingContext indexingContext,
+        Podcast? podcast = null);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/PlaylistItemFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/PlaylistItemFinder.cs
@@ -33,21 +33,26 @@ public partial class PlaylistItemFinder(
         EpisodeModel episode,
         IList<PlaylistItem> playlistItems,
         TimeSpan? youTubePublishDelay,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast? podcast = null)
     {
+        var scoringPodcast = YouTubeEnrichmentCandidate.ScoringPodcast(podcast, youTubePublishDelay);
+
         playlistItems = await ExcludeLiveAndUpcoming(playlistItems, indexingContext);
         if (!playlistItems.Any())
         {
             return null;
         }
 
-        var exactTitleMatch = await MatchOnExactTitleWithDuration(episode, playlistItems, indexingContext);
+        var exactTitleMatch = await MatchOnExactTitleWithDuration(
+            episode, playlistItems, indexingContext, scoringPodcast);
         if (exactTitleMatch != null)
         {
             return exactTitleMatch;
         }
 
-        var episodeNumberMatch = await MatchOnEpisodeNumberWithDuration(episode, playlistItems, indexingContext);
+        var episodeNumberMatch = await MatchOnEpisodeNumberWithDuration(
+            episode, playlistItems, indexingContext, scoringPodcast);
         if (episodeNumberMatch != null)
         {
             return episodeNumberMatch;
@@ -57,7 +62,7 @@ public partial class PlaylistItemFinder(
         var videoDetails = await videoService.GetVideoContentDetails(youTubeService, videoIds, indexingContext);
 
 
-        var videoMatch = MatchOnEpisodeDuration(episode, playlistItems, videoDetails, indexingContext);
+        var videoMatch = MatchOnEpisodeDuration(episode, playlistItems, videoDetails, scoringPodcast);
         if (videoMatch != null)
         {
             return videoMatch;
@@ -83,7 +88,15 @@ public partial class PlaylistItemFinder(
                             if (matchingVideoLength > MinDurationForPublicationDate &&
                                 matchingVideoLengthDifferentTicks < VideoDurationToleranceForPublicationDate.Ticks)
                             {
-                                return new FindEpisodeResponse(PlaylistItem: match);
+                                var candidate = YouTubeEnrichmentCandidate.ToEpisode(match, videoDetail);
+                                if (YouTubeEnrichmentCandidate.MeetsStrongMatch(episode, candidate, scoringPodcast))
+                                {
+                                    return new FindEpisodeResponse(PlaylistItem: match, Video: videoDetail);
+                                }
+
+                                logger.LogInformation(
+                                    "Rejected publish-delay match for '{episodeTitle}' because cross-platform score is below threshold.",
+                                    episode.Title);
                             }
                         }
                     }
@@ -91,14 +104,15 @@ public partial class PlaylistItemFinder(
             }
         }
 
-        return await MatchOnTextClosenessWithDuration(episode, playlistItems, indexingContext);
+        return await MatchOnTextClosenessWithDuration(
+            episode, playlistItems, indexingContext, scoringPodcast);
     }
 
     private FindEpisodeResponse? MatchOnEpisodeDuration(
         EpisodeModel episode,
         IList<PlaylistItem> searchResults,
         IList<Google.Apis.YouTube.v3.Data.Video>? videoDetails,
-        IndexingContext indexingContext)
+        Podcast scoringPodcast)
     {
         var videosWithDuration = videoDetails?
             .Where(x => YouTubeVideoDurationMatcher.HasDuration(x.GetLength()))
@@ -115,6 +129,15 @@ public partial class PlaylistItemFinder(
                 var matchingVideoLengthDifferentTicks = Math.Abs((matchingVideoLength - episode.Length).Ticks);
                 if (matchingVideoLengthDifferentTicks < VideoDurationTolerance.Ticks)
                 {
+                    var candidate = YouTubeEnrichmentCandidate.ToEpisode(searchResult, matchingPair.Video);
+                    if (!YouTubeEnrichmentCandidate.MeetsStrongMatch(episode, candidate, scoringPodcast))
+                    {
+                        logger.LogInformation(
+                            "Rejected duration-closest match for '{episodeTitle}' because cross-platform score is below threshold.",
+                            episode.Title);
+                        return null;
+                    }
+
                     logger.LogInformation(
                         "Matched episode '{episodeTitle}' and length: '{episodeLength:g}' with episode '{snippetTitle}' having length: '{videoLength:g}'.",
                         episode.Title, episode.Length, searchResult.Snippet?.Title,
@@ -185,7 +208,8 @@ public partial class PlaylistItemFinder(
     private async Task<FindEpisodeResponse?> MatchOnEpisodeNumberWithDuration(
         EpisodeModel episode,
         IList<PlaylistItem> playlistItems,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast scoringPodcast)
     {
         var match = MatchOnEpisodeNumber(episode, playlistItems);
         if (match == null)
@@ -193,13 +217,15 @@ public partial class PlaylistItemFinder(
             return null;
         }
 
-        return await ValidatePlaylistMatchWithDuration(episode, match, "episode-number", indexingContext);
+        return await ValidatePlaylistMatchWithDuration(
+            episode, match, "episode-number", indexingContext, scoringPodcast, requireStrongScore: true);
     }
 
     private async Task<FindEpisodeResponse?> MatchOnTextClosenessWithDuration(
         EpisodeModel episode,
         IList<PlaylistItem> playlistItems,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast scoringPodcast)
     {
         var match = MatchOnTextCloseness(episode, playlistItems);
         if (match == null)
@@ -207,13 +233,15 @@ public partial class PlaylistItemFinder(
             return null;
         }
 
-        return await ValidatePlaylistMatchWithDuration(episode, match, "fuzzy title", indexingContext);
+        return await ValidatePlaylistMatchWithDuration(
+            episode, match, "fuzzy title", indexingContext, scoringPodcast, requireStrongScore: true);
     }
 
     private async Task<FindEpisodeResponse?> MatchOnExactTitleWithDuration(
         EpisodeModel episode,
         IList<PlaylistItem> playlistItems,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast scoringPodcast)
     {
         var match = MatchOnExactTitle(episode, playlistItems);
         if (match == null)
@@ -221,14 +249,17 @@ public partial class PlaylistItemFinder(
             return null;
         }
 
-        return await ValidatePlaylistMatchWithDuration(episode, match, "episode-title", indexingContext);
+        return await ValidatePlaylistMatchWithDuration(
+            episode, match, "episode-title", indexingContext, scoringPodcast, requireStrongScore: true);
     }
 
     private async Task<FindEpisodeResponse?> ValidatePlaylistMatchWithDuration(
         EpisodeModel episode,
         PlaylistItem match,
         string matchKind,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast? scoringPodcast,
+        bool requireStrongScore)
     {
         var videoDetails = await videoService.GetVideoContentDetails(
             youTubeService, [match.GetVideoId()], indexingContext);
@@ -244,6 +275,23 @@ public partial class PlaylistItemFinder(
                 "Rejected {matchKind} match '{episodeTitle}' (length '{episodeLength:g}') with video '{videoTitle}' (length '{videoLength:g}') due to duration mismatch.",
                 matchKind, episode.Title, episode.Length, match.Snippet.Title, video.GetLength());
             return null;
+        }
+
+        if (requireStrongScore)
+        {
+            if (scoringPodcast == null)
+            {
+                return null;
+            }
+
+            var candidate = YouTubeEnrichmentCandidate.ToEpisode(match, video);
+            if (!YouTubeEnrichmentCandidate.MeetsStrongMatch(episode, candidate, scoringPodcast))
+            {
+                logger.LogInformation(
+                    "Rejected {matchKind} match '{episodeTitle}' because cross-platform score is below threshold.",
+                    matchKind, episode.Title);
+                return null;
+            }
         }
 
         logger.LogInformation("Matched on {matchKind} '{episodeTitle}'.", matchKind, episode.Title);

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeEnrichmentCandidate.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeEnrichmentCandidate.cs
@@ -1,0 +1,76 @@
+using Google.Apis.YouTube.v3.Data;
+using RedditPodcastPoster.Episodes.Matching;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.YouTube.Extensions;
+using EpisodeModel = RedditPodcastPoster.Models.Episodes.Episode;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Services;
+
+/// <summary>
+/// Adapts YouTube search/playlist candidates to <see cref="EpisodeModel"/> and applies
+/// <see cref="CrossPlatformMatchScorer"/> for enrichment acceptance (delay is a score signal).
+/// </summary>
+public static class YouTubeEnrichmentCandidate
+{
+    public static EpisodeModel ToEpisode(
+        string title,
+        string? description,
+        DateTime release,
+        TimeSpan length,
+        string youTubeId) =>
+        new()
+        {
+            Title = title,
+            Description = description ?? string.Empty,
+            Release = release,
+            Length = length,
+            YouTubeId = youTubeId
+        };
+
+    public static EpisodeModel ToEpisode(SearchResult searchResult, Google.Apis.YouTube.v3.Data.Video? video)
+    {
+        var length = video?.GetLength() ?? TimeSpan.Zero;
+        var description = searchResult.Snippet?.Description
+                          ?? video?.Snippet?.Description
+                          ?? string.Empty;
+        return ToEpisode(
+            searchResult.Snippet.Title,
+            description,
+            searchResult.Snippet.PublishedAtDateTimeOffset?.UtcDateTime ?? DateTime.MinValue,
+            length,
+            searchResult.Id.VideoId);
+    }
+
+    public static EpisodeModel ToEpisode(PlaylistItem playlistItem, Google.Apis.YouTube.v3.Data.Video? video)
+    {
+        var length = video?.GetLength() ?? TimeSpan.Zero;
+        var description = playlistItem.Snippet?.Description
+                          ?? video?.Snippet?.Description
+                          ?? string.Empty;
+        return ToEpisode(
+            playlistItem.Snippet.Title,
+            description,
+            playlistItem.Snippet.PublishedAtDateTimeOffset?.UtcDateTime ?? DateTime.MinValue,
+            length,
+            playlistItem.GetVideoId());
+    }
+
+    public static Podcast ScoringPodcast(Podcast? podcast, TimeSpan? youTubePublishDelay)
+    {
+        if (podcast != null)
+        {
+            return podcast;
+        }
+
+        return new Podcast
+        {
+            YouTubePublicationOffset = youTubePublishDelay?.Ticks
+        };
+    }
+
+    public static bool MeetsStrongMatch(
+        EpisodeModel existingEpisode,
+        EpisodeModel youTubeCandidate,
+        Podcast podcast) =>
+        CrossPlatformMatchScorer.MeetsMatchThreshold(existingEpisode, youTubeCandidate, podcast);
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeSearchResultFinder.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeSearchResultFinder.cs
@@ -33,15 +33,20 @@ public partial class YouTubeSearchResultFinder(
         EpisodeModel episode,
         IList<SearchResult> searchResults,
         TimeSpan? youTubePublishDelay,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast? podcast = null)
     {
-        var exactTitleMatch = await MatchOnExactTitleWithDuration(episode, searchResults, indexingContext);
+        var scoringPodcast = YouTubeEnrichmentCandidate.ScoringPodcast(podcast, youTubePublishDelay);
+
+        var exactTitleMatch = await MatchOnExactTitleWithDuration(
+            episode, searchResults, indexingContext, scoringPodcast);
         if (exactTitleMatch != null)
         {
             return exactTitleMatch;
         }
 
-        var episodeNumberMatch = await MatchOnEpisodeNumberWithDuration(episode, searchResults, indexingContext);
+        var episodeNumberMatch = await MatchOnEpisodeNumberWithDuration(
+            episode, searchResults, indexingContext, scoringPodcast);
         if (episodeNumberMatch != null)
         {
             return episodeNumberMatch;
@@ -52,7 +57,8 @@ public partial class YouTubeSearchResultFinder(
                 indexingContext);
 
 
-        var videoMatch = MatchOnEpisodeDuration(episode, searchResults, videoDetails, indexingContext);
+        var videoMatch = MatchOnEpisodeDuration(
+            episode, searchResults, videoDetails, scoringPodcast);
         if (videoMatch != null)
         {
             return videoMatch;
@@ -78,7 +84,15 @@ public partial class YouTubeSearchResultFinder(
                             if (matchingVideoLength > MinDurationForPublicationDate &&
                                 matchingVideoLengthDifferentTicks < VideoDurationToleranceForPublicationDate.Ticks)
                             {
-                                return new FindEpisodeResponse(match);
+                                var candidate = YouTubeEnrichmentCandidate.ToEpisode(match, videoDetail);
+                                if (YouTubeEnrichmentCandidate.MeetsStrongMatch(episode, candidate, scoringPodcast))
+                                {
+                                    return new FindEpisodeResponse(match, Video: videoDetail);
+                                }
+
+                                logger.LogInformation(
+                                    "Rejected publish-delay match for '{episodeTitle}' because cross-platform score is below threshold.",
+                                    episode.Title);
                             }
                         }
                     }
@@ -86,14 +100,15 @@ public partial class YouTubeSearchResultFinder(
             }
         }
 
-        return await MatchOnTextClosenessWithDuration(episode, searchResults, indexingContext);
+        return await MatchOnTextClosenessWithDuration(
+            episode, searchResults, indexingContext, scoringPodcast);
     }
 
     private FindEpisodeResponse? MatchOnEpisodeDuration(
         EpisodeModel episode,
         IList<SearchResult> searchResults,
         IList<Google.Apis.YouTube.v3.Data.Video>? videoDetails,
-        IndexingContext indexingContext)
+        Podcast scoringPodcast)
     {
         var videosWithDuration = videoDetails?
             .Where(x => YouTubeVideoDurationMatcher.HasDuration(x.GetLength()))
@@ -109,6 +124,15 @@ public partial class YouTubeSearchResultFinder(
                 var video = matchingPair.Video!;
                 if (IsDurationMatch(episode, video))
                 {
+                    var candidate = YouTubeEnrichmentCandidate.ToEpisode(searchResult, video);
+                    if (!YouTubeEnrichmentCandidate.MeetsStrongMatch(episode, candidate, scoringPodcast))
+                    {
+                        logger.LogInformation(
+                            "Rejected duration-closest match for '{episodeTitle}' because cross-platform score is below threshold.",
+                            episode.Title);
+                        return null;
+                    }
+
                     logger.LogInformation(
                         "Matched episode '{episodeTitle}' and length: '{episodeLength:g}' with episode '{snippetTitle}' having length: '{matchingPairVideoLength:g}'.",
                         episode.Title, episode.Length, matchingPair.SearchResult?.Snippet.Title,
@@ -138,7 +162,8 @@ public partial class YouTubeSearchResultFinder(
     private async Task<FindEpisodeResponse?> MatchOnEpisodeNumberWithDuration(
         EpisodeModel episode,
         IList<SearchResult> searchResults,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast scoringPodcast)
     {
         var match = MatchOnEpisodeNumber(episode, searchResults);
         if (match == null)
@@ -146,13 +171,15 @@ public partial class YouTubeSearchResultFinder(
             return null;
         }
 
-        return await ValidateSearchMatchWithDuration(episode, match, "episode-number", indexingContext);
+        return await ValidateSearchMatchWithDuration(
+            episode, match, "episode-number", indexingContext, scoringPodcast, requireStrongScore: true);
     }
 
     private async Task<FindEpisodeResponse?> MatchOnTextClosenessWithDuration(
         EpisodeModel episode,
         IList<SearchResult> searchResults,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast scoringPodcast)
     {
         var match = MatchOnTextCloseness(episode, searchResults);
         if (match == null)
@@ -160,7 +187,8 @@ public partial class YouTubeSearchResultFinder(
             return null;
         }
 
-        return await ValidateSearchMatchWithDuration(episode, match, "fuzzy title", indexingContext);
+        return await ValidateSearchMatchWithDuration(
+            episode, match, "fuzzy title", indexingContext, scoringPodcast, requireStrongScore: true);
     }
 
     private SearchResult? MatchOnEpisodeNumber(
@@ -216,7 +244,8 @@ public partial class YouTubeSearchResultFinder(
     private async Task<FindEpisodeResponse?> MatchOnExactTitleWithDuration(
         EpisodeModel episode,
         IList<SearchResult> searchResults,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast scoringPodcast)
     {
         var match = MatchOnExactTitle(episode, searchResults);
         if (match == null)
@@ -224,14 +253,17 @@ public partial class YouTubeSearchResultFinder(
             return null;
         }
 
-        return await ValidateSearchMatchWithDuration(episode, match, "episode-title", indexingContext);
+        return await ValidateSearchMatchWithDuration(
+            episode, match, "episode-title", indexingContext, scoringPodcast, requireStrongScore: true);
     }
 
     private async Task<FindEpisodeResponse?> ValidateSearchMatchWithDuration(
         EpisodeModel episode,
         SearchResult match,
         string matchKind,
-        IndexingContext indexingContext)
+        IndexingContext indexingContext,
+        Podcast? scoringPodcast,
+        bool requireStrongScore)
     {
         var videoDetails =
             await videoService.GetVideoContentDetails(youTubeService, [match.Id.VideoId], indexingContext);
@@ -247,6 +279,23 @@ public partial class YouTubeSearchResultFinder(
                 "Rejected {matchKind} match '{episodeTitle}' (length '{episodeLength:g}') with video '{videoTitle}' (length '{videoLength:g}') due to duration mismatch.",
                 matchKind, episode.Title, episode.Length, match.Snippet.Title, video.GetLength());
             return null;
+        }
+
+        if (requireStrongScore)
+        {
+            if (scoringPodcast == null)
+            {
+                return null;
+            }
+
+            var candidate = YouTubeEnrichmentCandidate.ToEpisode(match, video);
+            if (!YouTubeEnrichmentCandidate.MeetsStrongMatch(episode, candidate, scoringPodcast))
+            {
+                logger.LogInformation(
+                    "Rejected {matchKind} match '{episodeTitle}' because cross-platform score is below threshold.",
+                    matchKind, episode.Title);
+                return null;
+            }
         }
 
         logger.LogInformation("Matched on {matchKind} '{episodeTitle}'.", matchKind, episode.Title);


### PR DESCRIPTION
## Summary
- **DI:** `AddSpotifyServices` / `AddAppleServices` now call `AddSubjectServices` so `ISubjectMatcher` resolves in console tools (fixes `EnrichExistingEpisodesFromPodcastServices` crash; Functions were already fine).
- **Apple release authority:** new `AppleAuthoritativeAdoptReleaseMergePolicy` adopts Apple publish datetime over a timed YouTube release on a different calendar day; `GetAudioReleaseForPlatformLookup` no longer subtracts `YouTubePublishingDelay` once the release-authority audio identity is present.
- **Matching / YouTube enrich:** `CrossPlatformMatchScorer` subject/delay scoring and YouTube enricher/finders no longer hard-bypass on publishing delay (`YouTubeEnrichmentCandidate` + catalogue wrapper rules).
- **Tests / fixtures:** `DomainTestFixture.CreateAppleReleaseAuthorityPodcast`, Apple-authority audio lookup rules, release-date merging rules, and related scorer/enricher tests.
- **Agent rules:** add `deploy-functions-and-clis.mdc` and cross-link from `deployment.mdc`.

## Test plan
- [ ] `dotnet test` on Episodes.Tests and YouTube.Tests (or solution) for affected BusinessRules
- [ ] Smoke `EnrichExistingEpisodesFromPodcastServices` (or equivalent) — confirms `ISubjectMatcher` resolves
- [ ] Apple-authority podcast with cross-day YouTube timed release adopts Apple publish datetime on merge
- [ ] Audio platform lookup does not apply YouTube delay once Apple/Spotify id is present
- [ ] YouTube enrich still scores delayed candidates instead of hard-bypassing

Made with [Cursor](https://cursor.com)