### PR TITLE
fix(api): keep Bluesky AT URI for unpost delete

### DIFF
--- a/Cloud/Api/Models/EpisodeChangeState.cs
+++ b/Cloud/Api/Models/EpisodeChangeState.cs
@@ -6,6 +6,14 @@ public class EpisodeChangeState
     public bool UpdatedSubjects { get; set; }
     public bool UnTweet { get; set; }
     public bool UnBlueskyPost { get; set; }
+
+    /// <summary>
+    /// AT URI captured before <see cref="RedditPodcastPoster.Models.Episodes.Episode.ClearBlueskyPostState"/>,
+    /// so <c>RemovePost</c> can delete by rkey after local state is cleared for save.
+    /// Null when the episode only had the legacy <c>bluesky</c> flag (search fallback).
+    /// </summary>
+    public string? BlueskyPostUriToRemove { get; set; }
+
     public bool UpdateBBCImage { get; internal set; }
     public bool UpdateYouTubeImage { get; internal set; }
     public bool UpdateAppleImage { get; internal set; }

--- a/Cloud/Api/Models/EpisodeChangeState.cs
+++ b/Cloud/Api/Models/EpisodeChangeState.cs
@@ -6,14 +6,6 @@ public class EpisodeChangeState
     public bool UpdatedSubjects { get; set; }
     public bool UnTweet { get; set; }
     public bool UnBlueskyPost { get; set; }
-
-    /// <summary>
-    /// AT URI captured before <see cref="RedditPodcastPoster.Models.Episodes.Episode.ClearBlueskyPostState"/>,
-    /// so <c>RemovePost</c> can delete by rkey after local state is cleared for save.
-    /// Null when the episode only had the legacy <c>bluesky</c> flag (search fallback).
-    /// </summary>
-    public string? BlueskyPostUriToRemove { get; set; }
-
     public bool UpdateBBCImage { get; internal set; }
     public bool UpdateYouTubeImage { get; internal set; }
     public bool UpdateAppleImage { get; internal set; }

--- a/Cloud/Api/Services/Episodes/EpisodeChangeApplier.cs
+++ b/Cloud/Api/Services/Episodes/EpisodeChangeApplier.cs
@@ -87,6 +87,8 @@ public class EpisodeChangeApplier(ILogger<EpisodeChangeApplier> logger)
         if (episodeChangeRequest.UnBluesky == true && episode.BlueskyPosted)
         {
             changeState.UnBlueskyPost = true;
+            // Keep AT URI for RemovePost — Save clears Cosmostate first; delete needs the rkey.
+            changeState.BlueskyPostUriToRemove = episode.BlueskyPost;
             episode.ClearBlueskyPostState();
         }
 

--- a/Cloud/Api/Services/Episodes/EpisodeChangeApplier.cs
+++ b/Cloud/Api/Services/Episodes/EpisodeChangeApplier.cs
@@ -86,10 +86,8 @@ public class EpisodeChangeApplier(ILogger<EpisodeChangeApplier> logger)
 
         if (episodeChangeRequest.UnBluesky == true && episode.BlueskyPosted)
         {
+            // Do not clear BlueskyPost here — EpisodeUpdateService deletes first, then clears only on success.
             changeState.UnBlueskyPost = true;
-            // Keep AT URI for RemovePost — Save clears Cosmostate first; delete needs the rkey.
-            changeState.BlueskyPostUriToRemove = episode.BlueskyPost;
-            episode.ClearBlueskyPostState();
         }
 
         if (episodeChangeRequest.Subjects != null && episode.ApplyUserSubjects(episodeChangeRequest.Subjects))

--- a/Cloud/Api/Services/Episodes/EpisodeUpdateService.cs
+++ b/Cloud/Api/Services/Episodes/EpisodeUpdateService.cs
@@ -84,10 +84,38 @@ public class EpisodeUpdateService(
                     indexingContext);
             }
 
-            await episodeRepository.Save(podcastEpisodeResolverResponse.Episode);
-
             var podcastEpisode = new PodcastEpisode(podcastEpisodeResolverResponse.Podcast,
                 podcastEpisodeResolverResponse.Episode);
