### PR TITLE
fix(youtube): window playlist indexing on later of added-at and video publish

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Episode/YouTubeEpisodeProviderScheduledUploadRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Episode/YouTubeEpisodeProviderScheduledUploadRules.cs
@@ -1,0 +1,174 @@
+using System.Xml;
+using FluentAssertions;
+using Google.Apis.YouTube.v3.Data;
+using Moq;
+using Moq.AutoMock;
+using RedditPodcastPoster.Episodes.Adapters;
+using RedditPodcastPoster.Episodes.Adapters.Inputs;
+using RedditPodcastPoster.Episodes.Domain;
+using RedditPodcastPoster.Episodes.Factories;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.Models.Podcasts;
+using RedditPodcastPoster.PodcastServices.Abstractions.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Clients;
+using RedditPodcastPoster.PodcastServices.YouTube.Episode;
+using RedditPodcastPoster.PodcastServices.YouTube.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
+using RedditPodcastPoster.PodcastServices.YouTube.Video;
+using EpisodeModel = RedditPodcastPoster.Models.Episodes.Episode;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Episode;
+
+/// <summary>
+/// Creators schedule uploads: the video is added to the show playlist when it is uploaded and only
+/// becomes public days later. Playlist discovery must window such items on the video's publication
+/// and stamp the episode with it, otherwise release day sees no new episode.
+/// </summary>
+public class YouTubeEpisodeProviderScheduledUploadRules
+{
+    private readonly DomainTestFixture _fixture = new();
+    private readonly AutoMocker _mocker = new();
+
+    private IYouTubeEpisodeProvider Sut => _mocker.CreateInstance<YouTubeEpisodeProvider>();
+
+    [Fact(DisplayName =
+        "When a playlist holds a scheduled upload added before the released-since window but published inside it, " +
+        "playlist discovery yields the episode dated by the video's publication, because release day is when the " +
+        "episode becomes available.")]
+    public async Task Scheduled_upload_is_discovered_and_dated_by_video_publication()
+    {
+        // Arrange
+        var channelId = _fixture.CreateYouTubeChannelId();
+        var playlistId = _fixture.CreateYouTubePlaylistId();
+        var scheduledVideoId = _fixture.CreateYouTubeId();
+        var addedToPlaylistAt = DomainTestFixture.UtcAtTime(-5, TimeSpan.FromHours(14));
+        var videoPublishedAt = DomainTestFixture.UtcAtTime(0, TimeSpan.FromHours(15));
+        var indexingContext = new IndexingContext(DomainTestFixture.UtcDaysAgo(2));
+
+        _mocker.GetMock<ITolerantYouTubePlaylistService>()
+            .Setup(x => x.GetPlaylistVideoSnippets(
+                It.IsAny<YouTubePlaylistId>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<PlaylistOrder?>()))
+            .ReturnsAsync(new GetPlaylistVideoSnippetsResponse(
+                [CreateScheduledPlaylistItem(scheduledVideoId, addedToPlaylistAt, videoPublishedAt)]));
+
+        _mocker.GetMock<IYouTubeVideoService>()
+            .Setup(x => x.GetVideoContentDetails(
+                It.IsAny<IYouTubeServiceWrapper>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync([CreatePublicVideo(scheduledVideoId, channelId, videoPublishedAt)]);
+
+        _mocker.GetMock<IEpisodeFromCandidateFactory>()
+            .Setup(x => x.Create(It.IsAny<EpisodeCandidate>(), It.IsAny<bool>()))
+            .Returns(new EpisodeModel());
+
+        // Act
+        var response = await Sut.GetPlaylistEpisodes(
+            new YouTubePlaylistId(playlistId),
+            new YouTubeChannelId(channelId),
+            indexingContext,
+            playlistOrder: PlaylistOrder.Arbitrary);
+
+        // Assert
+        response.Results.Should().ContainSingle();
+        _mocker.GetMock<IEpisodeCatalogueAdapter<YouTubeCatalogueInput>>().Verify(
+            x => x.Adapt(It.Is<YouTubeCatalogueInput>(i =>
+                i.YouTubeId == scheduledVideoId && i.Release == videoPublishedAt)),
+            Times.Once,
+            "the episode must be dated by the video's publication, not by when it joined the playlist");
+    }
+
+    [Fact(DisplayName =
+        "When a playlist holds a video added and published before the released-since window, playlist discovery " +
+        "yields nothing, because widening to video-published-at must not pull genuinely old episodes back in.")]
+    public async Task Video_published_before_the_window_is_still_excluded()
+    {
+        // Arrange
+        var channelId = _fixture.CreateYouTubeChannelId();
+        var playlistId = _fixture.CreateYouTubePlaylistId();
+        var staleVideoId = _fixture.CreateYouTubeId();
+        var addedToPlaylistAt = DomainTestFixture.UtcAtTime(-5, TimeSpan.FromHours(14));
+        var videoPublishedAt = DomainTestFixture.UtcAtTime(-5, TimeSpan.FromHours(15));
+        var indexingContext = new IndexingContext(DomainTestFixture.UtcDaysAgo(2));
+
+        _mocker.GetMock<ITolerantYouTubePlaylistService>()
+            .Setup(x => x.GetPlaylistVideoSnippets(
+                It.IsAny<YouTubePlaylistId>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<PlaylistOrder?>()))
+            .ReturnsAsync(new GetPlaylistVideoSnippetsResponse(
+                [CreateScheduledPlaylistItem(staleVideoId, addedToPlaylistAt, videoPublishedAt)]));
+
+        _mocker.GetMock<IYouTubeVideoService>()
+            .Setup(x => x.GetVideoContentDetails(
+                It.IsAny<IYouTubeServiceWrapper>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IndexingContext>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync([CreatePublicVideo(staleVideoId, channelId, videoPublishedAt)]);
+
+        // Act
+        var response = await Sut.GetPlaylistEpisodes(
+            new YouTubePlaylistId(playlistId),
+            new YouTubeChannelId(channelId),
+            indexingContext,
+            playlistOrder: PlaylistOrder.Arbitrary);
+
+        // Assert
+        response.Results.Should().BeNullOrEmpty();
+        _mocker.GetMock<IEpisodeCatalogueAdapter<YouTubeCatalogueInput>>().Verify(
+            x => x.Adapt(It.IsAny<YouTubeCatalogueInput>()),
+            Times.Never);
+    }
+
+    private PlaylistItem CreateScheduledPlaylistItem(
+        string videoId,
+        DateTime addedToPlaylistAt,
+        DateTime videoPublishedAt) =>
+        new()
+        {
+            Snippet = new PlaylistItemSnippet
+            {
+                Title = _fixture.CreateTitle(),
+                ResourceId = new ResourceId { VideoId = videoId },
+                PublishedAtDateTimeOffset = new DateTimeOffset(addedToPlaylistAt, TimeSpan.Zero)
+            },
+            ContentDetails = new PlaylistItemContentDetails
+            {
+                VideoId = videoId,
+                VideoPublishedAtDateTimeOffset = new DateTimeOffset(videoPublishedAt, TimeSpan.Zero)
+            }
+        };
+
+    private Google.Apis.YouTube.v3.Data.Video CreatePublicVideo(
+        string videoId,
+        string channelId,
+        DateTime videoPublishedAt) =>
+        new()
+        {
+            Id = videoId,
+            Snippet = new VideoSnippet
+            {
+                Title = _fixture.CreateTitle(),
+                Description = _fixture.CreateTitle(),
+                ChannelId = channelId,
+                LiveBroadcastContent = "none",
+                PublishedAtDateTimeOffset = new DateTimeOffset(videoPublishedAt, TimeSpan.Zero)
+            },
+            ContentDetails = new VideoContentDetails
+            {
+                Duration = XmlConvert.ToString(_fixture.CreateDuration()),
+                ContentRating = new ContentRating()
+            },
+            Statistics = new VideoStatistics { ViewCount = 1000, LikeCount = 10, CommentCount = 2 }
+        };
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Extensions/ScheduledUploadIndexingWindowRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Extensions/ScheduledUploadIndexingWindowRules.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using Google.Apis.YouTube.v3.Data;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using RedditPodcastPoster.PodcastServices.Abstractions.Models;
+using RedditPodcastPoster.PodcastServices.YouTube.Extensions;
+
+namespace RedditPodcastPoster.PodcastServices.YouTube.Tests.Extensions;
+
+/// <summary>
+/// A playlist item's <c>snippet.publishedAt</c> is the added-to-playlist time. A scheduled upload
+/// joins the playlist when it is uploaded, days before it becomes public, so windowing purely on
+/// added-at drops the episode on the day it actually releases.
+/// </summary>
+public class ScheduledUploadIndexingWindowRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "When a playlist item's video published after the item was added to the playlist, the indexing window " +
+        "date is the video's publication, because a scheduled upload joins the playlist before it goes public.")]
+    public void Scheduled_upload_is_windowed_on_video_publication()
+    {
+        // Arrange
+        var addedAt = DomainTestFixture.UtcAtTime(-5, TimeSpan.FromHours(14));
+        var videoPublishedAt = DomainTestFixture.UtcAtTime(0, TimeSpan.FromHours(15));
+        var item = CreatePlaylistItem(_fixture.CreateYouTubeId(), addedAt, videoPublishedAt);
+
+        // Act
+        var windowDate = item.GetIndexingWindowDate();
+
+        // Assert
+        windowDate.Should().Be(new DateTimeOffset(videoPublishedAt, TimeSpan.Zero));
+    }
+
+    [Fact(DisplayName =
+        "When a backlog video is added to a curated playlist long after it was published, the indexing window " +
+        "date stays the added-to-playlist time, because added-at is the new-to-this-feed signal.")]
+    public void Backlog_video_is_windowed_on_added_to_playlist_time()
+    {
+        // Arrange
+        var videoPublishedAt = DomainTestFixture.UtcAtTime(-400, TimeSpan.FromHours(9));
+        var addedAt = DomainTestFixture.UtcAtTime(-1, TimeSpan.FromHours(11));
+        var item = CreatePlaylistItem(_fixture.CreateYouTubeId(), addedAt, videoPublishedAt);
+
+        // Act
+        var windowDate = item.GetIndexingWindowDate();
+
+        // Assert
+        windowDate.Should().Be(new DateTimeOffset(addedAt, TimeSpan.Zero));
+    }
+
+    [Fact(DisplayName =
+        "When a playlist item carries no content details, the indexing window date falls back to the " +
+        "added-to-playlist time, because video-published-at is only returned when contentDetails were requested.")]
+    public void Missing_content_details_falls_back_to_added_to_playlist_time()
+    {
+        // Arrange
+        var addedAt = DomainTestFixture.UtcAtTime(-2, TimeSpan.FromHours(8));
+        var item = CreatePlaylistItem(_fixture.CreateYouTubeId(), addedAt, videoPublishedAt: null);
+
+        // Act
+        var windowDate = item.GetIndexingWindowDate();
+
+        // Assert
+        windowDate.Should().Be(new DateTimeOffset(addedAt, TimeSpan.Zero));
+    }
+
+    [Fact(DisplayName =
+        "When episode matching is scoped by released-since, a scheduled upload added to the playlist before the " +
+        "window but published inside it is retained, because the video is new to the catalogue today.")]
+    public void Episode_matching_retains_scheduled_upload_published_inside_the_window()
+    {
+        // Arrange
+        var releasedSince = DomainTestFixture.UtcDaysAgo(2);
+        var scheduledId = _fixture.CreateYouTubeId();
+        var staleId = _fixture.CreateYouTubeId();
+        var items = new List<PlaylistItem>
+        {
+            CreatePlaylistItem(
+                scheduledId,
+                addedAt: DomainTestFixture.UtcAtTime(-5, TimeSpan.FromHours(14)),
+                videoPublishedAt: DomainTestFixture.UtcAtTime(0, TimeSpan.FromHours(15))),
+            CreatePlaylistItem(
+                staleId,
+                addedAt: DomainTestFixture.UtcAtTime(-5, TimeSpan.FromHours(14)),
+                videoPublishedAt: DomainTestFixture.UtcAtTime(-5, TimeSpan.FromHours(15)))
+        };
+
+        // Act
+        var matched = items.ForEpisodeMatching(new IndexingContext(releasedSince));
+
+        // Assert
+        matched.Should().ContainSingle().Which.GetVideoId().Should().Be(scheduledId);
+    }
+
+    private static PlaylistItem CreatePlaylistItem(
+        string videoId,
+        DateTime addedAt,
+        DateTime? videoPublishedAt) =>
+        new()
+        {
+            Snippet = new PlaylistItemSnippet
+            {
+                ResourceId = new ResourceId { VideoId = videoId },
+                PublishedAtDateTimeOffset = new DateTimeOffset(addedAt, TimeSpan.Zero)
+            },
+            ContentDetails = videoPublishedAt == null
+                ? null
+                : new PlaylistItemContentDetails
+                {
+                    VideoId = videoId,
+                    VideoPublishedAtDateTimeOffset = new DateTimeOffset(videoPublishedAt.Value, TimeSpan.Zero)
+                }
+        };
+}

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Mapping/YouTubeCatalogueInputMappingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube.Tests/Mapping/YouTubeCatalogueInputMappingRules.cs
@@ -74,6 +74,29 @@ public class YouTubeCatalogueInputMappingRules
             .ComparingByMembers<YouTubeCatalogueInput>());
     }
 
