### PR TITLE
Add universal title-casing known-terms

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Models/TitleCasing/LanguageTitleCasingRulesDocument.cs
+++ b/Class-Libraries/RedditPodcastPoster.Models/TitleCasing/LanguageTitleCasingRulesDocument.cs
@@ -11,6 +11,9 @@ namespace RedditPodcastPoster.Models.TitleCasing;
 [CosmosSelector(ModelType.LanguageTitleCasingRules)]
 public sealed class LanguageTitleCasingRulesDocument : CosmosSelector
 {
+    /// <summary>Reserved partition key for known-terms that apply to every language.</summary>
+    public const string UniversalLanguageKey = "*";
+
     public LanguageTitleCasingRulesDocument()
     {
         ModelType = ModelType.LanguageTitleCasingRules;
@@ -23,7 +26,7 @@ public sealed class LanguageTitleCasingRulesDocument : CosmosSelector
         Id = IdForLanguage(normalised);
     }
 
-    /// <summary>ISO language code; Cosmos partition key.</summary>
+    /// <summary>ISO language code or <see cref="UniversalLanguageKey"/>; Cosmos partition key.</summary>
     [JsonPropertyName("language")]
     [JsonPropertyOrder(10)]
     public string Language { get; set; } = "";
@@ -38,9 +41,19 @@ public sealed class LanguageTitleCasingRulesDocument : CosmosSelector
 
     public override string FileKey => $"TitleCasingRules-{Language}";
 
+    public static bool IsUniversal(string? language) =>
+        !string.IsNullOrWhiteSpace(language) &&
+        NormaliseLanguage(language) == UniversalLanguageKey;
+
     public static string NormaliseLanguage(string language)
     {
-        var trimmed = language.Trim().ToLowerInvariant().Replace('_', '-');
+        var trimmed = language.Trim();
+        if (trimmed == UniversalLanguageKey)
+        {
+            return UniversalLanguageKey;
+        }
+
+        trimmed = trimmed.ToLowerInvariant().Replace('_', '-');
         var dash = trimmed.IndexOf('-');
         return dash > 0 ? trimmed[..dash] : trimmed;
     }

--- a/Class-Libraries/RedditPodcastPoster.Text.Tests/LanguageTitleCasingRulesDocumentTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text.Tests/LanguageTitleCasingRulesDocumentTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using RedditPodcastPoster.Models.TitleCasing;
+
+namespace RedditPodcastPoster.Text.Tests;
+
+public class LanguageTitleCasingRulesDocumentTests
+{
+    [Fact(DisplayName = "NormaliseLanguage preserves the universal key '*'.")]
+    public void NormaliseLanguage_WithUniversalKey_PreservesStar()
+    {
+        // Arrange
+        // Act
+        var result = LanguageTitleCasingRulesDocument.NormaliseLanguage(
+            LanguageTitleCasingRulesDocument.UniversalLanguageKey);
+
+        // Assert
+        result.Should().Be(LanguageTitleCasingRulesDocument.UniversalLanguageKey);
+    }
+
+    [Fact(DisplayName = "IdForLanguage is stable for the universal key.")]
+    public void IdForLanguage_WithUniversalKey_IsStable()
+    {
+        // Arrange
+        // Act
+        var first = LanguageTitleCasingRulesDocument.IdForLanguage(
+            LanguageTitleCasingRulesDocument.UniversalLanguageKey);
+        var second = LanguageTitleCasingRulesDocument.IdForLanguage("*");
+
+        // Assert
+        first.Should().Be(second);
+        first.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact(DisplayName = "IsUniversal is true only for the reserved '*' key.")]
+    public void IsUniversal_WithStar_IsTrue()
+    {
+        // Arrange
+        // Act
+        // Assert
+        LanguageTitleCasingRulesDocument.IsUniversal("*").Should().BeTrue();
+        LanguageTitleCasingRulesDocument.IsUniversal("en").Should().BeFalse();
+        LanguageTitleCasingRulesDocument.IsUniversal(null).Should().BeFalse();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Text.Tests/LowerCaseTermsTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text.Tests/LowerCaseTermsTests.cs
@@ -26,6 +26,7 @@ public class LowerCaseTermsTests
     [InlineData("EN-us", "en")]
     [InlineData("pl", "pl")]
     [InlineData("fr-FR", "fr")]
+    [InlineData("*", "*")]
     public void NormaliseLanguageKey_MapsAsExpected(string? language, string expected)
     {
         // Arrange

--- a/Class-Libraries/RedditPodcastPoster.Text.Tests/TextSanitiserUniversalKnownTermsTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text.Tests/TextSanitiserUniversalKnownTermsTests.cs
@@ -9,8 +9,8 @@ namespace RedditPodcastPoster.Text.Tests;
 public class TextSanitiserUniversalKnownTermsTests
 {
     [Fact(DisplayName =
-        "Universal known-terms apply for a non-English language even when that language has no known terms.")]
-    public async Task SanitiseTitle_WithUniversalKnownTerm_AppliesForNonEnglishLanguage()
+        "Universal known-terms apply for a non-English language even when that language has an empty known-terms list.")]
+    public async Task SanitiseTitle_WithUniversalKnownTerm_AppliesWhenLanguageKnownTermsEmpty()
     {
         // Arrange
         var mocker = new AutoMocker();
@@ -45,7 +45,38 @@ public class TextSanitiserUniversalKnownTermsTests
     }
 
     [Fact(DisplayName =
-        "Language known-terms apply after universal when both match the same text.")]
+        "Universal known-terms still apply when the requested language has no rules document at all.")]
+    public async Task SanitiseTitle_WithUniversalKnownTerm_AppliesWhenLanguageDocumentMissing()
+    {
+        // Arrange
+        var mocker = new AutoMocker();
+        TitleCasingTestSupport.UseRules(
+            mocker,
+            TitleCasingTestSupport.CreateEnglishDefault(lowerCaseTerms: [], knownTerms: []),
+            new LanguageTitleCasingRulesDocument(LanguageTitleCasingRulesDocument.UniversalLanguageKey)
+            {
+                LowerCaseTerms = [],
+                KnownTerms =
+                [
+                    new KnownTermEntry
+                    {
+                        Literal = "BBC",
+                        Pattern = @"\bBBC\b",
+                        Options = "IgnoreCase, Compiled"
+                    }
+                ]
+            });
+        var sut = mocker.CreateInstance<TextSanitiser>();
+
+        // Act
+        var result = await sut.SanitiseTitle("Interview With Bbc Guest", null, [], [], "de");
+
+        // Assert
+        result.Should().Be("Interview With BBC Guest");
+    }
+
+    [Fact(DisplayName =
+        "Language known-terms apply after universal when both match the same text, so the language literal wins.")]
     public async Task SanitiseTitle_WithUniversalAndLanguageKnownTerms_AppliesLanguageAfterUniversal()
     {
         // Arrange
@@ -86,6 +117,50 @@ public class TextSanitiserUniversalKnownTermsTests
 
         // Assert
         result.Should().Be("Talk About Org Fr Tonight");
+    }
+
+    [Fact(DisplayName =
+        "Universal then language known-terms both apply when they match different tokens in the same title.")]
+    public async Task SanitiseTitle_WithNonOverlappingUniversalAndLanguageKnownTerms_AppliesBoth()
+    {
+        // Arrange
+        var mocker = new AutoMocker();
+        TitleCasingTestSupport.UseRules(
+            mocker,
+            TitleCasingTestSupport.CreateEnglishDefault(lowerCaseTerms: [], knownTerms: []),
+            new LanguageTitleCasingRulesDocument(LanguageTitleCasingRulesDocument.UniversalLanguageKey)
+            {
+                LowerCaseTerms = [],
+                KnownTerms =
+                [
+                    new KnownTermEntry
+                    {
+                        Literal = "BBC",
+                        Pattern = @"\bBBC\b",
+                        Options = "IgnoreCase, Compiled"
+                    }
+                ]
+            },
+            new LanguageTitleCasingRulesDocument("fr")
+            {
+                LowerCaseTerms = [],
+                KnownTerms =
+                [
+                    new KnownTermEntry
+                    {
+                        Literal = "ONU",
+                        Pattern = @"\bONU\b",
+                        Options = "IgnoreCase, Compiled"
+                    }
+                ]
+            });
+        var sut = mocker.CreateInstance<TextSanitiser>();
+
+        // Act
+        var result = await sut.SanitiseTitle("Bbc Meets Onu Today", null, [], [], "fr");
+
+        // Assert
+        result.Should().Be("BBC Meets ONU Today");
     }
 
     [Fact(DisplayName = "Missing universal document yields empty universal known-terms.")]

--- a/Class-Libraries/RedditPodcastPoster.Text.Tests/TextSanitiserUniversalKnownTermsTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text.Tests/TextSanitiserUniversalKnownTermsTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using Moq.AutoMock;
+using RedditPodcastPoster.Models.TitleCasing;
+using RedditPodcastPoster.Text.Sanitisers;
+using RedditPodcastPoster.Text.TitleCasing;
+
+namespace RedditPodcastPoster.Text.Tests;
+
+public class TextSanitiserUniversalKnownTermsTests
+{
+    [Fact(DisplayName =
+        "Universal known-terms apply for a non-English language even when that language has no known terms.")]
+    public async Task SanitiseTitle_WithUniversalKnownTerm_AppliesForNonEnglishLanguage()
+    {
+        // Arrange
+        var mocker = new AutoMocker();
+        TitleCasingTestSupport.UseRules(
+            mocker,
+            TitleCasingTestSupport.CreateEnglishDefault(lowerCaseTerms: [], knownTerms: []),
+            new LanguageTitleCasingRulesDocument(LanguageTitleCasingRulesDocument.UniversalLanguageKey)
+            {
+                LowerCaseTerms = [],
+                KnownTerms =
+                [
+                    new KnownTermEntry
+                    {
+                        Literal = "BBC",
+                        Pattern = @"\bBBC\b",
+                        Options = "IgnoreCase, Compiled"
+                    }
+                ]
+            },
+            new LanguageTitleCasingRulesDocument("pl")
+            {
+                LowerCaseTerms = [],
+                KnownTerms = []
+            });
+        var sut = mocker.CreateInstance<TextSanitiser>();
+
+        // Act
+        var result = await sut.SanitiseTitle("Interview With Bbc Guest", null, [], [], "pl");
+
+        // Assert
+        result.Should().Be("Interview With BBC Guest");
+    }
+
+    [Fact(DisplayName =
+        "Language known-terms apply after universal when both match the same text.")]
+    public async Task SanitiseTitle_WithUniversalAndLanguageKnownTerms_AppliesLanguageAfterUniversal()
+    {
+        // Arrange
+        var mocker = new AutoMocker();
+        TitleCasingTestSupport.UseRules(
+            mocker,
+            TitleCasingTestSupport.CreateEnglishDefault(lowerCaseTerms: [], knownTerms: []),
+            new LanguageTitleCasingRulesDocument(LanguageTitleCasingRulesDocument.UniversalLanguageKey)
+            {
+                LowerCaseTerms = [],
+                KnownTerms =
+                [
+                    new KnownTermEntry
+                    {
+                        Literal = "ORG",
+                        Pattern = @"\bORG\b",
+                        Options = "IgnoreCase, Compiled"
+                    }
+                ]
+            },
+            new LanguageTitleCasingRulesDocument("fr")
+            {
+                LowerCaseTerms = [],
+                KnownTerms =
+                [
+                    new KnownTermEntry
+                    {
+                        Literal = "Org Fr",
+                        Pattern = @"\bORG\b",
+                        Options = "IgnoreCase, Compiled"
+                    }
+                ]
+            });
+        var sut = mocker.CreateInstance<TextSanitiser>();
+
+        // Act
+        var result = await sut.SanitiseTitle("Talk About Org Tonight", null, [], [], "fr");
+
+        // Assert
+        result.Should().Be("Talk About Org Fr Tonight");
+    }
+
+    [Fact(DisplayName = "Missing universal document yields empty universal known-terms.")]
+    public void GetUniversalKnownTerms_WhenDocumentMissing_ReturnsEmpty()
+    {
+        // Arrange
+        var provider = new TitleCasingRulesProvider(
+            new Dictionary<string, LanguageTitleCasingRulesDocument>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["en"] = TitleCasingTestSupport.CreateEnglishDefault(lowerCaseTerms: [], knownTerms: [])
+            });
+
+        // Act
+        var result = provider.GetUniversalKnownTerms();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName =
+        "GetKnownTerms for a language does not merge universal known-terms.")]
+    public void GetKnownTerms_DoesNotIncludeUniversalTerms()
+    {
+        // Arrange
+        var universalTerm = new KnownTermEntry
+        {
+            Literal = "BBC",
+            Pattern = @"\bBBC\b",
+            Options = "IgnoreCase, Compiled"
+        };
+        var languageTerm = new KnownTermEntry
+        {
+            Literal = "Local",
+            Pattern = @"\bLocal\b",
+            Options = "IgnoreCase, Compiled"
+        };
+        var provider = new TitleCasingRulesProvider(
+            new Dictionary<string, LanguageTitleCasingRulesDocument>(StringComparer.OrdinalIgnoreCase)
+            {
+                [LanguageTitleCasingRulesDocument.UniversalLanguageKey] =
+                    new LanguageTitleCasingRulesDocument(LanguageTitleCasingRulesDocument.UniversalLanguageKey)
+                    {
+                        KnownTerms = [universalTerm]
+                    },
+                ["en"] = TitleCasingTestSupport.CreateEnglishDefault(
+                    lowerCaseTerms: [],
+                    knownTerms: [languageTerm])
+            });
+
+        // Act
+        var languageTerms = provider.GetKnownTerms("en");
+        var universalTerms = provider.GetUniversalKnownTerms();
+
+        // Assert
+        languageTerms.Should().ContainSingle().Which.Literal.Should().Be("Local");
+        universalTerms.Should().ContainSingle().Which.Literal.Should().Be("BBC");
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.Text/Models/LowerCaseTerms.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text/Models/LowerCaseTerms.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using RedditPodcastPoster.Models.TitleCasing;
 
 namespace RedditPodcastPoster.Text.Models;
 
@@ -78,9 +79,15 @@ public static class LowerCaseTerms
         return BuildExpressions(words, includeOrdinals: IsEnglish(language));
     }
 