+
+            var removeBlueskyPostResult = RemovePostState.Unknown;
+            if (changeState.UnBlueskyPost)
+            {
+                try
+                {
+                    // Delete first while BlueskyPost AT URI is still on the episode.
+                    removeBlueskyPostResult = await blueskyPostManager.RemovePost(podcastEpisode);
+                    if (removeBlueskyPostResult != RemovePostState.Deleted)
+                    {
+                        logger.LogWarning("Failure to delete bluesky-post. Result= {removeBlueskyPostResult}.",
+                            removeBlueskyPostResult);
+                    }
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e,
+                        "Error using bluesky-post-manager to remove post for episode with id '{episodeId}'.",
+                        podcastEpisodeResolverResponse.Episode.Id);
+                    removeBlueskyPostResult = RemovePostState.Other;
+                }
+
+                // Only flip Cosmostate when the remote post is gone (or already absent).
+                if (removeBlueskyPostResult is RemovePostState.Deleted or RemovePostState.NotFound)
+                {
+                    podcastEpisode.Episode.ClearBlueskyPostState();
+                }
+            }
+
+            await episodeRepository.Save(podcastEpisodeResolverResponse.Episode);
 
             if (changeState.UnPost)
             {
@@ -119,35 +147,6 @@ public class EpisodeUpdateService(
                 }
             }
 