+    [Fact(DisplayName =
+        "When a playlist item's video published after the item joined the playlist, catalogue mapping releases the " +
+        "episode on the video's publication, because a scheduled upload joins the playlist before it goes public.")]
+    public void Playlist_item_release_uses_video_publication_when_it_is_later()
+    {
+        // Arrange
+        var catalogueInput = _fixture.CreateYouTubeCatalogueInput();
+        var addedToPlaylistAt = DomainTestFixture.UtcAtTime(-5, TimeSpan.FromHours(14));
+        var videoPublishedAt = DomainTestFixture.UtcAtTime(0, TimeSpan.FromHours(15));
+        var playlistItemSnippet = CreatePlaylistItemSnippet(catalogueInput);
+        playlistItemSnippet.PublishedAtDateTimeOffset = new DateTimeOffset(addedToPlaylistAt, TimeSpan.Zero);
+        var videoDetails = CreateVideoDetails(
+            catalogueInput,
+            durationIso8601: XmlConvert.ToString(catalogueInput.Duration));
+        videoDetails.Snippet.PublishedAtDateTimeOffset = new DateTimeOffset(videoPublishedAt, TimeSpan.Zero);
+
+        // Act
+        var input = playlistItemSnippet.ToCatalogueInput(videoDetails, catalogueInput.Image);
+
+        // Assert
+        input.Release.Should().Be(videoPublishedAt);
+    }
+
     private SearchResult CreateSearchResult(YouTubeCatalogueInput catalogueInput) =>
         new()
         {

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Episode/YouTubeEpisodeProvider.cs
@@ -117,7 +117,7 @@ public class YouTubeEpisodeProvider(
         if (indexingContext.ReleasedSince.HasValue)
         {
             playlistItems = playlistItems
-                .Where(x => x.Snippet.PublishedAtDateTimeOffset.ReleasedSinceDate(indexingContext.ReleasedSince))
+                .Where(x => x.GetIndexingWindowDate().ReleasedSinceDate(indexingContext.ReleasedSince))
                 .ToList();
         }
 
@@ -197,7 +197,7 @@ public class YouTubeEpisodeProvider(
         if (indexingContext.ReleasedSince.HasValue)
         {
             results = results.Where(x =>
-                x.Snippet.PublishedAtDateTimeOffset.ReleasedSinceDate(indexingContext.ReleasedSince)).ToList();
+                x.GetIndexingWindowDate().ReleasedSinceDate(indexingContext.ReleasedSince)).ToList();
         }
 
         var videoDetails =

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/PlaylistItemExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Extensions/PlaylistItemExtensions.cs
@@ -12,6 +12,24 @@ public static class PlaylistItemExtensions
     public static string GetVideoId(this PlaylistItem item) =>
         item.ContentDetails?.VideoId ?? item.Snippet.ResourceId.VideoId;
 
+    /// <summary>
+    /// The date a playlist item enters an <see cref="IndexingContext.ReleasedSince"/> window.
+    /// A playlist item's <c>snippet.publishedAt</c> is the added-to-playlist time, which a scheduled
+    /// upload receives days before the video becomes public, so take whichever of added-at and the
+    /// video's own publication is later. Backlog videos added to a curated playlist long after they
+    /// were published keep their added-at, which is the "new to this feed" signal.
+    /// </summary>
+    public static DateTimeOffset? GetIndexingWindowDate(this PlaylistItem item) =>
+        LaterOf(item.Snippet?.PublishedAtDateTimeOffset, item.ContentDetails?.VideoPublishedAtDateTimeOffset);
+
+    /// <inheritdoc cref="GetIndexingWindowDate(PlaylistItem)"/>
+    public static DateTimeOffset? GetIndexingWindowDate(
+        this PlaylistItemSnippet playlistItemSnippet,
+        Google.Apis.YouTube.v3.Data.Video? videoDetails) =>
+        LaterOf(
+            playlistItemSnippet.PublishedAtDateTimeOffset,
+            videoDetails?.Snippet?.PublishedAtDateTimeOffset);
+
     public static IList<PlaylistItem> ForEpisodeMatching(
         this IEnumerable<PlaylistItem> items,
         IndexingContext indexingContext)
@@ -19,10 +37,25 @@ public static class PlaylistItemExtensions
         if (indexingContext.ReleasedSince.HasValue)
         {
             return items
-                .Where(x => x.Snippet.PublishedAtDateTimeOffset.ReleasedSinceDate(indexingContext.ReleasedSince))
+                .Where(x => x.GetIndexingWindowDate().ReleasedSinceDate(indexingContext.ReleasedSince))
                 .ToList();
         }
 
         return items.Take(MaxMatchCandidatesWithoutReleasedSince).ToList();
+    }
+
+    private static DateTimeOffset? LaterOf(DateTimeOffset? first, DateTimeOffset? second)
+    {
+        if (first == null)
+        {
+            return second;
+        }
+
+        if (second == null)
+        {
+            return first;
+        }
+
+        return second > first ? second : first;
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Mapping/YouTubeCatalogueInputMapping.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Mapping/YouTubeCatalogueInputMapping.cs
@@ -28,7 +28,7 @@ public static class YouTubeCatalogueInputMapping
             playlistItemSnippet.Title.Trim(),
             videoDetails.Snippet.Description.Trim(),
             videoDetails.GetLength() ?? TimeSpan.Zero,
-            playlistItemSnippet.PublishedAtDateTimeOffset!.Value.UtcDateTime,
+            playlistItemSnippet.GetIndexingWindowDate(videoDetails)!.Value.UtcDateTime,
             playlistItemSnippet.ToYouTubeUrl(),
             image);
 }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices.YouTube/Playlist/YouTubePlaylistService.cs
