### PR TITLE
fix(people): trim person name, aliases, and handles on create/update

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.People.Tests/PersonFactoryFieldTrimTests.cs
+++ b/Class-Libraries/RedditPodcastPoster.People.Tests/PersonFactoryFieldTrimTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using RedditPodcastPoster.People.Factories;
+using Xunit;
+
+namespace RedditPodcastPoster.People.Tests;
+
+/// <summary>
+/// Create-path trim rules for person name, aliases, and social handles.
+/// </summary>
+public class PersonFactoryFieldTrimTests
+{
+    private readonly PersonFactory _factory = new();
+
+    [Fact(DisplayName =
+        "Create trims leading and trailing whitespace from person name")]
+    public void Create_trims_name()
+    {
+        // Arrange
+        // Act
+        var person = _factory.Create("  Guest Name  ");
+
+        // Assert
+        person.Name.Should().Be("Guest Name");
+    }
+
+    [Fact(DisplayName =
+        "Create trims each alias and drops whitespace-only aliases")]
+    public void Create_trims_and_filters_aliases()
+    {
+        // Arrange
+        // Act
+        var person = _factory.Create(
+            "Guest",
+            aliases: ["  Aka One  ", "   ", "Aka Two"]);
+
+        // Assert
+        person.Aliases.Should().Equal("Aka One", "Aka Two");
+    }
+
+    [Fact(DisplayName =
+        "Create sets aliases to null when every supplied alias is whitespace")]
+    public void Create_whitespace_only_aliases_become_null()
+    {
+        // Arrange
+        // Act
+        var person = _factory.Create("Guest", aliases: ["  ", "\t"]);
+
+        // Assert
+        person.Aliases.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "Create trims each space-delimited Twitter/X handle and normalizes @ prefix")]
+    public void Create_trims_space_delimited_twitter_handles()
+    {
+        // Arrange
+        // Act
+        var person = _factory.Create(
+            "Guest",
+            twitterHandle: "  x_one   @x_two  ");
+
+        // Assert
+        person.TwitterHandle.Should().Be("@x_one @x_two");
+    }
+
+    [Fact(DisplayName =
+        "Create trims each space-delimited Bluesky handle and normalizes @ prefix")]
+    public void Create_trims_space_delimited_bluesky_handles()
+    {
+        // Arrange
+        // Act
+        var person = _factory.Create(
+            "Guest",
+            blueskyHandle: "  one.bsky.social   @two.bsky.social  ");
+
+        // Assert
+        person.BlueskyHandle.Should().Be("@one.bsky.social @two.bsky.social");
+    }
+
+    [Fact(DisplayName =
+        "Create sets Twitter handle to null when the supplied value is whitespace")]
+    public void Create_whitespace_only_twitter_handle_becomes_null()
+    {
+        // Arrange
+        // Act
+        var person = _factory.Create("Guest", twitterHandle: "  ");
+
+        // Assert
+        person.TwitterHandle.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "Create sets Bluesky handle to null when the supplied value is whitespace")]
+    public void Create_whitespace_only_bluesky_handle_becomes_null()
+    {
+        // Arrange
+        // Act
+        var person = _factory.Create("Guest", blueskyHandle: "\t");
+
+        // Assert
+        person.BlueskyHandle.Should().BeNull();
+    }
+}

--- a/Class-Libraries/RedditPodcastPoster.People/Factories/PersonFactory.cs
+++ b/Class-Libraries/RedditPodcastPoster.People/Factories/PersonFactory.cs
@@ -33,7 +33,7 @@ public class PersonFactory : IPersonFactory
         {
             IsOrganization = isOrganization,
             SortName = PersonSortNameResolver.ResolveForPersist(name.Trim(), sortName, isOrganization),
-            Aliases = aliases?.Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).ToArray(),
+            Aliases = NormalizeAliases(aliases),
             TwitterHandle = NormalizeHandle(twitterHandle),
             BlueskyHandle = NormalizeHandle(blueskyHandle)
         };
@@ -56,5 +56,19 @@ public class PersonFactory : IPersonFactory
             .ToArray();
 
         return parts.Length == 0 ? null : string.Join(' ', parts);
+    }
+
+    private static string[]? NormalizeAliases(string[]? aliases)
+    {
+        if (aliases == null)
+        {
+            return null;
+        }
+
+        var normalized = aliases
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .ToArray();
+        return normalized.Length == 0 ? null : normalized;
     }
 }

