### PR TITLE
fix(subjects): register ISubjectsProvider via AddSubjectServices

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeEnrichmentCandidate.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Services/YouTubeEnrichmentCandidate.cs
@@ -34,11 +34,11 @@ public static class YouTubeEnrichmentCandidate
                           ?? video?.Snippet?.Description
                           ?? string.Empty;
         return ToEpisode(
-            searchResult.Snippet.Title,
+            searchResult.Snippet?.Title ?? string.Empty,
             description,
-            searchResult.Snippet.PublishedAtDateTimeOffset?.UtcDateTime ?? DateTime.MinValue,
+            searchResult.Snippet?.PublishedAtDateTimeOffset?.UtcDateTime ?? DateTime.MinValue,
             length,
-            searchResult.Id.VideoId);
+            searchResult.Id?.VideoId ?? string.Empty);
     }
 
     public static EpisodeModel ToEpisode(PlaylistItem playlistItem, Google.Apis.YouTube.v3.Data.Video? video)
@@ -48,9 +48,9 @@ public static class YouTubeEnrichmentCandidate
                           ?? video?.Snippet?.Description
                           ?? string.Empty;
         return ToEpisode(
-            playlistItem.Snippet.Title,
+            playlistItem.Snippet?.Title ?? string.Empty,
             description,
-            playlistItem.Snippet.PublishedAtDateTimeOffset?.UtcDateTime ?? DateTime.MinValue,
+            playlistItem.Snippet?.PublishedAtDateTimeOffset?.UtcDateTime ?? DateTime.MinValue,
             length,
             playlistItem.GetVideoId());
     }

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Extensions/ServiceCollectionExtensions.cs
@@ -35,13 +35,27 @@ public static class ServiceCollectionExtensions
                 .AddScoped<IRecentPodcastEpisodeCategoriser, RecentPodcastEpisodeCategoriser>()
                 .AddScoped<ISubjectFactory, SubjectFactory>()
                 .AddScoped<IHashTagProvider, HashTagProvider>()
-                .AddSingleton<ICachedSubjectProvider, CachedSubjectProvider>();
+                .AddSingleton<ICachedSubjectProvider, CachedSubjectProvider>()
+                // SubjectService needs ISubjectsProvider; hosts that only get subjects via
+                // AddSpotifyServices/AddAppleServices must not omit the provider registration.
+                .AddCachedSubjectProvider();
         }
 
         public IServiceCollection AddCachedSubjectProvider()
         {
+            // Share the CachedSubjectProvider singleton with ICachedSubjectProvider when present
+            // (AddSubjectServices); otherwise create a standalone cached provider.
             return services
-                .AddSingleton<ISubjectsProvider, CachedSubjectProvider>();
+                .AddSingleton<ISubjectsProvider>(s =>
+                {
+                    var cached = s.GetService<ICachedSubjectProvider>();
+                    if (cached != null)
+                    {
+                        return cached;
+                    }
+
+                    return ActivatorUtilities.CreateInstance<CachedSubjectProvider>(s);
+                });
         }
 
         public IServiceCollection AddSubjectProvider()


### PR DESCRIPTION
## Summary
- Register `ISubjectsProvider` from `AddSubjectServices` (via `AddCachedSubjectProvider`) so EnrichExisting and other Spotify/Apple hosts that resolve `SubjectService` do not omit the provider.
- Share the `CachedSubjectProvider` singleton between `ICachedSubjectProvider` and `ISubjectsProvider` when both are registered.
- Clear CS8602 nullable warnings on `YouTubeEnrichmentCandidate` Snippet/Id access.

Follow-up to #941 (Apple-authority enrich + subject DI), where this registration was still incomplete for hosts that only call `AddSubjectServices`.

## Test plan
- [ ] Confirm `AddSubjectServices()` registers `ISubjectsProvider` and resolves the same instance as `ICachedSubjectProvider` when both are requested
- [ ] Build Spotify/Apple-consuming hosts (e.g. EnrichExisting path) without missing `ISubjectsProvider` DI failures
- [ ] Confirm `YouTubeEnrichmentCandidate` builds without CS8602 on Snippet access