### PR TITLE
fix(language): English as null; stop podcast-language search fallback

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/HomepagePublisher.cs
+++ b/Class-Libraries/RedditPodcastPoster.ContentPublisher/Publishers/HomepagePublisher.cs
@@ -158,7 +158,7 @@ public class HomepagePublisher(
                 Length = episode.Length,
                 Subjects = episode.Subjects,
                 Images = episode.Images,
-                Language = episode.Language ?? episode.PodcastLanguage
+                Language = episode.Language
             });
         }
 

--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Extensions/PodcastEpisodeExtensions.cs
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Extensions/PodcastEpisodeExtensions.cs
@@ -26,7 +26,9 @@ public static class PodcastEpisodeExtensions
             InternetArchive = podcastEpisode.Episode.Urls.InternetArchive != null
                 ? podcastEpisode.Episode.Urls.InternetArchive.ToString()
                 : string.Empty,
-            Lang = podcastEpisode.Episode.Language ?? podcastEpisode.Podcast.Language,
+            // Episode.Language only — null means English. Do not fall back to podcast language
+            // (that undid curator "English" / "No Language" clears on non-English shows).
+            Lang = NullIfWhiteSpace(podcastEpisode.Episode.Language),
             PodcastAppleId = podcastEpisode.Podcast.AppleId?.ToString(),
             PodcastName = podcastEpisode.Podcast.Name.Trim(),
             PodcastSearchTerms = podcastEpisode.Podcast.SearchTerms ?? string.Empty,
@@ -37,6 +39,6 @@ public static class PodcastEpisodeExtensions
         };
     }
 
-    private static string? NullIfWhiteSpace(string value) =>
+    private static string? NullIfWhiteSpace(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;
 }

--- a/Class-Libraries/RedditPodcastPoster.Models/Episodes/Episode.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/Episodes/Episode.cs
@@ -215,7 +215,12 @@ public class Episode
         return episode;
     }
 
-    public (bool, bool) SetPodcastProperties(Podcast podcast)
+    /// <param name="inheritLanguageIfUnset">
+    /// When true (new episodes only), copy <see cref="Podcast.Language"/> onto this episode if
+    /// <see cref="Language"/> is unset. Never pass true for existing episodes — null language means
+    /// English and must not be overwritten by the podcast default.
+    /// </param>
+    public (bool, bool) SetPodcastProperties(Podcast podcast, bool inheritLanguageIfUnset = false)
     {
         var updated = false;
         if (PodcastId != podcast.Id)
@@ -258,7 +263,7 @@ public class Episode
             updatedMetadata = true;
         }
 
-        if (InheritLanguageFromPodcastIfUnset(podcast))
+        if (inheritLanguageIfUnset && InheritLanguageFromPodcastIfUnset(podcast))
         {
             updated = true;
         }