@@ -7,6 +7,7 @@ using RedditPodcastPoster.Models.Podcasts;
 using RedditPodcastPoster.PodcastServices.Abstractions;
 using RedditPodcastPoster.PodcastServices.YouTube.Clients;
 using RedditPodcastPoster.PodcastServices.YouTube.Exceptions;
+using RedditPodcastPoster.PodcastServices.YouTube.Extensions;
 using RedditPodcastPoster.PodcastServices.YouTube.Models;
 using RedditPodcastPoster.PodcastServices.YouTube.Quota;
 using RedditPodcastPoster.PodcastServices.Abstractions.Models;
@@ -40,7 +41,7 @@ public class YouTubePlaylistService(
 
         // Curated playlists carry no date information in their positions: new items may appear at
         // either end. Walk at max batch size (1 quota unit per 50 items) with a hard page cap
-        // (see ArbitraryYouTubePlaylistWalk.MaxPages) and rely on the ReleasedSince added-at
+        // (see ArbitraryYouTubePlaylistWalk.MaxPages) and rely on the ReleasedSince window
         // filter below; skip the head-order probe entirely so the expensive-query flag is never
         // flipped by a meaningless head sample.
         var arbitraryOrder = playlistOrder == PlaylistOrder.Arbitrary;
@@ -61,8 +62,11 @@ public class YouTubePlaylistService(
         var knownToBeInReverseOrder = false;
         bool? isExpensiveQuery = null;
         var pagesFetched = 0;
+        // contentDetails is free on playlistItems.list (1 unit per page regardless of parts) and carries
+        // videoPublishedAt, which the ReleasedSince filter below needs to window scheduled uploads on
+        // their public release rather than the earlier added-to-playlist time.
         var requestScope = "snippet";
-        if (withContentDetails)
+        if (withContentDetails || indexingContext.ReleasedSince.HasValue)
         {
             requestScope += ",contentDetails";
         }
@@ -186,7 +190,7 @@ public class YouTubePlaylistService(
         if (result.Any() && indexingContext.ReleasedSince != null)
         {
             result = result.Where(x =>
-                x.Snippet.PublishedAtDateTimeOffset.ReleasedSinceDate(indexingContext.ReleasedSince)).ToList();
+                x.GetIndexingWindowDate().ReleasedSinceDate(indexingContext.ReleasedSince)).ToList();
         }
 
         return new GetPlaylistVideoSnippetsResponse(result, isExpensiveQuery);

--- a/docs/catalogue-pagination.md
+++ b/docs/catalogue-pagination.md
@@ -21,7 +21,7 @@ on page one:
 |-----------------|----------------------------|----------------|
 | Newest-first (reverse-chronological) | Head of the list | Page from offset/page 0; stop when items fall before `ReleasedSince` |
 | Oldest-first (ascending) | Tail of the list | Spotify: jump to last page and walk back. YouTube: no end-jump API → full walk (expensive) |
-| Arbitrary / curated | Either end, inconsistently | YouTube only: capped full walk + filter on added-at; never trust position |
+| Arbitrary / curated | Either end, inconsistently | YouTube only: capped full walk + filter on the indexing-window date; never trust position |
 
 Mis-classifying order causes either **missed episodes** (early-stop on a stale head) or
 **quota burn** (unbounded walks on news-channel-scale feeds). The system therefore:
@@ -38,8 +38,13 @@ Mis-classifying order causes either **missed episodes** (early-stop on a stale h
 
 Indexing windows pass `IndexingContext.ReleasedSince`. Date-scoped walks must stop (or
 filter) once items fall outside that window. Spotify truncates to **date-only** before
-comparing (catalogue releases have no reliable time-of-day). YouTube playlist items use
-`snippet.publishedAt` = **added-to-playlist** time for playlist walks.
+comparing (catalogue releases have no reliable time-of-day). YouTube playlist items window on
+`PlaylistItem.GetIndexingWindowDate()` — the **later** of `snippet.publishedAt`
+(added-to-playlist) and `contentDetails.videoPublishedAt` (video publication). A scheduled
+upload joins the playlist days before it goes public, so added-at alone drops it from the
+window; a backlog video added long after publication keeps added-at, which is the
+"new to this feed" signal. Playlist item requests therefore ask for `contentDetails` whenever
+`ReleasedSince` is set (same 1-unit page cost).
 
 ### Expensive-query flags (podcast document)
 
@@ -214,7 +219,7 @@ Continue while nextPageToken != null
   AND (not reverse-chrono OR last item still in ReleasedSince window)
         │
         ▼
-Filter results by ReleasedSince (added-at)
+Filter results by ReleasedSince (later of added-at and video-published-at)
 Discovery: YouTubeExpensiveQueryFlag.Apply (unless Arbitrary)
 ```
 
@@ -267,6 +272,7 @@ still must be capped so a mis-tagged uploads feed cannot empty the daily key bud
 | Head-order probe (incl. equal timestamps) | `YouTube.Tests/Playlist/PlaylistItemOrderingRules.cs` |
 | Flag Apply set / clear / inconclusive | `YouTube.Tests/Playlist/YouTubeExpensiveQueryFlagRules.cs` |
 | Discovery flag round-trip + Arbitrary | `YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerRules.cs` |
+| Scheduled-upload indexing window (later of added-at / video-published-at) | `YouTube.Tests/Extensions/ScheduledUploadIndexingWindowRules.cs`, `YouTube.Tests/Episode/YouTubeEpisodeProviderScheduledUploadRules.cs` |
 | Discovery path wiring | `YouTube.Tests/Handlers/YouTubeEpisodeRetrievalHandlerTests.cs` |
 | `RunExpensiveYouTubePlaylistPagination` | `YouTube.Tests/IndexingContextExtensionsTests.cs` |
 | Pipeline persistence | `PodcastServices.Tests/BusinessRules/Indexing/IndexingOrchestrationRules.cs` |
@@ -296,6 +302,7 @@ still must be capped so a mis-tagged uploads feed cannot empty the daily key bud
 |---------|--------------|-------|
 | Recent episode missing Spotify URL | Ascending catalogue + skip-expensive without window; or walk-back circuit breaker | Flag flip / circuit-breaker Error; `ReleasedSince` window |
 | Recent YouTube URL missing on curated show | Playlist not `Arbitrary`, or wrong playlist id, or Arbitrary cap tripped | `youTubePlaylistOrder`, playlist id / `youTubePlaylistIdHistory`, Arbitrary circuit-breaker Error |
+| YouTube episode public today but not indexed, and its playlist item was added days ago | Scheduled upload — added-at is outside the window, video-published-at is inside | `contentDetails.videoPublishedAt` vs `snippet.publishedAt` on the playlist item |
 | Expensive flag stuck `true` forever | Probe never returned conclusive newest-first (should not happen — Apply clears) | Flag-flip Warning history |
 | Quota spike on YouTube | Mis-tagged Arbitrary on a huge playlist; or many ascending full walks | Arbitrary circuit-breaker; hour-0 expensive YouTube pass |
 

--- a/docs/youtube-playlist-order.md
+++ b/docs/youtube-playlist-order.md
@@ -34,6 +34,7 @@ Manually curated playlists break both assumptions:
 | No reverse/tail pagination — `nextPageToken` only walks forward | "Check both ends cheaply" is not possible positionally |
 | `playlistItems.list` accepts `playlistId` + `videoId` (~1 unit) and returns `snippet.position` | A known video's playlist position can be looked up without walking |
 | For playlist items, `snippet.publishedAt` = **added-to-playlist time** | On curated playlists, added-at is the "new to this feed" signal regardless of position |
+| A **scheduled** upload joins the playlist days before it goes public; `contentDetails.videoPublishedAt` carries the real publication | Windowing on added-at alone hides scheduled uploads. Window on `PlaylistItem.GetIndexingWindowDate()` — the later of added-at and video-published-at |
 
 ---
 
@@ -58,7 +59,8 @@ When `Arbitrary`:
   channel-scale playlist.
 - Head-order probe skipped; `IsExpensiveQuery` stays `null`; discovery never Applys the
   expensive flag.
-- `ReleasedSince` filter (added-at) still applies after the walk.
+- `ReleasedSince` filter still applies after the walk, on the indexing-window date
+  (later of added-at and `contentDetails.videoPublishedAt`).
 - `SkipExpensiveYouTubeQueries` does not degrade to a single page.
 
 Full decision tables, discovery vs enrichment, and hourly gates:
@@ -98,3 +100,4 @@ Critical YouTube-only cases:
 | Equal added-at timestamps count as reverse-chrono (curated failure mode) | `PlaylistItemOrderingRules` |
 | Arbitrary circuit breaker trips at MaxPages with next token remaining | `ArbitraryYouTubePlaylistWalkRules` |
 | Arbitrary leaves expensive flag untouched even if a probe value sneaks through | `YouTubeEpisodeRetrievalHandlerRules` |
+| Scheduled upload added before the window but published inside it is retained and dated by publication | `ScheduledUploadIndexingWindowRules`, `YouTubeEpisodeProviderScheduledUploadRules` |


### PR DESCRIPTION
## Summary

- Fix YouTube playlist `ReleasedSince` windowing so scheduled uploads are not dropped when they join the playlist days before going public.
- Window on `PlaylistItem.GetIndexingWindowDate()` — the **later** of `snippet.publishedAt` (added-to-playlist) and `contentDetails.videoPublishedAt` (public publish) — and use the same date when mapping catalogue release.
- Docs updated in sync (`docs/catalogue-pagination.md`, `docs/youtube-playlist-order.md`) per AGENTS.md HARD guidance for this area.

### Production evidence (Preacher Boys Podcast)

YouTube release authority; `youTubePlaylistId: "PLKdUWzQpByAQ"`; `youTubePlaylistOrder: "Arbitrary"` (previous playlist `PL3bVHY_fIafVIG-QBn_UtBqpeRfLeBhsJ` replaced 2026-07-25). Indexer `indexer__ReleasedDaysAgo = 2` (window from ~2026-08-03).

| Field | Value |
|-------|-------|
| Video | `MTgRFb3mWZc` — "How Abusive Pastors Get Power and Keep Power in Churches" |
| Playlist | `PLKdUWzQpByAQ` (item present) |
| `snippet.publishedAt` (added-at) | 2026-07-31 14:52:07Z |
| `contentDetails.videoPublishedAt` (public) | 2026-08-05 15:00:25Z |
| Window start (~ReleasedDaysAgo=2) | ~2026-08-03 |
| Rejection | Compared window against **added-at** → July 31 outside window → filtered before match/merge |

Category: returned by source but filtered out.

### What changed

- `GetIndexingWindowDate()` on playlist items / snippets
- `YouTubePlaylistService` requests `contentDetails` when `ReleasedSince` is set; filters on the new window date
- `YouTubeEpisodeProvider` + catalogue mapping use the same window date for filter and release stamp
- Rule tests for scheduled-upload keep / backlog keep-added-at / old publish still excluded

### Backlog additions unaffected

A video published long ago and added to a curated playlist recently still windows on **added-at** (the later timestamp), so "new to this feed" backlog items remain in-window.

### Quota

`playlistItems.list` costs **1 unit per page regardless of parts**. Requesting `contentDetails` alongside `snippet` when `ReleasedSince` is set does **not** increase quota per call (commented in `YouTubePlaylistService`).

## Test plan

- [x] `dotnet test Class-Libraries\RedditPodcastPoster.PodcastServices.YouTube.Tests` — Passed: 216, Skipped: 1, Total: 217
- [x] `dotnet test Class-Libraries\RedditPodcastPoster.PodcastServices.Tests` — Passed: 75, Failed: 0
- [x] `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged -BaseRef origin/main` — OK (3 file(s))
- [ ] After deploy: re-index Preacher Boys and confirm `MTgRFb3mWZc` is discovered when published inside the window
