### PR TITLE
Widen catalogue duration band for long Apple cuts

### DIFF
--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchScorerRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchScorerRules.cs
@@ -180,6 +180,7 @@ public class CatalogueMatchScorerRules
         var probe = _fixture.CreateEpisode(e =>
         {
             e.Title = youTubeTitle;
+            e.Description = string.Empty;
             e.Length = length;
             e.Release = release;
             e.YouTubeId = _fixture.CreateYouTubeId();
@@ -187,7 +188,10 @@ public class CatalogueMatchScorerRules
         });
         var weak = _fixture.CreateEpisode(e =>
         {
-            e.Title = _fixture.CreateTitle();
+            // Disjoint title + empty description so duration+day alone stay below threshold
+            e.Title =
+                "Guest Answers Live Questions About A Political Figure And An Identity Foundation";
+            e.Description = string.Empty;
             e.Length = length;
             e.Release = release;
             e.SpotifyId = _fixture.CreateSpotifyId();
@@ -196,6 +200,7 @@ public class CatalogueMatchScorerRules
         var strong = _fixture.CreateEpisode(e =>
         {
             e.Title = $"{youTubeTitle}: editorial rename";
+            e.Description = string.Empty;
             e.Length = length;
             e.Release = release;
             e.SpotifyId = _fixture.CreateSpotifyId();
@@ -360,5 +365,167 @@ public class CatalogueMatchScorerRules
             CatalogueMatchScorer.FuzzyTitlePoints +
             CatalogueMatchScorer.SingleSharedSubjectPoints);
         CatalogueMatchScorer.MeetsMatchThreshold(probe, catalogue).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "For a long YouTube-discovered episode, an Apple catalogue row a little over five minutes longer " +
+        "still awards duration points and meets the threshold with same-day release and a fuzzy title, " +
+        "because the duration band is max(five minutes, ten percent of the shorter length).")]
+    public void long_episode_apple_slightly_longer_than_five_minutes_meets_threshold()
+    {
+        // Arrange — ~97m YouTube vs ~102.5m Apple (~5.5m gap); 10% of shorter ≈ 9.7m
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var baseTitle = _fixture.CreateTitle(6);
+        var youTubeLength = TimeSpan.FromMinutes(97);
+        var appleLength = youTubeLength + TimeSpan.FromMinutes(5) + TimeSpan.FromSeconds(30);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = baseTitle;
+            e.Description = string.Empty;
+            e.Length = youTubeLength;
+            e.Release = release;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = DomainTestFixture.CreateTypoTitleVariant(baseTitle);
+            e.Description = string.Empty;
+            e.Length = appleLength;
+            e.Release = release;
+            e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+        var band = CatalogueMatchScorer.GetDurationBand(youTubeLength, appleLength);
+
+        // Assert
+        (appleLength - youTubeLength).Should().BeGreaterThan(CatalogueMatchScorer.DurationBandFloor);
+        (appleLength - youTubeLength).Should().BeLessThan(band);
+        score.Should().Be(
+            CatalogueMatchScorer.DurationWithinBandPoints +
+            CatalogueMatchScorer.SameCalendarDayReleasePoints +
+            CatalogueMatchScorer.FuzzyTitlePoints);
+        CatalogueMatchScorer.MeetsMatchThreshold(probe, catalogue).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "When both sides have duration and the gap equals the proportional band for a long episode, " +
+        "the score is zero because the duration hard-fail uses a strict less-than band edge.")]
+    public void long_episode_duration_gap_exactly_at_proportional_band_scores_zero()
+    {
+        // Arrange
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var baseTitle = _fixture.CreateTitle(6);
+        var shorter = TimeSpan.FromMinutes(100);
+        var band = CatalogueMatchScorer.GetDurationBand(shorter, shorter);
+        var longer = shorter + band;
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = baseTitle;
+            e.Description = string.Empty;
+            e.Length = shorter;
+            e.Release = release;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = DomainTestFixture.CreateTypoTitleVariant(baseTitle);
+            e.Description = string.Empty;
+            e.Length = longer;
+            e.Release = release;
+            e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+
+        // Assert
+        band.Should().BeGreaterThan(CatalogueMatchScorer.DurationBandFloor);
+        score.Should().Be(0);
+    }
+
+    [Fact(DisplayName =
+        "When both sides have duration and the gap is just inside the proportional band for a long episode, " +
+        "duration points are awarded so same-day release plus fuzzy title can meet the threshold.")]
+    public void long_episode_duration_gap_just_inside_proportional_band_meets_threshold()
+    {
+        // Arrange
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var baseTitle = _fixture.CreateTitle(6);
+        var shorter = TimeSpan.FromMinutes(100);
+        var band = CatalogueMatchScorer.GetDurationBand(shorter, shorter);
+        var longer = shorter + band - TimeSpan.FromTicks(1);
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = baseTitle;
+            e.Description = string.Empty;
+            e.Length = shorter;
+            e.Release = release;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = DomainTestFixture.CreateTypoTitleVariant(baseTitle);
+            e.Description = string.Empty;
+            e.Length = longer;
+            e.Release = release;
+            e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [];
+        });
+
+        // Act
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+
+        // Assert
+        band.Should().BeGreaterThan(CatalogueMatchScorer.DurationBandFloor);
+        score.Should().Be(
+            CatalogueMatchScorer.DurationWithinBandPoints +
+            CatalogueMatchScorer.SameCalendarDayReleasePoints +
+            CatalogueMatchScorer.FuzzyTitlePoints);
+        CatalogueMatchScorer.MeetsMatchThreshold(probe, catalogue).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "For a short episode the duration band stays at the five-minute floor, so a gap of exactly " +
+        "five minutes still hard-fails even though ten percent of the shorter length is smaller.")]
+    public void short_episode_duration_band_keeps_five_minute_floor()
+    {
+        // Arrange — 20m → 10% = 2m; floor remains 5m
+        var release = DomainTestFixture.UtcDateDaysAgo(1);
+        var baseTitle = _fixture.CreateTitle(6);
+        var shorter = TimeSpan.FromMinutes(20);
+        var longer = shorter + CatalogueMatchScorer.DurationBandFloor;
+        var probe = _fixture.CreateEpisode(e =>
+        {
+            e.Title = baseTitle;
+            e.Description = string.Empty;
+            e.Length = shorter;
+            e.Release = release;
+            e.YouTubeId = _fixture.CreateYouTubeId();
+            e.Subjects = [];
+        });
+        var catalogue = _fixture.CreateEpisode(e =>
+        {
+            e.Title = DomainTestFixture.CreateTypoTitleVariant(baseTitle);
+            e.Description = string.Empty;
+            e.Length = longer;
+            e.Release = release;
+            e.AppleId = _fixture.CreateAppleId();
+            e.Subjects = [];
+        });
+
+        // Act
+        var band = CatalogueMatchScorer.GetDurationBand(shorter, longer);
+        var score = CatalogueMatchScorer.Score(probe, catalogue);
+
+        // Assert
+        band.Should().Be(CatalogueMatchScorer.DurationBandFloor);
+        score.Should().Be(0);
     }
 }

