### PR TITLE
fix: delete Removed episodes from search on index / --reindex-search

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/EpisodeSearchIndexEligibility.cs
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/EpisodeSearchIndexEligibility.cs
@@ -1,0 +1,13 @@
+using RedditPodcastPoster.Models.Episodes;
+using RedditPodcastPoster.Models.Podcasts;
+
+namespace RedditPodcastPoster.EntitySearchIndexer;
+
+/// <summary>
+///     Whether an episode must be absent from Azure Search (delete / skip upload).
+/// </summary>
+public static class EpisodeSearchIndexEligibility
+{
+    public static bool ShouldExcludeFromSearch(Podcast podcast, Episode episode) =>
+        episode.Removed || podcast.IsRemoved();
+}

--- a/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Services/EpisodeSearchIndexerService.cs
+++ b/Class-Libraries/RedditPodcastPoster.EntitySearchIndexer/Services/EpisodeSearchIndexerService.cs
@@ -56,10 +56,23 @@ public class EpisodeSearchIndexerService(
                 { EpisodeIndexRequestState = EpisodeIndexRequestState.EpisodeNotFound };
         }
 
-        var document = podcastEpisode.ToEpisodeSearchRecord();
-
         try
         {
+            if (EpisodeSearchIndexEligibility.ShouldExcludeFromSearch(
+                    podcastEpisode.Podcast, podcastEpisode.Episode))
+            {
+                await searchClient.DeleteDocumentsAsync(
+                    "id",
+                    [episodeId.ToString()],
+                    new IndexDocumentsOptions { ThrowOnAnyError = true },
+                    c);
+                logger.LogInformation(
+                    "Removed excluded episode '{episodeId}' (podcast '{podcastName}') from search-index.",
+                    episodeId, podcastEpisode.Podcast.Name);
+                return new EntitySearchIndexerResponse { IndexerState = IndexerState.Executed };
+            }
+
+            var document = podcastEpisode.ToEpisodeSearchRecord();
             await searchClient.MergeOrUploadDocumentsAsync([document],
                 new IndexDocumentsOptions { ThrowOnAnyError = true }, c);
             return new EntitySearchIndexerResponse { IndexerState = IndexerState.Executed };
@@ -76,6 +89,7 @@ public class EpisodeSearchIndexerService(
     public async Task<EntitySearchIndexerResponse> IndexEpisodes(IEnumerable<Guid> episodeIds, CancellationToken c)
     {
         var documents = new List<EpisodeSearchRecord>();
+        var deleteIds = new List<string>();
         var podcasts = new Dictionary<Guid, Podcast>();
 
         foreach (var episodeId in episodeIds)
@@ -99,13 +113,52 @@ public class EpisodeSearchIndexerService(
                 podcasts.Add(episode.PodcastId, podcast);
             }
 
-            var document = new PodcastEpisode(podcast, episode).ToEpisodeSearchRecord();
-            documents.Add(document);
+            if (EpisodeSearchIndexEligibility.ShouldExcludeFromSearch(podcast, episode))
+            {
+                deleteIds.Add(episodeId.ToString());
+                continue;
+            }
+
+            documents.Add(new PodcastEpisode(podcast, episode).ToEpisodeSearchRecord());
         }
 
-        if (documents.Count > 0)
+        if (documents.Count == 0 && deleteIds.Count == 0)
         {
-            try
+            logger.LogWarning("No documents to update in search-index");
+            return new EntitySearchIndexerResponse { EpisodeIndexRequestState = EpisodeIndexRequestState.NoDocuments };
+        }
+
+        try
+        {
+            if (deleteIds.Count > 0)
+            {
+                var deleteResult = await searchClient.DeleteDocumentsAsync(
+                    "id",
+                    deleteIds,
+                    new IndexDocumentsOptions { ThrowOnAnyError = false },
+                    c);
+                var deleteFailures = deleteResult.Value.Results.Where(x => !x.Succeeded).ToArray();
+                foreach (var failure in deleteFailures)
+                {
+                    logger.LogError("Failed to delete search document '{Key}': {ErrorMessage}", failure.Key,
+                        failure.ErrorMessage);
+                }
+
+                if (deleteFailures.Length > 0)
+                {
+                    var ex = new RequestFailedException(deleteResult.GetRawResponse());
+                    logger.LogError(ex,
+                        "Failed to delete {count} removed/excluded episode(s) from search-index.",
+                        deleteFailures.Length);
+                    return new EntitySearchIndexerResponse { IndexerState = MapRequestFailedException(ex) };
+                }
+
+                logger.LogInformation(
+                    "Deleted {count} removed/excluded episode(s) from search-index.",
+                    deleteIds.Count);
+            }
+
+            if (documents.Count > 0)
             {
                 var result =
                     await searchClient.MergeOrUploadDocumentsAsync(documents,
@@ -125,20 +178,17 @@ public class EpisodeSearchIndexerService(
                         string.Join(", ", failures.Select(x => $"'{x.Key}'")), ex.Status, ex.Message);
                     return new EntitySearchIndexerResponse { IndexerState = MapRequestFailedException(ex) };
                 }
+            }
 
-                return new EntitySearchIndexerResponse { IndexerState = IndexerState.Executed };
-            }
-            catch (RequestFailedException ex)
-            {
-                logger.LogError(ex,
-                    "Failed to index episodes. Status-code: {statusCode}, message: '{message}'.",
-                    ex.Status, ex.Message);
-                return new EntitySearchIndexerResponse { IndexerState = MapRequestFailedException(ex) };
-            }
+            return new EntitySearchIndexerResponse { IndexerState = IndexerState.Executed };
         }
-
-        logger.LogWarning("No documents to update in search-index");
-        return new EntitySearchIndexerResponse { EpisodeIndexRequestState = EpisodeIndexRequestState.NoDocuments };
+        catch (RequestFailedException ex)
+        {
+            logger.LogError(ex,
+                "Failed to index episodes. Status-code: {statusCode}, message: '{message}'.",
+                ex.Status, ex.Message);
+            return new EntitySearchIndexerResponse { IndexerState = MapRequestFailedException(ex) };
+        }
     }
 
     private static IndexerState MapRequestFailedException(RequestFailedException ex) =>

