### PR TITLE
infra: indexer hourly AppRequests miss alert

### DIFF
--- a/Infrastructure/functions.bicep
+++ b/Infrastructure/functions.bicep
@@ -712,6 +712,64 @@ resource failedExecutionAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01
   }
 }
 
+// Hourly pipeline miss (AppRequests): timer fires ~:03 UTC; allow until :20 of the next hour
+// before declaring the previous full UTC hour a miss (pipeline finish + ingestion lag).
+// Window PT2H so evaluations at :20–:59 still include the full previous hour [H-1:00, H:00).
+// Fires when neither successful orchestration:HourlyOrchestration nor activity:Indexer
+// appears for AppRoleName indexer-${suffix}. See docs/indexing-app-insights-queries.md.
+var indexerHourlyMissAlertQuery = '''
+let hourStart = startofhour(ago(1h));
+let hourEnd = hourStart + 1h;
+AppRequests
+| where TimeGenerated between (hourStart .. hourEnd)
+| where AppRoleName == "indexer-${suffix}"
+| where Success == true
+| where Name startswith "orchestration:HourlyOrchestration" or Name == "activity:Indexer"
+| summarize SuccessfulSignals = count()
+| extend ReadyToJudge = datetime_part("minute", now()) >= 20
+| where ReadyToJudge and SuccessfulSignals == 0
+| project TimeGenerated = hourStart
+'''
+
+resource indexerHourlyAppRequestsMissAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = if (enableAlerts) {
+  name: 'functions-hourly-apprequests-miss-alert-${suffix}'
+  location: location
+  properties: {
+    displayName: 'Indexer hourly AppRequests miss'
+    description: 'No successful HourlyOrchestration or Indexer AppRequests for the previous full UTC hour (judged from :20 UTC onward). Uses AppRequests only — not AppTraces.'
+    enabled: true
+    scopes: [
+      logAnalyticsWorkspace.id
+    ]
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT2H'
+    severity: 2
+    autoMitigate: true
+    criteria: {
+      allOf: [
+        {
+          query: indexerHourlyMissAlertQuery
+          timeAggregation: 'Count'
+          operator: 'GreaterThan'
+          threshold: 0
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+        }
+      ]
+    }
+    actions: {
+      actionGroups: [
+        monitoringActionGroup.id
+      ]
+      customProperties: {
+        category: 'HourlyAppRequestsMiss'
+      }
+    }
+  }
+}
+
 var storageAccountName = storage.name
 var applicationInsightsConnectionString = applicationInsights.properties.ConnectionString
 var userAssignedIdentityId = userAssignedIdentity.id

--- a/docs/indexing-app-insights-queries.md
+++ b/docs/indexing-app-insights-queries.md
@@ -104,6 +104,17 @@ AppRequests
 
 Cursor rule: [`.cursor/rules/production-execution-truth.mdc`](../.cursor/rules/production-execution-truth.mdc) (`alwaysApply: true`).
 
+### Automated miss alert (infra)
+
+Bicep scheduled query rule **`functions-hourly-apprequests-miss-alert-${suffix}`** (`Indexer hourly AppRequests miss` in [`Infrastructure/functions.bicep`](../Infrastructure/functions.bicep)):
+
+- **Table:** `AppRequests` on `loganalytics-${suffix}` (not AppTraces alone).
+- **Role:** `AppRoleName == "indexer-${suffix}"` (prod: `indexer-infra`).
+- **Success signals:** `orchestration:HourlyOrchestration` or `activity:Indexer` with `Success == true`.
+- **Window:** previous full UTC hour `[H-1:00, H:00)`; judged only when `minute(now()) >= 20` so the ~`:03` timer + pipeline + ingestion can finish (~10–15 min grace after hour start).
+- **Cadence:** evaluate every **15 min**, query window **2h** (covers the prior hour when evaluating late in the current hour).
+- **Action group:** `functions-alerts-${suffix}` (same as OOM / host-drain / failed-execution alerts; optional `alertEmailAddress` + Owner role receivers).
+
 ---
 
 ## Warning-level diagnostic log catalog


### PR DESCRIPTION
## Summary
- Add scheduled query alert `functions-hourly-apprequests-miss-alert-${suffix}` that fires when the previous UTC hour has no successful `orchestration:HourlyOrchestration` or `activity:Indexer` AppRequests for `indexer-${suffix}` (prod: `indexer-infra`).
- Evaluate every 15 minutes with a 2h window; only judge after :20 UTC so the ~:03 timer + pipeline + ingestion can finish.
- Document the alert under execution audit guardrails in `docs/indexing-app-insights-queries.md`.

## Test plan
- [ ] `az bicep build --file Infrastructure/functions.bicep`
- [ ] Merge and let `deploy.yml` provision (`functions.bicep`) create the rule on `loganalytics-infra`
- [ ] Confirm alert appears in Azure Monitor → Scheduled query rules, scoped to workspace, action group `functions-alerts-infra`
- [ ] After next :20 UTC, verify no false fire when AppRequests show a successful hourly for the prior hour