### PR TITLE
fix(matching): window Apple catalogue releases by calendar day

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchScorerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchScorerRules.cs
@@ -212,6 +212,81 @@ public class CatalogueMatchScorerRules
     }
 
     [Fact(DisplayName =
+        "An Apple catalogue row released in the early-morning audio slot matches a YouTube probe " +
+        "published later the same calendar day, even though the gap exceeds twelve hours.")]
+    public void apple_same_calendar_day_beyond_twelve_hours_meets_threshold()
+    {
+        // Arrange
+        var baseTitle = _fixture.CreateTitle(5);
+        var youTubeRelease = DomainTestFixture.UtcAtTime(-1, TimeSpan.FromHours(17) + TimeSpan.FromMinutes(15));
+        var appleRelease = DomainTestFixture.UtcAtTime(-1, TimeSpan.FromMinutes(5));
+        var length = _fixture.CreateDuration();
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = baseTitle;
+            e.Description = string.Empty;
+            e.Length = length;
+            e.Release = youTubeRelease;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = DomainTestFixture.CreateTypoTitleVariant(baseTitle);
+            e.Description = string.Empty;
+            e.Length = length;
+            e.Release = appleRelease;
+            e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+
+        // Assert
+        (youTubeRelease - appleRelease).Should().BeGreaterThan(TimeSpan.FromHours(12));
+        score.Should().Be(
+            CatalogueMatchScorer.DurationWithinBandPoints +
+            CatalogueMatchScorer.SameCalendarDayReleasePoints +
+            CatalogueMatchScorer.FuzzyTitlePoints);
+        CatalogueMatchScorer.MeetsMatchThreshold(probe, catalogue).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "An Apple catalogue row released more than a day either side of the probe scores zero, " +
+        "so widening to calendar-day tolerance does not admit wrong-week audio.")]
+    public void apple_outside_day_tolerance_scores_zero()
+    {
+        // Arrange
+        var baseTitle = _fixture.CreateTitle(5);
+        var length = _fixture.CreateDuration();
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = baseTitle;
+            e.Description = string.Empty;
+            e.Length = length;
+            e.Release = DomainTestFixture.UtcAtTime(-1, TimeSpan.FromHours(17));
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = baseTitle;
+            e.Description = string.Empty;
+            e.Length = length;
+            e.Release = DomainTestFixture.UtcAtTime(-4, TimeSpan.FromHours(17));
+            e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+
+        // Assert
+        score.Should().Be(0);
+    }
+
+    [Fact(DisplayName =
         "When the catalogue row has no duration (Apple omitting durationInMilliseconds), " +
         "same-calendar-day release and disjoint titles with empty subjects stay below the threshold, " +
         "because missing duration must not revive release-only attaches.")]

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchScorer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchScorer.cs
@@ -12,6 +12,8 @@ namespace RedditPodcastPoster.Episodes.Matching;
 /// When either side lacks duration (e.g. Apple omitting <c>durationInMilliseconds</c>),
 /// duration points are skipped and duration band is not a hard fail — release window plus
 /// title/description/subjects must still clear the threshold (release alone cannot).
+/// Spotify and Apple catalogue items are both windowed on calendar days, not elapsed hours,
+/// because audio slots and YouTube publishes on the same day can be far more than twelve hours apart.
 /// </summary>
 public static class CatalogueMatchScorer
 {
@@ -135,13 +137,23 @@ public static class CatalogueMatchScorer
         return best;
     }
 