--- a/Class-Libraries/RedditPodcastPoster.PodcastServices/Merging/EpisodeMerger.cs
+++ b/Class-Libraries/RedditPodcastPoster.PodcastServices/Merging/EpisodeMerger.cs
@@ -48,7 +48,7 @@ public class EpisodeMerger(
                 if (existingEpisode == null)
                 {
                     episodeToMerge.Id = Guid.NewGuid();
-                    episodeToMerge.SetPodcastProperties(podcast);
+                    episodeToMerge.SetPodcastProperties(podcast, inheritLanguageIfUnset: true);
                     addedEpisodes.Add(episodeToMerge);
                     episodesToSave.Add(episodeToMerge);
                     existingList.Add(episodeToMerge);

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Factories/PodcastAndEpisodeFactory.cs
@@ -74,7 +74,7 @@ public class PodcastAndEpisodeFactory(
             episode.Urls.InternetArchive != null,
             guestsResult.Additions,
             guestsResult.SkippedLowConfidence);
-        episode.SetPodcastProperties(newPodcast);
+        episode.SetPodcastProperties(newPodcast, inheritLanguageIfUnset: true);
         return new CreatePodcastWithEpisodeResponse(newPodcast, episode, submitEpisodeDetails);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/PodcastProcessor.cs
+++ b/Class-Libraries/RedditPodcastPoster.UrlSubmission/Processors/PodcastProcessor.cs
@@ -62,7 +62,7 @@ public class PodcastProcessor(
         {
             episodeResult = SubmitResultState.Created;
             episode = episodeFactory.CreateEpisode(categorisedItem);
-            episode.SetPodcastProperties(categorisedItem.MatchingPodcast);
+            episode.SetPodcastProperties(categorisedItem.MatchingPodcast, inheritLanguageIfUnset: true);
             var subjectsResult = await subjectEnricher.EnrichSubjects(
                 episode,
                 new SubjectEnrichmentOptions(

--- a/Cloud/Api/Services/Episodes/EpisodeChangeApplier.cs
+++ b/Cloud/Api/Services/Episodes/EpisodeChangeApplier.cs
@@ -276,8 +276,7 @@ public class EpisodeChangeApplier(ILogger<EpisodeChangeApplier> logger)
 
         if (episodeChangeRequest.Language != null)
         {
-            episode.Language =
-                episodeChangeRequest.Language == string.Empty ? null : episodeChangeRequest.Language;
+            episode.Language = NormaliseEpisodeLanguage(episodeChangeRequest.Language);
         }
 
         if (episodeChangeRequest.HasChange && inPastWeek)
@@ -296,5 +295,25 @@ public class EpisodeChangeApplier(ILogger<EpisodeChangeApplier> logger)
         }
 
         return changeState;
+    }
+
+    /// <summary>
+    /// Empty and English codes are stored as null (product English/default).
+    /// </summary>
+    internal static string? NormaliseEpisodeLanguage(string language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return null;
+        }
+
+        var trimmed = language.Trim();
+        var lower = trimmed.ToLowerInvariant().Replace('_', '-');
+        if (lower is "en" || lower.StartsWith("en-", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return trimmed;
     }
 }

--- a/Cloud/Api/Services/Podcasts/PodcastChangeApplier.cs
+++ b/Cloud/Api/Services/Podcasts/PodcastChangeApplier.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using DomainPodcast = RedditPodcastPoster.Models.Podcasts.Podcast;
 using Api.Models;
+using Api.Services.Episodes;
 using RedditPodcastPoster.PodcastServices.YouTube.Playlist;
 
 namespace Api.Services.Podcasts;
@@ -191,7 +192,7 @@ public class PodcastChangeApplier(ILogger<PodcastChangeApplier> logger)
 
         if (podcastChangeRequest.Language != null)
         {
-            podcast.Language = podcastChangeRequest.Language == string.Empty ? null : podcastChangeRequest.Language;
+            podcast.Language = EpisodeChangeApplier.NormaliseEpisodeLanguage(podcastChangeRequest.Language);
         }
 
         if (podcastChangeRequest.KnownTerms != null)

--- a/Cloud/Api/Services/Podcasts/PodcastUpdateService.cs
+++ b/Cloud/Api/Services/Podcasts/PodcastUpdateService.cs
@@ -103,22 +103,18 @@ public class PodcastUpdateService(
 
     private async Task PropagatePodcastLanguageToEpisodes(DomainPodcast podcast, CancellationToken c)
     {
-        var podcastLanguage = podcast.Language?.Trim();
-        if (string.IsNullOrWhiteSpace(podcastLanguage))
-        {
-            return;
-        }
-
+        // Refresh denormalised PodcastLanguage only. Episode.Language null means English and must
+        // not be overwritten by the podcast default (new episodes inherit via SetPodcastProperties
+        // inheritLanguageIfUnset: true).
         var updatedEpisodeIds = new List<Guid>();
         await foreach (var episode in episodeRepository.GetByPodcastId(podcast.Id).WithCancellation(c))
         {
-            if (!string.IsNullOrWhiteSpace(episode.Language))
+            var (updated, _) = episode.SetPodcastProperties(podcast);
+            if (!updated)
             {
                 continue;
             }
 
-            episode.Language = podcastLanguage;
-            episode.SetPodcastProperties(podcast);
             await episodeRepository.Save(episode);
             updatedEpisodeIds.Add(episode.Id);
         }

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/EpisodeChangeApplierLanguageTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/EpisodeChangeApplierLanguageTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Api.Models;
+using Api.Services.Episodes;
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
+using Xunit;
+using Episode = RedditPodcastPoster.Models.Episodes.Episode;
+
+namespace FunctionHost.Tests.Api;
+
+public class EpisodeChangeApplierLanguageTests
+{
+    private static EpisodeChangeApplier CreateSut() =>
+        new(NullLogger<EpisodeChangeApplier>.Instance);
+
+    private static Episode CreateEpisode(Action<Episode>? customize = null)
+    {
+        var episode = new Episode
+        {
+            Id = Guid.NewGuid(),
+            PodcastId = Guid.NewGuid(),
+            Title = "Original title",
+            Description = "Original description",
+            Release = DateTime.UtcNow.AddDays(-30),
+            Length = TimeSpan.FromMinutes(30),
+            Urls = new ServiceUrls(),
+            Language = "fil"
+        };
+        customize?.Invoke(episode);
+        return episode;
+    }
+
+    [Fact(DisplayName =
+        "Apply clears Language when the request sets an empty string, because empty means English/default")]
+    public void Apply_clears_language_on_empty_string()
+    {
+        // Arrange
+        var episode = CreateEpisode();
+        var sut = CreateSut();
+
+        // Act
+        sut.Apply(episode, new EpisodeChangeRequest { Language = "" });
+
+        // Assert
+        episode.Language.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "Apply stores English language codes as null because English is the product default")]
+    public void Apply_clears_language_when_english_code_is_set()
+    {
+        // Arrange
+        var episode = CreateEpisode();
+        var sut = CreateSut();
+
+        // Act
+        sut.Apply(episode, new EpisodeChangeRequest { Language = "en" });
+
+        // Assert
+        episode.Language.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "Apply stores regional English codes as null (en-GB) so search treats them as English")]
+    public void Apply_clears_language_when_regional_english_code_is_set()
+    {
+        // Arrange
+        var episode = CreateEpisode(e => e.Language = "es");
+        var sut = CreateSut();
+
+        // Act
+        sut.Apply(episode, new EpisodeChangeRequest { Language = "en-GB" });
+
+        // Assert
+        episode.Language.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Apply keeps non-English language codes on the episode")]
+    public void Apply_sets_non_english_language_code()
+    {
+        // Arrange
+        var episode = CreateEpisode(e => e.Language = null);
+        var sut = CreateSut();
+
+        // Act
+        sut.Apply(episode, new EpisodeChangeRequest { Language = "fil" });
+
+        // Assert
+        episode.Language.Should().Be("fil");
+    }
+}

--- a/Cloud/Unit-Tests/Indexer.Tests/PodcastEpisodeExtensionsTests.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/PodcastEpisodeExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Indexer.Tests;
 public class PodcastEpisodeExtensionsTests
 {
     [Fact(DisplayName =
-        "ToEpisodeSearchRecord maps platform ids and podcast language, and wires YouTube image " +
+        "ToEpisodeSearchRecord maps platform ids from the episode language only, and wires YouTube image " +
         "compaction through the youtubeId.")]
     public void Maps_service_ids_language_and_compacts_youtube_image()
     {
@@ -29,12 +29,12 @@ public class PodcastEpisodeExtensionsTests
             YouTube = new Uri($"https://i.ytimg.com/vi/{episode.YouTubeId}/maxresdefault.jpg"),
             Spotify = new Uri("https://i.scdn.co/image/opaque")
         };
-        episode.Language = null;
+        episode.Language = "es";
         var podcast = new Podcast
         {
             Name = " Podcast ",
             AppleId = 1234567890,
-            Language = "es",
+            Language = "fr",
             SearchTerms = "podcast terms"
         };
 
@@ -52,6 +52,23 @@ public class PodcastEpisodeExtensionsTests
         // thumbnail is loss-lessly compacted to the "yx" token.
         result.Image.Should().Be("yx");
         result.Duration.Should().Be("00:02:03");
+    }
+
+    [Fact(DisplayName =
+        "ToEpisodeSearchRecord leaves Lang null when the episode language is unset, even if the " +
+        "podcast has a default language, because null means English.")]
+    public void Leaves_lang_null_when_episode_language_unset_despite_podcast_default()
+    {
+        // Arrange
+        var episode = CreateEpisode();
+        episode.Language = null;
+        var podcast = new Podcast { Name = "Podcast", Language = "fil" };
+
+        // Act
+        var result = new PodcastEpisode(podcast, episode).ToEpisodeSearchRecord();
+
+        // Assert
+        result.Lang.Should().BeNull();
     }
 
     [Fact(DisplayName =

--- a/Console-Apps/AddAudioPodcast/AddAudioPodcastProcessor.cs
+++ b/Console-Apps/AddAudioPodcast/AddAudioPodcastProcessor.cs
@@ -112,7 +112,7 @@ public class AddAudioPodcastProcessor(
                         podcast.IgnoredSubjects,
                         podcast.DefaultSubject,
                         podcast.DescriptionRegex));
-                episode.SetPodcastProperties(podcast);
+                episode.SetPodcastProperties(podcast, inheritLanguageIfUnset: true);
             }
 
             if (episodes.Any())

--- a/Console-Apps/CreateSearchIndex/CreateSearchIndexProcessor.cs
+++ b/Console-Apps/CreateSearchIndex/CreateSearchIndexProcessor.cs
@@ -466,7 +466,7 @@ public partial class CreateSearchIndexProcessor(
                                 IIF({isSpotifyToken}, {spotifyToken},
                                     IIF({isAppleToken}, {appleToken},
                                         (e.images.youtube ?? e.images.spotify ?? e.images.apple ?? e.images.other) ?? """"))) as image,
-                            e.lang ?? e.podcastLanguage as lang,
+                            e.lang as lang,
                             e._ts
                             FROM episodes e
                             WHERE {ActiveEpisodesFilter}

--- a/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubePodcastProcessor.cs
+++ b/Console-Apps/EnrichYouTubeOnlyPodcasts/EnrichYouTubePodcastProcessor.cs
@@ -209,7 +209,7 @@ public class EnrichYouTubePodcastProcessor(
                             podcast.IgnoredSubjects,
                             podcast.DefaultSubject,
                             podcast.DescriptionRegex));
-                    episode.SetPodcastProperties(podcast);
+                    episode.SetPodcastProperties(podcast, inheritLanguageIfUnset: true);
                     addedEpisodes.Add(episode);
                 }
             }


### PR DESCRIPTION
## Summary
- Store curator English / cleared language as `null` (including `en` / `en-*`), and index / homepage publish from episode language only — no podcast-language fallback.
- Inherit podcast default language only when creating episodes; podcast language updates refresh denormalised `PodcastLanguage` without overwriting English episodes.
- Cover change-applier and search-record behaviour with unit tests.

## Test plan
- [ ] Edit an episode on a non-English podcast to English (or clear language) and confirm Cosmos `lang` is null and search facet treats it as English
- [ ] Confirm new episodes on a Filipino (etc.) podcast still inherit podcast language on create
- [ ] `dotnet test` on Indexer.Tests (PodcastEpisodeExtensions) and FunctionHost.Tests (EpisodeChangeApplierLanguage)
- [ ] After API deploy, re-save or reindex any episodes previously stuck on podcast fallback