--- a/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes.Tests/BusinessRules/Matching/CatalogueMatchingRules.cs
@@ -563,12 +563,12 @@ public class CatalogueMatchingRules
     }
 
     [Fact(DisplayName =
-        "When enriching a YouTube-discovered episode and both sides have duration outside the five-minute band, " +
+        "When enriching a YouTube-discovered episode and both sides have duration outside the proportional band, " +
         "FindCatalogueMatchByLength returns null even when a typo-aligned title sits within twelve hours of release, " +
         "because multi-criteria scoring requires the duration band when both lengths are present.")]
     public void youtube_discovered_release_only_outside_duration_band_returns_null()
     {
-        // Arrange
+        // Arrange — 20m gap >> max(5m, 10% of 40m)
         var sharedTitle = _fixture.CreateShortTitle();
         var probeLength = TimeSpan.FromMinutes(60);
         var mismatchedLength = TimeSpan.FromMinutes(40);
@@ -1375,7 +1375,7 @@ public class CatalogueMatchingRules
         "because multi-criteria scoring requires duration within band.")]
     public void youtube_discovered_multiple_release_only_candidates_outside_duration_band_returns_null()
     {
-        // Arrange - typo titles avoid early containment; durations outside five-minute band
+        // Arrange - typo titles avoid early containment; durations far outside proportional band
         var sharedTitle = _fixture.CreateShortTitle();
         var probeLength = TimeSpan.FromMinutes(60);
         var probeRelease = DomainTestFixture.UtcAtTime(-4, _fixture.CreateNonMidnightTimeOfDay());

--- a/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchScorer.cs
+++ b/Class-Libraries/RedditPodcastPoster.Episodes/Matching/CatalogueMatchScorer.cs
@@ -12,6 +12,10 @@ namespace RedditPodcastPoster.Episodes.Matching;
 /// When either side lacks duration (e.g. Apple omitting <c>durationInMilliseconds</c>),
 /// duration points are skipped and duration band is not a hard fail — release window plus
 /// title/description/subjects must still clear the threshold (release alone cannot).
+/// When both sides have duration, the allowed gap is
+/// <c>max(<see cref="DurationBandFloor"/>, <see cref="DurationBandProportionOfShorter"/> × shorter)</c>
+/// so long Apple cuts with a few minutes of ads still match while short episodes keep a
+/// five-minute floor (Aug 2026: long YouTube cut vs slightly longer Apple audio).
 /// Spotify and Apple catalogue items are both windowed on calendar days, not elapsed hours,
 /// because audio slots and YouTube publishes on the same day can be far more than twelve hours apart.
 /// </summary>
@@ -28,13 +32,37 @@ public static class CatalogueMatchScorer
     public const int SingleSharedSubjectPoints = 15;
     public const int MultipleSharedSubjectPoints = 25;
 
+    /// <summary>Minimum absolute duration gap allowed when both sides report length.</summary>
+    public static readonly TimeSpan DurationBandFloor = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Fraction of the shorter duration added on top of <see cref="DurationBandFloor"/> for long episodes.
+    /// </summary>
+    public const double DurationBandProportionOfShorter = 0.10;
+
     private const int MinFuzzyTitleScore = 65;
     private const int MinFuzzyDescriptionScore = 70;
     private const int DescriptionCompareMaxChars = 500;
 
     /// <summary>
+    /// Allowed absolute duration delta when both sides have length:
+    /// <c>max(DurationBandFloor, DurationBandProportionOfShorter × shorter)</c>.
+    /// </summary>
+    public static TimeSpan GetDurationBand(TimeSpan left, TimeSpan right)
+    {
+        var shorter = left <= right ? left : right;
+        if (shorter <= TimeSpan.Zero)
+        {
+            return DurationBandFloor;
+        }
+
+        var proportional = TimeSpan.FromTicks((long)(shorter.Ticks * DurationBandProportionOfShorter));
+        return proportional > DurationBandFloor ? proportional : DurationBandFloor;
+    }
+
+    /// <summary>
     /// Scores a probe against a catalogue candidate within the YouTube-discovered release window.
-    /// When both sides have duration, requires the ±5 minute band; otherwise scores without
+    /// When both sides have duration, requires the proportional duration band; otherwise scores without
     /// duration points so Apple catalogue gaps can still match on title/subjects.
     /// </summary>
     public static int Score(
@@ -48,8 +76,8 @@ public static class CatalogueMatchScorer
 
         if (probeHasDuration && catalogueHasDuration)
         {
-            if (Math.Abs((catalogueItem.Length - probe.Length).Ticks) >=
-                TimeSpan.FromMinutes(5).Ticks)
+            var band = GetDurationBand(probe.Length, catalogueItem.Length);
+            if (Math.Abs((catalogueItem.Length - probe.Length).Ticks) >= band.Ticks)
             {
                 return 0;
             }


### PR DESCRIPTION
## Summary
- YouTube-discovered Spotify/Apple catalogue matching now allows duration gaps of `max(5 minutes, 10% of the shorter length)` instead of a flat ±5 minute hard-fail.
- Fixes misses where Apple audio is a few minutes longer than YouTube on long episodes (verified locally with Index against Julian Dorey #460).
- Adds BusinessRules coverage for the long-episode Apple case, proportional band edges, and the short-episode five-minute floor.

## Test plan
- [x] `dotnet test` on `RedditPodcastPoster.Episodes.Tests` filtered to CatalogueMatchScorer/Matching rules (15 passed)
- [x] `pwsh ./scripts/assert-unit-test-guardrails.ps1 -GitChanged`
- [x] Published Index CLI and confirmed Apple URL matched on re-index
- [ ] Deploy API/indexer so submit + scheduled index use the new band