+    /// <summary>
+    /// Spotify and Apple both publish audio on the show's own schedule, which routinely sits more than
+    /// twelve hours from the YouTube publish the probe is derived from (Aug 2026 The Indo Daily: audio at
+    /// 00:05, YouTube at 18:15 the same day). Both are compared on calendar days rather than elapsed hours.
+    /// </summary>
+    private static bool IsAudioCatalogueItem(Episode catalogueItem) =>
+        !string.IsNullOrWhiteSpace(catalogueItem.SpotifyId) || catalogueItem.AppleId is > 0;
+
     private static int ScoreRelease(DateTime probeRelease, Episode catalogueItem)
     {
-        if (!string.IsNullOrWhiteSpace(catalogueItem.SpotifyId))
+        if (IsAudioCatalogueItem(catalogueItem))
         {
-            if (EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
+            if (EpisodeReleaseTolerance.AudioCatalogueReleaseMatches(
                     catalogueItem.Release,
-                    probeRelease))
+                    probeRelease,
+                    toleranceTicks: 0,
+                    podcast: null))
             {
                 var probeDate = DateOnly.FromDateTime(probeRelease);
                 var catalogueDate = DateOnly.FromDateTime(catalogueItem.Release);
@@ -168,11 +180,13 @@ public static class CatalogueMatchScorer
 
     private static bool IsWithinReleaseWindow(DateTime probeRelease, Episode catalogueItem)
     {
-        if (!string.IsNullOrWhiteSpace(catalogueItem.SpotifyId))
+        if (IsAudioCatalogueItem(catalogueItem))
         {
-            return EpisodeReleaseTolerance.SpotifyCatalogueReleaseMatches(
+            return EpisodeReleaseTolerance.AudioCatalogueReleaseMatches(
                 catalogueItem.Release,
-                probeRelease);
+                probeRelease,
+                toleranceTicks: 0,
+                podcast: null);
         }
 
         return Math.Abs((catalogueItem.Release - probeRelease).Ticks) <


### PR DESCRIPTION
## Summary

Apple Podcasts URLs were never attached to YouTube-discovered episodes on shows that publish audio in an early-morning slot and the YouTube cut later the same day.

`CatalogueMatchScorer` decided its release window by checking for a `SpotifyId` on the candidate. Spotify candidates therefore got calendar-day tolerance, while Apple candidates — which carry an `AppleId`, never a `SpotifyId` — fell through to an absolute 12-hour branch. `IsWithinReleaseWindow` returned false and `Score` short-circuited to zero before any title, duration, description, or subject evidence was considered, so no Apple candidate could win.

Reproduced on **The Indo Daily** (`588225f9-5d91-4d7b-9f55-7c2d3ed48d10`, Apple `1568934774`) with [this YouTube URL](https://www.youtube.com/watch?v=YhZJvABrXng):

| | Title | Release (UTC) | Duration |
|---|---|---|---|
| YouTube | The Jared Leto investigation as star denies sexual misconduct allegations \| The Indo Daily | 2026-08-04 18:15:30 | 20:09 |
| Apple | Inside the Jared Leto investigation as Hollywood star denies sexual misconduct allegations | 2026-08-04 00:05:00 | 22:46 |

The titles diverge enough to miss the exact/containment pass in `FindCatalogueMatchByLength`, so matching fell to the scorer. The podcast's `youTubePublicationOffset` of 1 hour put the probe at 17:15:30, still 17h10m from Apple's 00:05 slot — over the 12-hour limit. This show is affected on every episode, which is why both `submit-url -m` and `index.exe -n "The Indo Daily"` skipped Apple while Spotify attached correctly.

## Changes

- Added `IsAudioCatalogueItem`, treating a candidate as an audio catalogue row when it has either a `SpotifyId` or an `AppleId`.
- Routed both `IsWithinReleaseWindow` and `ScoreRelease` through the existing `EpisodeReleaseTolerance.AudioCatalogueReleaseMatches` helper, so Apple and Spotify are compared on calendar days rather than elapsed hours.
- Two regression tests in `CatalogueMatchScorerRules`.

The August 2026 wrong-attach protection is unchanged: same-day plus duration still totals 55 against a threshold of 60, so a match continues to require title, description, or subject evidence. For the episode above the score becomes 30 (duration within 2m37s) + 25 (same calendar day) + title and description similarity.

The 12-hour branch remains for candidates with neither identifier. `FindCatalogueMatchByLength` has only two callers — `SpotifySearchResultFinder` and `AppleEpisodeResolver` — so in practice every candidate now takes the calendar-day path.

## Test plan

- [x] `RedditPodcastPoster.Episodes.Tests` — 316 passed
- [x] `RedditPodcastPoster.PodcastServices.Apple.Tests` — 35 passed
- [x] `RedditPodcastPoster.PodcastServices.Spotify.Tests` — 162 passed
- [x] New test `apple_same_calendar_day_beyond_twelve_hours_meets_threshold` fails on `main`, passes here
- [x] New test `apple_outside_day_tolerance_scores_zero` passes both before and after, guarding against over-widening
- [ ] Re-run `index.exe -n "The Indo Daily"` after merge and confirm the Apple URL attaches to `41a0f70d-80e3-47c1-a4b9-cadf06a76746`

## Follow-up (not in this PR)

The Indo Daily's `youTubePublicationOffset` is 1 hour but the observed YouTube-vs-audio gap is roughly 18 hours. Matching no longer depends on that value being accurate, but it still feeds the "awaiting delayed audio release" enrichment skip, so it's worth correcting separately.