-    /// <summary>Null/whitespace and English IETF tags map to <c>en</c>.</summary>
+    /// <summary>Null/whitespace and English IETF tags map to <c>en</c>. Preserves universal key <c>*</c>.</summary>
     public static string NormaliseLanguageKey(string? language)
     {
+        if (!string.IsNullOrWhiteSpace(language) &&
+            language.Trim() == LanguageTitleCasingRulesDocument.UniversalLanguageKey)
+        {
+            return LanguageTitleCasingRulesDocument.UniversalLanguageKey;
+        }
+
         if (IsEnglish(language))
         {
             return "en";
@@ -96,6 +103,11 @@ public static class LowerCaseTerms
         if (string.IsNullOrWhiteSpace(language))
         {
             return true;
+        }
+
+        if (language.Trim() == LanguageTitleCasingRulesDocument.UniversalLanguageKey)
+        {
+            return false;
         }
 
         var lower = language.Trim().ToLowerInvariant().Replace('_', '-');

--- a/Class-Libraries/RedditPodcastPoster.Text/Sanitisers/TextSanitiser.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text/Sanitisers/TextSanitiser.cs
@@ -256,6 +256,11 @@ public partial class TextSanitiser(
         input = SeasonEpisode.Replace(input, m => m.Value.ToUpper());
         input = input.Replace("W/", "w/");
 
+        foreach (var term in rulesProvider.GetUniversalKnownTerms())
+        {
+            input = term.ToRegex().Replace(input, term.Literal);
+        }
+
         foreach (var term in rulesProvider.GetKnownTerms(language))
         {
             input = term.ToRegex().Replace(input, term.Literal);

--- a/Class-Libraries/RedditPodcastPoster.Text/TitleCasing/ITitleCasingRulesProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text/TitleCasing/ITitleCasingRulesProvider.cs
@@ -10,4 +10,7 @@ public interface ITitleCasingRulesProvider
     IDictionary<string, Regex> GetLowerCaseExpressions(string? language);
 
     IReadOnlyList<KnownTermEntry> GetKnownTerms(string? language);
+
+    /// <summary>Known terms that apply to every language (Cosmos language key <c>*</c>).</summary>
+    IReadOnlyList<KnownTermEntry> GetUniversalKnownTerms();
 }

--- a/Class-Libraries/RedditPodcastPoster.Text/TitleCasing/TitleCasingRulesProvider.cs
+++ b/Class-Libraries/RedditPodcastPoster.Text/TitleCasing/TitleCasingRulesProvider.cs
@@ -36,7 +36,18 @@ public class TitleCasingRulesProvider(
     public IReadOnlyList<KnownTermEntry> GetKnownTerms(string? language)
     {
         var key = LowerCaseTerms.NormaliseLanguageKey(language);
-        if (!byLanguage.TryGetValue(key, out var rules))
+        if (key == LanguageTitleCasingRulesDocument.UniversalLanguageKey ||
+            !byLanguage.TryGetValue(key, out var rules))
+        {
+            return [];
+        }
+
+        return rules.KnownTerms;
+    }
+
+    public IReadOnlyList<KnownTermEntry> GetUniversalKnownTerms()
+    {
+        if (!byLanguage.TryGetValue(LanguageTitleCasingRulesDocument.UniversalLanguageKey, out var rules))
         {
             return [];
         }

--- a/Cloud/Api/Services/TitleCasingRules/TitleCasingRulesGetService.cs
+++ b/Cloud/Api/Services/TitleCasingRules/TitleCasingRulesGetService.cs
@@ -31,6 +31,14 @@ public class TitleCasingRulesGetService(
                     IsDefault: false);
             }
 
+            if (normalised == LanguageTitleCasingRulesDocument.UniversalLanguageKey)
+            {
+                return new TitleCasingRulesGetResult(
+                    TitleCasingRulesGetStatus.Ok,
+                    new LanguageTitleCasingRulesDocument(LanguageTitleCasingRulesDocument.UniversalLanguageKey),
+                    IsDefault: true);
+            }
+
             if (normalised == "en")
             {
                 var defaults = await BuildEnglishDefaultAsync();

--- a/Cloud/Api/Services/TitleCasingRules/TitleCasingRulesUpdateService.cs
+++ b/Cloud/Api/Services/TitleCasingRules/TitleCasingRulesUpdateService.cs
@@ -24,9 +24,14 @@ public class TitleCasingRulesUpdateService(
                     Error: "Language code must be non-empty.");
             }
 
+            var isUniversal = normalised == LanguageTitleCasingRulesDocument.UniversalLanguageKey;
             var document = new LanguageTitleCasingRulesDocument(normalised);
 
-            if (body.LowerCaseTerms is { Count: > 0 })
+            if (isUniversal)
+            {
+                document.LowerCaseTerms = [];
+            }
+            else if (body.LowerCaseTerms is { Count: > 0 })
             {
                 document.LowerCaseTerms = body.LowerCaseTerms
                     .Select(term => term.Trim())

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Services/TitleCasingRulesUpdateServiceTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Services/TitleCasingRulesUpdateServiceTests.cs
@@ -1,0 +1,54 @@
+using Api.Models;
+using Api.Services.TitleCasingRules;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RedditPodcastPoster.Models.TitleCasing;
+using RedditPodcastPoster.Persistence.Abstractions.Repositories;
+using Xunit;
+
+namespace FunctionHost.Tests.Api.Services;
+
+public class TitleCasingRulesUpdateServiceTests
+{
+    [Fact(DisplayName =
+        "PUT for universal language '*' forces empty lower-case terms even when the body sends some.")]
+    public async Task UpdateAsync_WithUniversalAndLowerCaseTerms_ClearsLowerCaseTerms()
+    {
+        // Arrange
+        LanguageTitleCasingRulesDocument? saved = null;
+        var repo = new Mock<ILanguageTitleCasingRulesRepository>();
+        repo.Setup(x => x.Save(It.IsAny<LanguageTitleCasingRulesDocument>()))
+            .Callback<LanguageTitleCasingRulesDocument>(d => saved = d)
+            .Returns(Task.CompletedTask);
+        var sut = new TitleCasingRulesUpdateService(
+            repo.Object,
+            NullLogger<TitleCasingRulesUpdateService>.Instance);
+        var body = new LanguageTitleCasingRulesUpdateRequest
+        {
+            LowerCaseTerms = ["the", "of"],
+            KnownTerms =
+            [
+                new KnownTermUpdate
+                {
+                    Literal = "BBC",
+                    Pattern = @"\bBBC\b",
+                    Options = "IgnoreCase, Compiled"
+                }
+            ]
+        };
+
+        // Act
+        var result = await sut.UpdateAsync(
+            LanguageTitleCasingRulesDocument.UniversalLanguageKey,
+            body,
+            CancellationToken.None);
+
+        // Assert
+        result.Status.Should().Be(TitleCasingRulesUpdateStatus.Ok);
+        saved.Should().NotBeNull();
+        saved!.Language.Should().Be(LanguageTitleCasingRulesDocument.UniversalLanguageKey);
+        saved.LowerCaseTerms.Should().BeEmpty();
+        saved.KnownTerms.Should().ContainSingle().Which.Literal.Should().Be("BBC");
+    }
+}

--- a/Infrastructure/functions.bicep
+++ b/Infrastructure/functions.bicep
@@ -212,6 +212,10 @@ var content= {
     content__SearchSuggestionsKey: 'search-suggestions'
 }
 
+// Shared Cosmos settings for ALL function apps (api / discover / indexer) via coreSettings.
+// CosmosDbSettingsValidator fails host start if any container key is blank
+// (e.g. missing cosmosdb__TitleCasingRulesContainer → OptionsValidationException / exit 134).
+// Keep this object complete whenever CosmosDbSettings gains a required property.
 var cosmosdb= {
     cosmosdb__AuthKeyOrResourceToken: cosmosdbAuthKeyOrResourceToken
     cosmosdb__DatabaseId: 'cultpodcasts-db'
@@ -466,7 +470,7 @@ var coreSettings= union(
     bluesky, 
     cloudflare, 
     content,
-    cosmosdb,
+    cosmosdb, // required cosmosdb__* containers for every app — do not omit
     delayedPublication,
     pushSubscriptions, 
     reddit, 
@@ -736,6 +740,8 @@ module apiFunction 'function.bicep' = {
     instanceMemoryMB: 2048
     appSettings: union({
         Logging__LogLevel__Api: 'Information'
+        // Explicit: OptionsValidationException if missing after code that binds TitleCasingRules.
+        cosmosdb__TitleCasingRulesContainer: 'TitleCasingRules'
     }, apiSettings)
     userAssignedIdentityId: userAssignedIdentityId
     userAssignedIdentityClientId: userAssignedIdentityClientId
@@ -757,6 +763,7 @@ module discoveryFunction 'function.bicep' = {
     instanceMemoryMB: 2048
     appSettings: union({
         Logging__LogLevel__Discovery: 'Information'
+        cosmosdb__TitleCasingRulesContainer: 'TitleCasingRules'
     }, discoverySettings, discoverScorer)
     userAssignedIdentityId: userAssignedIdentityId
     userAssignedIdentityClientId: userAssignedIdentityClientId
@@ -778,6 +785,7 @@ module indexerFunction 'function.bicep' = {
     instanceMemoryMB: 2048
     appSettings: union({
         Logging__LogLevel__Indexer: 'Information'
+        cosmosdb__TitleCasingRulesContainer: 'TitleCasingRules'
     }, indexerSettings)
     userAssignedIdentityId: userAssignedIdentityId
     userAssignedIdentityClientId: userAssignedIdentityClientId


### PR DESCRIPTION
## Summary
- Reserved Cosmos language key `*` for known-terms that apply to every episode language
- Apply universal known-terms before language/podcast/subject terms in `FixCasing`
- GET/PUT `title-casing-rules/*` forces empty lower-case terms on universal

## Test plan
- [ ] `dotnet test` Text.Tests + FunctionHost TitleCasingRulesUpdateService
- [ ] Admin Universal button + Promote (website PR) against deployed Api