--- a/Class-Libraries/RedditPodcastPoster.Indexing/Services/Indexer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Indexing/Services/Indexer.cs
@@ -104,6 +104,13 @@ public class Indexer(
                         x.EnrichmentContext.SpotifyUrlUpdated,
                         x.EnrichmentContext.AppleUrlUpdated,
                         x.EnrichmentContext.YouTubeUrlUpdated)))
+                // Elimination marks Removed in Cosmos; include those IDs so search push deletes them.
+                .Concat(results.FilterResult.FilteredEpisodes.Select(x =>
+                    new IndexedEpisode(
+                        x.Episode,
+                        x.Episode.Urls.Spotify != null,
+                        x.Episode.Urls.Apple != null,
+                        x.Episode.Urls.YouTube != null)))
                 .Distinct()
                 .ToArray();
 
@@ -119,7 +126,7 @@ public class Indexer(
                 logger.LogInformation(resultsMessage);
             }
 
-            foreach (var indexedEpisode in updatedEpisodes)
+            foreach (var indexedEpisode in updatedEpisodes.Where(x => !x.Episode.Removed))
             {
                 var subjectsResult = await subjectEnricher.EnrichSubjects(
                     indexedEpisode.Episode,

--- a/Cloud/Unit-Tests/Indexer.Tests/BusinessRules/EpisodeSearchIndexEligibilityRules.cs
+++ b/Cloud/Unit-Tests/Indexer.Tests/BusinessRules/EpisodeSearchIndexEligibilityRules.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using RedditPodcastPoster.EntitySearchIndexer;
+using RedditPodcastPoster.Episodes.TestSupport.Fixtures;
+using Xunit;
+
+namespace Indexer.Tests.BusinessRules;
+
+public class EpisodeSearchIndexEligibilityRules
+{
+    private readonly DomainTestFixture _fixture = new();
+
+    [Fact(DisplayName =
+        "Search eligibility: when the episode is Removed, exclude it from Azure Search so " +
+        "elimination / admin removals delete the search document instead of re-uploading it.")]
+    public void excludes_removed_episode()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast();
+        var episode = _fixture.CreateEpisode(e => e.Removed = true);
+
+        // Act
+        var exclude = EpisodeSearchIndexEligibility.ShouldExcludeFromSearch(podcast, episode);
+
+        // Assert
+        exclude.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "Search eligibility: when the podcast is Removed, exclude every episode from Azure Search " +
+        "so --reindex-search clears the podcast's documents.")]
+    public void excludes_episode_when_podcast_removed()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast(p => p.Removed = true);
+        var episode = _fixture.CreateEpisode(e => e.Removed = false);
+
+        // Act
+        var exclude = EpisodeSearchIndexEligibility.ShouldExcludeFromSearch(podcast, episode);
+
+        // Assert
+        exclude.Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "Search eligibility: when neither podcast nor episode is Removed, keep the episode " +
+        "eligible for Azure Search upload.")]
+    public void includes_active_episode()
+    {
+        // Arrange
+        var podcast = _fixture.CreatePodcast(p => p.Removed = false);
+        var episode = _fixture.CreateEpisode(e => e.Removed = false);
+
+        // Act
+        var exclude = EpisodeSearchIndexEligibility.ShouldExcludeFromSearch(podcast, episode);
+
+        // Assert
+        exclude.Should().BeFalse();
+    }
+}

