### PR TITLE
fix(subjects): make AddSubjectServices register ITextSanitiser

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/RedditPodcastPoster.Subjects.Tests.csproj
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/RedditPodcastPoster.Subjects.Tests.csproj
@@ -12,7 +12,10 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -26,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\RedditPodcastPoster.DependencyInjection.Abstractions\RedditPodcastPoster.DependencyInjection.Abstractions.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Models\RedditPodcastPoster.Models.csproj" />
     <ProjectReference Include="..\RedditPodcastPoster.Subjects\RedditPodcastPoster.Subjects.csproj" />
   </ItemGroup>

--- a/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectServicesDependencyInjectionTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects.Tests/SubjectServicesDependencyInjectionTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RedditPodcastPoster.DependencyInjection;
+using RedditPodcastPoster.Persistence.Abstractions.Providers;
+using RedditPodcastPoster.Subjects.Extensions;
+using RedditPodcastPoster.Subjects.Matching;
+using RedditPodcastPoster.Text.KnownTerms;
+using RedditPodcastPoster.Text.Sanitisers;
+
+namespace RedditPodcastPoster.Subjects.Tests;
+
+public class SubjectServicesDependencyInjectionTests
+{
+    [Fact(DisplayName =
+        "AddSubjectServices self-containment: when host stubs Cosmos subjects provider and KnownTerms, then ISubjectMatcher resolves, because SubjectService needs ITextSanitiser + ISubjectsProvider.")]
+    public void AddSubjectServices_resolves_ISubjectMatcher_with_host_stubs()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSubjectServices();
+        ReplaceSubjectsProviderWithStub(services);
+        services.AddSingleton(Mock.Of<IAsyncInstance<IKnownTermsProvider>>());
+
+        using var provider = services.BuildServiceProvider();
+
+        // Act
+        var matcher = provider.GetRequiredService<ISubjectMatcher>();
+        var textSanitiser = provider.GetRequiredService<ITextSanitiser>();
+
+        // Assert
+        matcher.Should().NotBeNull();
+        textSanitiser.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName =
+        "AddSubjectServices registration: when called alone, then ITextSanitiser and ISubjectsProvider are registered, because Spotify/Apple hosts must not omit those deps.")]
+    public void AddSubjectServices_registers_text_sanitiser_and_subjects_provider()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddSubjectServices();
+
+        // Assert
+        services.Should().Contain(d => d.ServiceType == typeof(ITextSanitiser));
+        services.Should().Contain(d => d.ServiceType == typeof(ISubjectsProvider));
+        services.Should().Contain(d => d.ServiceType == typeof(ISubjectMatcher));
+    }
+
+    private static void ReplaceSubjectsProviderWithStub(IServiceCollection services)
+    {
+        foreach (var descriptor in services.Where(d => d.ServiceType == typeof(ISubjectsProvider)).ToList())
+        {
+            services.Remove(descriptor);
+        }
+
+        services.AddSingleton(Mock.Of<ISubjectsProvider>());
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Subjects/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Subjects/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using RedditPodcastPoster.Subjects.Matching;
 using RedditPodcastPoster.Subjects.Providers;
 using RedditPodcastPoster.Subjects.Repositories;
 using RedditPodcastPoster.Subjects.Services;
+using RedditPodcastPoster.Text.Extensions;
 
 namespace RedditPodcastPoster.Subjects.Extensions;
 
@@ -18,9 +19,18 @@ public static class ServiceCollectionExtensions
 {
     extension(IServiceCollection services)
     {
+        /// <summary>
+        /// Subject matching / categorisation graph.
+        /// Self-contained for <see cref="ISubjectMatcher"/> resolution once the host has
+        /// <c>AddRepositories()</c> (Cosmos container factory + KnownTerms for
+        /// <see cref="RedditPodcastPoster.Text.Sanitisers.ITextSanitiser"/>).
+        /// Called transitively by <c>AddSpotifyServices</c> / <c>AddAppleServices</c>.
+        /// </summary>
         public IServiceCollection AddSubjectServices()
         {
             return services
+                // SubjectService → ITextSanitiser (description extract for matching)
+                .AddTextSanitiser()
                 .AddSingleton<ISubjectRepository>(s =>
                 {
                     var containerFactory = s.GetRequiredService<ICosmosDbContainerFactory>();

--- a/Class-Libraries/RedditPodcastPoster.Text/Extensions/ServiceCollectionExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text/Extensions/ServiceCollectionExtensions.cs
@@ -14,11 +14,19 @@ public static class ServiceCollectionExtensions
     extension(IServiceCollection services)
     {
         /// <summary>
-        /// Text sanitisation services. Requires <c>AddRepositories()</c> (Persistence) for
-        /// <see cref="KnownTerms.IKnownTermsProvider"/> resolution via Cosmos lookup repos.
+        /// Text sanitisation services. Safe to call more than once (e.g. from
+        /// <c>AddSubjectServices</c> and an explicit host registration).
+        /// Requires <c>AddRepositories()</c> (Persistence) for
+        /// <see cref="KnownTerms.IKnownTermsProvider"/> via <c>IAsyncInstance&lt;IKnownTermsProvider&gt;</c>
+        /// when resolving <see cref="ITextSanitiser"/>.
         /// </summary>
         public IServiceCollection AddTextSanitiser()
         {
+            if (services.Any(d => d.ServiceType == typeof(ITextSanitiser)))
+            {
+                return services;
+            }
+
             return services
                 .AddSingleton<ITextSanitiser, TextSanitiser>()
                 .AddSingleton<IHtmlSanitiser, HtmlSanitiser>()


### PR DESCRIPTION
## Summary
- `AddSubjectServices` now calls `AddTextSanitiser()`, so hosts that only get subjects via `AddSpotifyServices` / `AddAppleServices` can resolve `ISubjectMatcher` → `SubjectService` without an explicit text-sanitiser registration.
- `AddTextSanitiser` is idempotent (skips if `ITextSanitiser` already registered).
- DI smoke tests cover registration + resolve of `ISubjectMatcher` with host stubs for `ISubjectsProvider` and KnownTerms.

**Root cause:** #942 fixed `ISubjectsProvider`; `SubjectService` still needed `ITextSanitiser`. `EnrichPodcastWithImages` calls Spotify/Apple but not `AddTextSanitiser()`.

**Constructor deps (for reference):**
| Type | Deps |
|------|------|
| SubjectService | ISubjectsProvider, ITextSanitiser, ILogger |
| SubjectMatcher | ISubjectService, ILogger |
| CachedSubjectProvider | ISubjectRepository, ILogger |
| SubjectEnricher | ISubjectMatcher, ILogger |
| Categoriser | ISubjectEnricher, ILogger |
| TextSanitiser | IAsyncInstance&lt;IKnownTermsProvider&gt; (via AddRepositories) |

**CLIs incomplete before this fix** (Spotify/Apple or SubjectServices without TextSanitiser): `EnrichPodcastWithImages`, `ExportSearchSuggestions`, `CosmosDbUploader`, `CosmosDbDownloader`. (`EnrichExistingEpisodesFromPodcastServices` already had it.)

## Test plan
- [x] `dotnet test` Subjects.Tests DI smoke tests
- [ ] Re-run `enrichpodcastWithImages -s "Unification Church"` after publishing CLI