-            var removeBlueskyPostResult = RemovePostState.Unknown;
-            if (changeState.UnBlueskyPost)
-            {
-                try
-                {
-                    // Apply cleared BlueskyPost before Save; restore stashed AT URI for delete-by-rkey.
-                    if (!string.IsNullOrWhiteSpace(changeState.BlueskyPostUriToRemove))
-                    {
-                        podcastEpisode.Episode.BlueskyPost = changeState.BlueskyPostUriToRemove;
-                    }
-
-                    removeBlueskyPostResult = await blueskyPostManager.RemovePost(podcastEpisode);
-                    podcastEpisode.Episode.ClearBlueskyPostState();
-                    if (removeBlueskyPostResult != RemovePostState.Deleted)
-                    {
-                        logger.LogWarning("Failure to delete bluesky-post. Result= {removeBlueskyPostResult}.",
-                            removeBlueskyPostResult);
-                    }
-                }
-                catch (Exception e)
-                {
-                    podcastEpisode.Episode.ClearBlueskyPostState();
-                    logger.LogError(e,
-                        "Error using bluesky-post-manager to remove post for episode with id '{episodeId}'.",
-                        podcastEpisodeResolverResponse.Episode.Id);
-                    removeBlueskyPostResult = RemovePostState.Other;
-                }
-            }
-
             var outcome = new EpisodeUpdateOutcome();
             if (changeState.UnTweet)
             {
@@ -156,7 +155,8 @@ public class EpisodeUpdateService(
 
             if (changeState.UnBlueskyPost)
             {
-                outcome.BlueskyPostDeleted = removeBlueskyPostResult == RemovePostState.Deleted;
+                outcome.BlueskyPostDeleted = removeBlueskyPostResult is RemovePostState.Deleted
+                    or RemovePostState.NotFound;
             }
 
             if (episodeChangeRequestWrapper.EpisodeChangeRequest.Removed.HasValue &&

--- a/Cloud/Api/Services/Episodes/EpisodeUpdateService.cs
+++ b/Cloud/Api/Services/Episodes/EpisodeUpdateService.cs
@@ -124,7 +124,14 @@ public class EpisodeUpdateService(
             {
                 try
                 {
+                    // Apply cleared BlueskyPost before Save; restore stashed AT URI for delete-by-rkey.
+                    if (!string.IsNullOrWhiteSpace(changeState.BlueskyPostUriToRemove))
+                    {
+                        podcastEpisode.Episode.BlueskyPost = changeState.BlueskyPostUriToRemove;
+                    }
+
                     removeBlueskyPostResult = await blueskyPostManager.RemovePost(podcastEpisode);
+                    podcastEpisode.Episode.ClearBlueskyPostState();
                     if (removeBlueskyPostResult != RemovePostState.Deleted)
                     {
                         logger.LogWarning("Failure to delete bluesky-post. Result= {removeBlueskyPostResult}.",
@@ -133,6 +140,7 @@ public class EpisodeUpdateService(
                 }
                 catch (Exception e)
                 {
+                    podcastEpisode.Episode.ClearBlueskyPostState();
                     logger.LogError(e,
                         "Error using bluesky-post-manager to remove post for episode with id '{episodeId}'.",
                         podcastEpisodeResolverResponse.Episode.Id);

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/EpisodeChangeApplierTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/EpisodeChangeApplierTests.cs
@@ -255,7 +255,7 @@ public class EpisodeChangeApplierTests
     }
 
     [Fact(DisplayName =
-        "Plain English rule: when UnBluesky is requested for an AT-URI episode, then clear Cosmostate but stash the URI on change state, because RemovePost must delete by rkey after Save.")]
+        "Plain English rule: when UnBluesky is requested for an AT-URI episode, then set UnBlueskyPost but leave BlueskyPost on the episode, because delete must run before Cosmostate is cleared.")]
     public void Apply_sets_unbluesky_post_flag_and_nulls_field()
     {
         // Arrange
@@ -268,10 +268,8 @@ public class EpisodeChangeApplierTests
 
         // Assert
         state.UnBlueskyPost.Should().BeTrue();
-        state.BlueskyPostUriToRemove.Should().Be(atUri);
-        episode.BlueskyPosted.Should().BeFalse();
-        episode.BlueskyPost.Should().BeNull();
-        episode.OldBlueskyPosted.Should().BeNull();
+        episode.BlueskyPosted.Should().BeTrue();
+        episode.BlueskyPost.Should().Be(atUri);
     }
 
     [Fact(DisplayName = "Apply does not set UnBlueskyPost when UnBluesky is requested but episode is not Bluesky-posted")]
@@ -290,7 +288,7 @@ public class EpisodeChangeApplierTests
     }
 
     [Fact(DisplayName =
-        "Plain English rule: when UnBluesky is requested for a legacy bluesky-flag episode, then clear the flag and leave BlueskyPostUriToRemove null, because RemovePost falls back to list-records search.")]
+        "Plain English rule: when UnBluesky is requested for a legacy bluesky-flag episode, then set UnBlueskyPost but leave OldBlueskyPosted, because EpisodeUpdateService clears only after a successful delete.")]
     public void Apply_clears_legacy_old_bluesky_posted_on_unpost()
     {
         // Arrange
@@ -302,9 +300,8 @@ public class EpisodeChangeApplierTests
 
         // Assert
         state.UnBlueskyPost.Should().BeTrue();
-        state.BlueskyPostUriToRemove.Should().BeNull();
-        episode.BlueskyPosted.Should().BeFalse();
-        episode.OldBlueskyPosted.Should().BeNull();
+        episode.BlueskyPosted.Should().BeTrue();
+        episode.OldBlueskyPosted.Should().BeTrue();
     }
 
     // ----- Subjects -----

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/EpisodeChangeApplierTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/EpisodeChangeApplierTests.cs
@@ -254,12 +254,13 @@ public class EpisodeChangeApplierTests
         state.UnTweet.Should().BeTrue();
     }
 
-    [Fact(DisplayName = "Apply sets UnBlueskyPost when UnBluesky is requested and episode is Bluesky-posted, and clears Bluesky post state")]
+    [Fact(DisplayName =
+        "Plain English rule: when UnBluesky is requested for an AT-URI episode, then clear Cosmostate but stash the URI on change state, because RemovePost must delete by rkey after Save.")]
     public void Apply_sets_unbluesky_post_flag_and_nulls_field()
     {
         // Arrange
-        var episode = CreateEpisode(e =>
-            e.BlueskyPost = "at://did:plc:example/app.bsky.feed.post/3k2yuhir2j2");
+        const string atUri = "at://did:plc:example/app.bsky.feed.post/3k2yuhir2j2";
+        var episode = CreateEpisode(e => e.BlueskyPost = atUri);
         var sut = CreateSut();
 
         // Act
@@ -267,6 +268,7 @@ public class EpisodeChangeApplierTests
 
         // Assert
         state.UnBlueskyPost.Should().BeTrue();
+        state.BlueskyPostUriToRemove.Should().Be(atUri);
         episode.BlueskyPosted.Should().BeFalse();
         episode.BlueskyPost.Should().BeNull();
         episode.OldBlueskyPosted.Should().BeNull();
@@ -287,7 +289,8 @@ public class EpisodeChangeApplierTests
         episode.BlueskyPosted.Should().BeFalse();
     }
 
-    [Fact(DisplayName = "Apply clears legacy OldBlueskyPosted when UnBluesky is requested for a pre-migration episode")]
+    [Fact(DisplayName =
+        "Plain English rule: when UnBluesky is requested for a legacy bluesky-flag episode, then clear the flag and leave BlueskyPostUriToRemove null, because RemovePost falls back to list-records search.")]
     public void Apply_clears_legacy_old_bluesky_posted_on_unpost()
     {
         // Arrange
@@ -299,6 +302,7 @@ public class EpisodeChangeApplierTests
 
         // Assert
         state.UnBlueskyPost.Should().BeTrue();
+        state.BlueskyPostUriToRemove.Should().BeNull();
         episode.BlueskyPosted.Should().BeFalse();
         episode.OldBlueskyPosted.Should().BeNull();
     }

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Services/EpisodeUpdateServiceTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Services/EpisodeUpdateServiceTests.cs
@@ -164,8 +164,8 @@ public class EpisodeUpdateServiceTests
     }
 
     [Fact(DisplayName =
-        "Plain English rule: when UnBluesky is requested for an episode with a stored AT URI, then RemovePost is called with that URI restored on the episode, because delete-by-rkey must not fall back to list-records search after Cosmostate clear.")]
-    public async Task update_unbluesky_restores_at_uri_for_remove_post()
+        "Plain English rule: when UnBluesky succeeds, then RemovePost sees the AT URI on the episode and Cosmostate is cleared before Save, because delete-before-clear keeps retry possible on failure.")]
+    public async Task update_unbluesky_deletes_then_clears_on_success()
     {
         // Arrange
         var episodeId = Guid.NewGuid();
@@ -216,6 +216,58 @@ public class EpisodeUpdateServiceTests
         uriSeenByRemove.Should().Be(atUri);
         episode.BlueskyPost.Should().BeNull();
         blueskyPostManager.Verify(m => m.RemovePost(It.IsAny<PodcastEpisode>()), Times.Once);
+    }
+
+    [Fact(DisplayName =
+        "Plain English rule: when UnBluesky delete fails, then Cosmostate keeps BlueskyPost, because a failed remote delete must not flip posted state and block retries.")]
+    public async Task update_unbluesky_keeps_at_uri_when_delete_fails()
+    {
+        // Arrange
+        var episodeId = Guid.NewGuid();
+        var podcastId = Guid.NewGuid();
+        const string atUri = "at://did:plc:example/app.bsky.feed.post/3k2yuhir2j2";
+        var episode = new Episode
+        {
+            Id = episodeId,
+            PodcastId = podcastId,
+            Title = "Original",
+            BlueskyPost = atUri,
+            Release = DateTime.UtcNow.AddDays(-30)
+        };
+        var podcast = new Podcast { Id = podcastId, Name = "Show" };
+
+        var resolver = new Mock<IPodcastEpisodeResolver>();
+        resolver.Setup(r => r.ResolvePodcast(It.IsAny<PodcastEpisodeResolverRequest>(), It.IsAny<string>()))
+            .ReturnsAsync(new PodcastEpisodeResolverResponse(episode, podcast, PodcastEpisodeResolveState.Resolved));
+
+        var episodeRepo = new Mock<IEpisodeRepository>();
+        episodeRepo.Setup(r => r.Save(It.IsAny<Episode>())).Returns(Task.CompletedTask);
+
+        var blueskyPostManager = new Mock<IBlueskyPostManager>(MockBehavior.Strict);
+        blueskyPostManager
+            .Setup(m => m.RemovePost(It.IsAny<PodcastEpisode>()))
+            .ReturnsAsync(RemovePostState.Other);
+
+        var indexer = new Mock<IEpisodeSearchIndexerService>();
+        indexer.Setup(s => s.IndexEpisode(It.IsAny<Podcast>(), It.IsAny<Episode>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EntitySearchIndexerResponse { IndexerState = IndexerState.Executed });
+
+        var service = CreateService(
+            resolver.Object,
+            episodeRepo.Object,
+            blueskyPostManager: blueskyPostManager.Object,
+            indexer: indexer.Object);
+
+        // Act
+        var result = await service.UpdateAsync(
+            new EpisodeChangeRequestWrapper(podcastId, episodeId, new EpisodeChangeRequest { UnBluesky = true }),
+            CancellationToken.None);
+
+        // Assert
+        result.Status.Should().Be(EpisodeUpdateStatus.Accepted);
+        result.Outcome!.BlueskyPostDeleted.Should().BeFalse();
+        episode.BlueskyPost.Should().Be(atUri);
+        episode.BlueskyPosted.Should().BeTrue();
     }
 
     private static EpisodeUpdateService CreateService(

--- a/Cloud/Unit-Tests/FunctionHost.Tests/Api/Services/EpisodeUpdateServiceTests.cs
+++ b/Cloud/Unit-Tests/FunctionHost.Tests/Api/Services/EpisodeUpdateServiceTests.cs
@@ -6,6 +6,7 @@ using Api.Resolvers;
 using Api.Services.Episodes;
 using Azure.Search.Documents;
 using RedditPodcastPoster.Bluesky.Managers;
+using RedditPodcastPoster.Bluesky.Models;
 using RedditPodcastPoster.ContentPublisher.Publishers;
 using RedditPodcastPoster.EntitySearchIndexer.Models;
 using RedditPodcastPoster.EntitySearchIndexer.Services;
@@ -160,6 +161,61 @@ public class EpisodeUpdateServiceTests
         result.Status.Should().Be(EpisodeUpdateStatus.Accepted);
         tweetManager.Verify(m => m.RemoveTweet(It.IsAny<PodcastEpisode>()), Times.Never);
         blueskyPostManager.Verify(m => m.RemovePost(It.IsAny<PodcastEpisode>()), Times.Never);
+    }
+
+    [Fact(DisplayName =
+        "Plain English rule: when UnBluesky is requested for an episode with a stored AT URI, then RemovePost is called with that URI restored on the episode, because delete-by-rkey must not fall back to list-records search after Cosmostate clear.")]
+    public async Task update_unbluesky_restores_at_uri_for_remove_post()
+    {
+        // Arrange
+        var episodeId = Guid.NewGuid();
+        var podcastId = Guid.NewGuid();
+        const string atUri = "at://did:plc:example/app.bsky.feed.post/3k2yuhir2j2";
+        var episode = new Episode
+        {
+            Id = episodeId,
+            PodcastId = podcastId,
+            Title = "Original",
+            BlueskyPost = atUri,
+            Release = DateTime.UtcNow.AddDays(-30)
+        };
+        var podcast = new Podcast { Id = podcastId, Name = "Show" };
+
+        var resolver = new Mock<IPodcastEpisodeResolver>();
+        resolver.Setup(r => r.ResolvePodcast(It.IsAny<PodcastEpisodeResolverRequest>(), It.IsAny<string>()))
+            .ReturnsAsync(new PodcastEpisodeResolverResponse(episode, podcast, PodcastEpisodeResolveState.Resolved));
+
+        var episodeRepo = new Mock<IEpisodeRepository>();
+        episodeRepo.Setup(r => r.Save(It.IsAny<Episode>())).Returns(Task.CompletedTask);
+
+        string? uriSeenByRemove = null;
+        var blueskyPostManager = new Mock<IBlueskyPostManager>(MockBehavior.Strict);
+        blueskyPostManager
+            .Setup(m => m.RemovePost(It.IsAny<PodcastEpisode>()))
+            .Callback<PodcastEpisode>(pe => uriSeenByRemove = pe.Episode.BlueskyPost)
+            .ReturnsAsync(RemovePostState.Deleted);
+
+        var indexer = new Mock<IEpisodeSearchIndexerService>();
+        indexer.Setup(s => s.IndexEpisode(It.IsAny<Podcast>(), It.IsAny<Episode>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EntitySearchIndexerResponse { IndexerState = IndexerState.Executed });
+
+        var service = CreateService(
+            resolver.Object,
+            episodeRepo.Object,
+            blueskyPostManager: blueskyPostManager.Object,
+            indexer: indexer.Object);
+
+        // Act
+        var result = await service.UpdateAsync(
+            new EpisodeChangeRequestWrapper(podcastId, episodeId, new EpisodeChangeRequest { UnBluesky = true }),
+            CancellationToken.None);
+
+        // Assert
+        result.Status.Should().Be(EpisodeUpdateStatus.Accepted);
+        result.Outcome!.BlueskyPostDeleted.Should().BeTrue();
+        uriSeenByRemove.Should().Be(atUri);
+        episode.BlueskyPost.Should().BeNull();
+        blueskyPostManager.Verify(m => m.RemovePost(It.IsAny<PodcastEpisode>()), Times.Once);
     }
 
     private static EpisodeUpdateService CreateService(


### PR DESCRIPTION
## Summary
- Un-Bluesky was clearing `blueskyPost` before `RemovePost`, so delete lost the AT URI and fell back to weak list-records search (`NotFound`), leaving orphan posts on Bluesky.
- Stash the AT URI on change state, restore it for `RemovePost`, then clear again; cover with applier + update-service tests.

## Test plan
- [x] `dotnet test` FunctionHost.Tests filter EpisodeChangeApplierTests|EpisodeUpdateServiceTests
- [x] unit-test guardrails (`-GitChanged`)
- [ ] Deploy `api-infra` and Un-Bluesky an episode that still has `blueskyPost`; confirm `blueskyPostDeleted: true` and post gone on bsky.app
- [ ] Existing orphan posts (URI already cleared) still need manual delete