--- a/Cloud/Unit-Tests/Indexer.Tests/Indexer.Tests.csproj
+++ b/Cloud/Unit-Tests/Indexer.Tests/Indexer.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -25,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Indexer\Indexer.csproj" />
     <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.EntitySearchIndexer\RedditPodcastPoster.EntitySearchIndexer.csproj" />
+    <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.Episodes.TestSupport\RedditPodcastPoster.Episodes.TestSupport.csproj" />
     <ProjectReference Include="..\..\..\Class-Libraries\RedditPodcastPoster.Search\RedditPodcastPoster.Search.csproj" />
   </ItemGroup>
 

--- a/Console-Apps/Index/IndexProcessor.cs
+++ b/Console-Apps/Index/IndexProcessor.cs
@@ -82,18 +82,25 @@ internal class IndexProcessor(
         }
 
         var episodeIds = new List<Guid>();
+        var removedCount = 0;
         foreach (var podcastId in podcastIds)
         {
             await foreach (var episode in episodeRepository.GetByPodcastId(podcastId))
             {
                 episodeIds.Add(episode.Id);
+                if (episode.Removed)
+                {
+                    removedCount++;
+                }
             }
         }
 
+        // IndexEpisodes uploads active docs and deletes Removed / podcast-removed ones.
         logger.LogInformation(
-            "Reindexing {EpisodeCount} episode(s) across {PodcastCount} podcast(s) into Azure Search.",
+            "Reindexing {EpisodeCount} episode(s) across {PodcastCount} podcast(s) into Azure Search ({RemovedCount} Removed — will be deleted from the index).",
             episodeIds.Count,
-            podcastIds.Count);
+            podcastIds.Count,
+            removedCount);
 
         if (episodeIds.Count == 0)
         {


### PR DESCRIPTION
## Summary
- Elimination sets `Removed` in Cosmos but search push was still merge/uploading those episodes (and `--reindex-search` re-uploaded them)
- `EpisodeSearchIndexerService` now deletes search documents when the episode or podcast is Removed
- Normal `index` includes elimination-filtered episode IDs in the post-index search batch so they get deleted
- `--reindex-search` logs Removed count; same delete path applies

## Test plan
- [x] `dotnet test Cloud/Unit-Tests/Indexer.Tests --filter EpisodeSearchIndexEligibilityRules`
- [x] `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged`
- [ ] Publish Index CLI, then `index -n "Narcissists Playbook" --reindex-search` and confirm Removed episode URLs 404 from search / public episode page
- [ ] Spot-check an active episode for the same podcast still resolves in search

Made with [Cursor](https://cursor.com)