--- a/Cloud/Api/Services/People/PersonChangeApplier.cs
+++ b/Cloud/Api/Services/People/PersonChangeApplier.cs
@@ -45,9 +45,11 @@ public static class PersonChangeApplier
 
         if (change.Aliases != null)
         {
-            entity.Aliases = change.Aliases.Length == 0
-                ? null
-                : change.Aliases.Select(x => x.Trim()).ToArray();
+            var aliases = change.Aliases
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Select(x => x.Trim())
+                .ToArray();
+            entity.Aliases = aliases.Length == 0 ? null : aliases;
         }
 
         if (change.TwitterHandle != null)

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/PersonChangeApplierTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/PersonChangeApplierTests.cs
@@ -1,0 +1,141 @@
+using Api.Models;
+using Api.Services.People;
+using FluentAssertions;
+using RedditPodcastPoster.Models.People;
+using Xunit;
+
+namespace FunctionHost.Tests.Api;
+
+/// <summary>
+/// Pure-apply unit tests for <see cref="PersonChangeApplier"/>: mutates an in-memory
+/// <see cref="Person"/> from a <see cref="PersonChangeRequest"/> with no repository I/O.
+/// Covers server-side trim of name, aliases, and social handles on edit.
+/// </summary>
+public class PersonChangeApplierTests
+{
+    private static Person CreatePerson(Action<Person>? customize = null)
+    {
+        var person = new Person("Original Name")
+        {
+            Aliases = ["Original Alias"],
+            TwitterHandle = "@originalx",
+            BlueskyHandle = "@original.bsky.social"
+        };
+        customize?.Invoke(person);
+        return person;
+    }
+
+    [Fact(DisplayName =
+        "Apply trims leading and trailing whitespace from person name")]
+    public void Apply_trims_name()
+    {
+        // Arrange
+        var person = CreatePerson();
+        var request = new PersonChangeRequest { Name = "  Trimmed Name  " };
+
+        // Act
+        PersonChangeApplier.Apply(person, request);
+
+        // Assert
+        person.Name.Should().Be("Trimmed Name");
+    }
+
+    [Fact(DisplayName =
+        "Apply trims each alias and drops whitespace-only aliases")]
+    public void Apply_trims_and_filters_aliases()
+    {
+        // Arrange
+        var person = CreatePerson();
+        var request = new PersonChangeRequest
+        {
+            Aliases = ["  First Alias  ", "   ", "Second Alias", "\t"]
+        };
+
+        // Act
+        PersonChangeApplier.Apply(person, request);
+
+        // Assert
+        person.Aliases.Should().Equal("First Alias", "Second Alias");
+    }
+
+    [Fact(DisplayName =
+        "Apply sets aliases to null when every supplied alias is whitespace")]
+    public void Apply_whitespace_only_aliases_become_null()
+    {
+        // Arrange
+        var person = CreatePerson();
+        var request = new PersonChangeRequest { Aliases = ["  ", "\t"] };
+
+        // Act
+        PersonChangeApplier.Apply(person, request);
+
+        // Assert
+        person.Aliases.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "Apply trims each space-delimited Twitter/X handle and normalizes @ prefix")]
+    public void Apply_trims_space_delimited_twitter_handles()
+    {
+        // Arrange
+        var person = CreatePerson();
+        var request = new PersonChangeRequest
+        {
+            TwitterHandle = "  handle_one   @handle_two  "
+        };
+
+        // Act
+        PersonChangeApplier.Apply(person, request);
+
+        // Assert
+        person.TwitterHandle.Should().Be("@handle_one @handle_two");
+    }
+
+    [Fact(DisplayName =
+        "Apply trims each space-delimited Bluesky handle and normalizes @ prefix")]
+    public void Apply_trims_space_delimited_bluesky_handles()
+    {
+        // Arrange
+        var person = CreatePerson();
+        var request = new PersonChangeRequest
+        {
+            BlueskyHandle = "  alice.bsky.social   @bob.bsky.social  "
+        };
+
+        // Act
+        PersonChangeApplier.Apply(person, request);
+
+        // Assert
+        person.BlueskyHandle.Should().Be("@alice.bsky.social @bob.bsky.social");
+    }
+
+    [Fact(DisplayName =
+        "Apply sets Twitter handle to null when the supplied value is whitespace")]
+    public void Apply_whitespace_only_twitter_handle_becomes_null()
+    {
+        // Arrange
+        var person = CreatePerson();
+        var request = new PersonChangeRequest { TwitterHandle = "  " };
+
+        // Act
+        PersonChangeApplier.Apply(person, request);
+
+        // Assert
+        person.TwitterHandle.Should().BeNull();
+    }
+
+    [Fact(DisplayName =
+        "Apply sets Bluesky handle to null when the supplied value is whitespace")]
+    public void Apply_whitespace_only_bluesky_handle_becomes_null()
+    {
+        // Arrange
+        var person = CreatePerson();
+        var request = new PersonChangeRequest { BlueskyHandle = "\t" };
+
+        // Act
+        PersonChangeApplier.Apply(person, request);
+
+        // Assert
+        person.BlueskyHandle.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Server-side trim for person name, per-alias, and X/Bluesky handles (space-delimited multi-handles) on create and edit
- Whitespace-only aliases become null on update (aligned with create)
- Unit tests for `PersonFactory` and `PersonChangeApplier`

## Test plan
- [x] `dotnet test` People.Tests PersonFactoryFieldTrimTests
- [x] `dotnet test` FunctionHost.Tests PersonChangeApplierTests
- [x] unit-test guardrails
- [ ] Edit/add person with padded name/aliases/handles; saved values trimmed


Made with [Cursor](https://cursor.com)